### PR TITLE
refactor: polish frontend layout with Mantine

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>PromptSwap</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/forms/CreatePoolForm.tsx
+++ b/frontend/src/components/forms/CreatePoolForm.tsx
@@ -1,4 +1,4 @@
-import { Button, Select, TextInput, Textarea, Stack } from '@mantine/core';
+import { Button, Select, TextInput, Textarea, Stack, Paper, Title } from '@mantine/core';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { type NewPool, newPoolSchema } from '../../types';
@@ -37,8 +37,9 @@ export default function CreatePoolForm() {
   });
 
   return (
-    <form onSubmit={onSubmit}>
+    <Paper withBorder shadow="sm" p="md" radius="md" component="form" onSubmit={onSubmit}>
       <Stack>
+        <Title order={4}>Create Pool</Title>
         <TextInput label="Name" {...form.register('name')} />
         <Controller
           name="exchange"
@@ -55,10 +56,10 @@ export default function CreatePoolForm() {
         <TextInput label="TP %" type="number" {...form.register('tpPct', { valueAsNumber: true })} />
         <TextInput label="SL %" type="number" {...form.register('slPct', { valueAsNumber: true })} />
         <Textarea label="Notes" {...form.register('notes')} />
-        <Button type="submit" loading={createMutation.isPending} mt="md">
+        <Button type="submit" loading={createMutation.isPending} mt="md" fullWidth>
           Create
         </Button>
       </Stack>
-    </form>
+    </Paper>
   );
 }

--- a/frontend/src/components/tables/PoolsTable.tsx
+++ b/frontend/src/components/tables/PoolsTable.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Button, Group, Table, TextInput, Pagination } from '@mantine/core';
+import { Button, Group, Table, TextInput, Pagination, Paper, Stack, Title } from '@mantine/core';
 import { usePools } from '../../hooks/usePools';
 
 const PAGE_SIZE = 10;
@@ -22,49 +22,53 @@ export default function PoolsTable() {
   const paged = sorted.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
   return (
-    <div>
-      <TextInput
-        placeholder="Search"
-        mb="sm"
-        value={search}
-        onChange={(e) => setSearch(e.currentTarget.value)}
-      />
-      <Table striped withTableBorder>
-        <Table.Thead>
-          <Table.Tr>
-            <Table.Th onClick={() => setSort('name')}>Name</Table.Th>
-            <Table.Th onClick={() => setSort('exchange')}>Exchange</Table.Th>
-            <Table.Th>Status</Table.Th>
-            <Table.Th></Table.Th>
-          </Table.Tr>
-        </Table.Thead>
-        <Table.Tbody>
-          {paged.map((pool) => (
-            <Table.Tr key={pool.id}>
-              <Table.Td>{pool.name}</Table.Td>
-              <Table.Td>{pool.exchange}</Table.Td>
-              <Table.Td>{pool.status}</Table.Td>
-              <Table.Td>
-                <Group justify="flex-end">
-                  <Button
-                    size="xs"
-                    variant="light"
-                    onClick={() =>
-                      statusMutation.mutate({
-                        id: pool.id,
-                        status: pool.status === 'active' ? 'paused' : 'active',
-                      })
-                    }
-                  >
-                    {pool.status === 'active' ? 'Pause' : 'Activate'}
-                  </Button>
-                </Group>
-              </Table.Td>
+    <Paper withBorder shadow="sm" p="md" radius="md">
+      <Stack>
+        <Title order={4}>Pools</Title>
+        <TextInput
+          placeholder="Search"
+          value={search}
+          onChange={(e) => setSearch(e.currentTarget.value)}
+        />
+        <Table striped withTableBorder>
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th onClick={() => setSort('name')}>Name</Table.Th>
+              <Table.Th onClick={() => setSort('exchange')}>Exchange</Table.Th>
+              <Table.Th>Status</Table.Th>
+              <Table.Th></Table.Th>
             </Table.Tr>
-          ))}
-        </Table.Tbody>
-      </Table>
-      <Pagination mt="sm" total={pages} value={page} onChange={setPage} />
-    </div>
+          </Table.Thead>
+          <Table.Tbody>
+            {paged.map((pool) => (
+              <Table.Tr key={pool.id}>
+                <Table.Td>{pool.name}</Table.Td>
+                <Table.Td>{pool.exchange}</Table.Td>
+                <Table.Td>{pool.status}</Table.Td>
+                <Table.Td>
+                  <Group justify="flex-end">
+                    <Button
+                      size="xs"
+                      variant="light"
+                      onClick={() =>
+                        statusMutation.mutate({
+                          id: pool.id,
+                          status: pool.status === 'active' ? 'paused' : 'active',
+                        })
+                      }
+                    >
+                      {pool.status === 'active' ? 'Pause' : 'Activate'}
+                    </Button>
+                  </Group>
+                </Table.Td>
+              </Table.Tr>
+            ))}
+          </Table.Tbody>
+        </Table>
+        <Group justify="center" mt="sm">
+          <Pagination total={pages} value={page} onChange={setPage} />
+        </Group>
+      </Stack>
+    </Paper>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,68 +1,7 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+html, body, #root {
+  height: 100%;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }

--- a/frontend/src/routes/Pools.tsx
+++ b/frontend/src/routes/Pools.tsx
@@ -1,16 +1,18 @@
-import { Grid } from '@mantine/core';
+import { Container, Grid } from '@mantine/core';
 import CreatePoolForm from '../components/forms/CreatePoolForm';
 import PoolsTable from '../components/tables/PoolsTable';
 
 export default function Pools() {
   return (
-    <Grid>
-      <Grid.Col span={{ base: 12, md: 6 }}>
-        <CreatePoolForm />
-      </Grid.Col>
-      <Grid.Col span={{ base: 12, md: 6 }}>
-        <PoolsTable />
-      </Grid.Col>
-    </Grid>
+    <Container size="lg" py="md">
+      <Grid gutter="xl">
+        <Grid.Col span={{ base: 12, md: 5 }}>
+          <CreatePoolForm />
+        </Grid.Col>
+        <Grid.Col span={{ base: 12, md: 7 }}>
+          <PoolsTable />
+        </Grid.Col>
+      </Grid>
+    </Container>
   );
 }


### PR DESCRIPTION
## Summary
- wrap Pools form and table in Mantine Paper components with headings
- add Container layout for responsive spacing
- simplify global CSS and update HTML title

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b36eb2874832c8f78598c563be95d