### PR TITLE
Handle non-array pool data in PoolsTable

### DIFF
--- a/frontend/src/components/tables/PoolsTable.tsx
+++ b/frontend/src/components/tables/PoolsTable.tsx
@@ -12,7 +12,8 @@ export default function PoolsTable() {
   const [sort, setSort] = useState<SortKey>('name');
   const [page, setPage] = useState(1);
 
-  const data = (poolsQuery.data || []).filter((p) =>
+  const pools = Array.isArray(poolsQuery.data) ? poolsQuery.data : [];
+  const data = pools.filter((p) =>
     p.name.toLowerCase().includes(search.toLowerCase()),
   );
 

--- a/frontend/src/lib/mocks.ts
+++ b/frontend/src/lib/mocks.ts
@@ -23,7 +23,7 @@ export function setupMocks() {
       config.adapter = async () => ({ data: pools, status: 200, statusText: 'OK', headers: {}, config });
     }
     if (method === 'post' && url === '/pools') {
-      const payload: NewPool = JSON.parse(data as any);
+      const payload: NewPool = JSON.parse(String(data));
       const pool: Pool = {
         ...payload,
         id: Math.random().toString(36).slice(2),
@@ -38,7 +38,7 @@ export function setupMocks() {
     }
     if (method === 'patch' && url?.startsWith('/pools/')) {
       const id = url.split('/').pop()!;
-      const payload = JSON.parse(data as any);
+      const payload = JSON.parse(String(data));
       pools = pools.map((p) => (p.id === id ? { ...p, ...payload } : p));
       const pool = pools.find((p) => p.id === id)!;
       config.adapter = async () => ({ data: pool, status: 200, statusText: 'OK', headers: {}, config });


### PR DESCRIPTION
## Summary
- Guard PoolsTable against invalid `poolsQuery` results to prevent runtime errors
- Remove `any` from frontend mocks to satisfy linting

## Testing
- `npm test`
- `npm --prefix frontend run lint`
- `npm run dev` (frontend + backend start)

------
https://chatgpt.com/codex/tasks/task_e_689b33f922f0832c8e7bbaec1be12e5a