### PR TITLE
feat: add encrypted API key routes

### DIFF
--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -2,7 +2,9 @@ CREATE TABLE IF NOT EXISTS users(
   id TEXT PRIMARY KEY,
   is_auto_enabled INTEGER,
   policy_json TEXT,
-  session_key_expires_at INTEGER
+  session_key_expires_at INTEGER,
+  ai_api_key_enc TEXT,
+  binance_api_key_enc TEXT
 );
 
 CREATE TABLE IF NOT EXISTS executions(

--- a/backend/src/routes/api-keys.ts
+++ b/backend/src/routes/api-keys.ts
@@ -1,0 +1,98 @@
+import type { FastifyInstance } from 'fastify';
+import { db } from '../db/index.js';
+import { env } from '../util/env.js';
+import { encrypt, decrypt } from '../util/crypto.js';
+
+export default async function apiKeyRoutes(app: FastifyInstance) {
+  app.post('/users/:id/ai-key', async (req, reply) => {
+    const id = (req.params as any).id;
+    const { key } = req.body as { key: string };
+    const row = db.prepare('SELECT ai_api_key_enc FROM users WHERE id = ?').get(id);
+    if (!row) return reply.code(404).send({ error: 'user not found' });
+    if (row.ai_api_key_enc) return reply.code(400).send({ error: 'key exists' });
+    const enc = encrypt(key, env.KEY_PASSWORD);
+    db.prepare('UPDATE users SET ai_api_key_enc = ? WHERE id = ?').run(enc, id);
+    return { key };
+  });
+
+  app.get('/users/:id/ai-key', async (req, reply) => {
+    const id = (req.params as any).id;
+    const row = db
+      .prepare('SELECT ai_api_key_enc FROM users WHERE id = ?')
+      .get(id) as { ai_api_key_enc?: string } | undefined;
+    if (!row || !row.ai_api_key_enc)
+      return reply.code(404).send({ error: 'not found' });
+    const key = decrypt(row.ai_api_key_enc, env.KEY_PASSWORD);
+    return { key };
+  });
+
+  app.put('/users/:id/ai-key', async (req, reply) => {
+    const id = (req.params as any).id;
+    const { key } = req.body as { key: string };
+    const row = db
+      .prepare('SELECT ai_api_key_enc FROM users WHERE id = ?')
+      .get(id) as { ai_api_key_enc?: string } | undefined;
+    if (!row || !row.ai_api_key_enc)
+      return reply.code(404).send({ error: 'not found' });
+    const enc = encrypt(key, env.KEY_PASSWORD);
+    db.prepare('UPDATE users SET ai_api_key_enc = ? WHERE id = ?').run(enc, id);
+    return { key };
+  });
+
+  app.delete('/users/:id/ai-key', async (req, reply) => {
+    const id = (req.params as any).id;
+    const row = db
+      .prepare('SELECT ai_api_key_enc FROM users WHERE id = ?')
+      .get(id) as { ai_api_key_enc?: string } | undefined;
+    if (!row || !row.ai_api_key_enc)
+      return reply.code(404).send({ error: 'not found' });
+    db.prepare('UPDATE users SET ai_api_key_enc = NULL WHERE id = ?').run(id);
+    return { ok: true };
+  });
+
+  app.post('/users/:id/binance-key', async (req, reply) => {
+    const id = (req.params as any).id;
+    const { key } = req.body as { key: string };
+    const row = db.prepare('SELECT binance_api_key_enc FROM users WHERE id = ?').get(id);
+    if (!row) return reply.code(404).send({ error: 'user not found' });
+    if (row.binance_api_key_enc) return reply.code(400).send({ error: 'key exists' });
+    const enc = encrypt(key, env.KEY_PASSWORD);
+    db.prepare('UPDATE users SET binance_api_key_enc = ? WHERE id = ?').run(enc, id);
+    return { key };
+  });
+
+  app.get('/users/:id/binance-key', async (req, reply) => {
+    const id = (req.params as any).id;
+    const row = db
+      .prepare('SELECT binance_api_key_enc FROM users WHERE id = ?')
+      .get(id) as { binance_api_key_enc?: string } | undefined;
+    if (!row || !row.binance_api_key_enc)
+      return reply.code(404).send({ error: 'not found' });
+    const key = decrypt(row.binance_api_key_enc, env.KEY_PASSWORD);
+    return { key };
+  });
+
+  app.put('/users/:id/binance-key', async (req, reply) => {
+    const id = (req.params as any).id;
+    const { key } = req.body as { key: string };
+    const row = db
+      .prepare('SELECT binance_api_key_enc FROM users WHERE id = ?')
+      .get(id) as { binance_api_key_enc?: string } | undefined;
+    if (!row || !row.binance_api_key_enc)
+      return reply.code(404).send({ error: 'not found' });
+    const enc = encrypt(key, env.KEY_PASSWORD);
+    db.prepare('UPDATE users SET binance_api_key_enc = ? WHERE id = ?').run(enc, id);
+    return { key };
+  });
+
+  app.delete('/users/:id/binance-key', async (req, reply) => {
+    const id = (req.params as any).id;
+    const row = db
+      .prepare('SELECT binance_api_key_enc FROM users WHERE id = ?')
+      .get(id) as { binance_api_key_enc?: string } | undefined;
+    if (!row || !row.binance_api_key_enc)
+      return reply.code(404).send({ error: 'not found' });
+    db.prepare('UPDATE users SET binance_api_key_enc = NULL WHERE id = ?').run(id);
+    return { ok: true };
+  });
+}

--- a/backend/src/routes/api-keys.ts
+++ b/backend/src/routes/api-keys.ts
@@ -7,7 +7,11 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
   app.post('/users/:id/ai-key', async (req, reply) => {
     const id = (req.params as any).id;
     const { key } = req.body as { key: string };
-    const row = db.prepare('SELECT ai_api_key_enc FROM users WHERE id = ?').get(id);
+    const row = db
+      .prepare<[string], { ai_api_key_enc?: string }>(
+        'SELECT ai_api_key_enc FROM users WHERE id = ?'
+      )
+      .get(id);
     if (!row) return reply.code(404).send({ error: 'user not found' });
     if (row.ai_api_key_enc) return reply.code(400).send({ error: 'key exists' });
     const enc = encrypt(key, env.KEY_PASSWORD);
@@ -53,7 +57,11 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
   app.post('/users/:id/binance-key', async (req, reply) => {
     const id = (req.params as any).id;
     const { key } = req.body as { key: string };
-    const row = db.prepare('SELECT binance_api_key_enc FROM users WHERE id = ?').get(id);
+    const row = db
+      .prepare<[string], { binance_api_key_enc?: string }>(
+        'SELECT binance_api_key_enc FROM users WHERE id = ?'
+      )
+      .get(id);
     if (!row) return reply.code(404).send({ error: 'user not found' });
     if (row.binance_api_key_enc) return reply.code(400).send({ error: 'key exists' });
     const enc = encrypt(key, env.KEY_PASSWORD);

--- a/backend/src/util/crypto.ts
+++ b/backend/src/util/crypto.ts
@@ -1,0 +1,25 @@
+import { randomBytes, scryptSync, createCipheriv, createDecipheriv } from 'node:crypto';
+
+const ALGORITHM = 'aes-256-ctr';
+const IV_LENGTH = 16; // AES block size
+const SALT_LENGTH = 16;
+
+export function encrypt(text: string, password: string): string {
+  const iv = randomBytes(IV_LENGTH);
+  const salt = randomBytes(SALT_LENGTH);
+  const key = scryptSync(password, salt, 32);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([cipher.update(text, 'utf8'), cipher.final()]);
+  return Buffer.concat([salt, iv, encrypted]).toString('base64');
+}
+
+export function decrypt(payload: string, password: string): string {
+  const buffer = Buffer.from(payload, 'base64');
+  const salt = buffer.subarray(0, SALT_LENGTH);
+  const iv = buffer.subarray(SALT_LENGTH, SALT_LENGTH + IV_LENGTH);
+  const encrypted = buffer.subarray(SALT_LENGTH + IV_LENGTH);
+  const key = scryptSync(password, salt, 32);
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+  return decrypted.toString('utf8');
+}

--- a/backend/src/util/env.ts
+++ b/backend/src/util/env.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 const envSchema = z.object({
   DATABASE_URL: z.string().default('./data.db'),
   CRON: z.string().default('0 * * * *'),
+  KEY_PASSWORD: z.string(),
 });
 
 export const env = envSchema.parse(process.env);

--- a/backend/test/apiKeys.test.ts
+++ b/backend/test/apiKeys.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+
+process.env.DATABASE_URL = ':memory:';
+process.env.KEY_PASSWORD = 'test-pass';
+
+const { db, migrate } = await import('../src/db/index.js');
+import buildServer from '../src/server.js';
+
+migrate();
+
+describe('AI API key routes', () => {
+  it('performs CRUD operations', async () => {
+    const app = await buildServer();
+    db.prepare('INSERT INTO users (id) VALUES (?)').run('user1');
+
+    let res = await app.inject({
+      method: 'POST',
+      url: '/users/user1/ai-key',
+      payload: { key: 'aikey1' },
+    });
+    expect(res.statusCode).toBe(200);
+    const row = db
+      .prepare('SELECT ai_api_key_enc FROM users WHERE id = ?')
+      .get('user1');
+    expect(row.ai_api_key_enc).not.toBe('aikey1');
+
+    res = await app.inject({ method: 'GET', url: '/users/user1/ai-key' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ key: 'aikey1' });
+
+    res = await app.inject({
+      method: 'POST',
+      url: '/users/user1/ai-key',
+      payload: { key: 'dup' },
+    });
+    expect(res.statusCode).toBe(400);
+
+    res = await app.inject({
+      method: 'PUT',
+      url: '/users/user1/ai-key',
+      payload: { key: 'aikey2' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ key: 'aikey2' });
+
+    res = await app.inject({ method: 'DELETE', url: '/users/user1/ai-key' });
+    expect(res.statusCode).toBe(200);
+
+    res = await app.inject({ method: 'GET', url: '/users/user1/ai-key' });
+    expect(res.statusCode).toBe(404);
+
+    await app.close();
+  });
+});
+
+describe('Binance API key routes', () => {
+  it('performs CRUD operations', async () => {
+    const app = await buildServer();
+    db.prepare('INSERT INTO users (id) VALUES (?)').run('user2');
+
+    let res = await app.inject({
+      method: 'POST',
+      url: '/users/user2/binance-key',
+      payload: { key: 'bkey1' },
+    });
+    expect(res.statusCode).toBe(200);
+    const row = db
+      .prepare('SELECT binance_api_key_enc FROM users WHERE id = ?')
+      .get('user2');
+    expect(row.binance_api_key_enc).not.toBe('bkey1');
+
+    res = await app.inject({ method: 'GET', url: '/users/user2/binance-key' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ key: 'bkey1' });
+
+    res = await app.inject({
+      method: 'POST',
+      url: '/users/user2/binance-key',
+      payload: { key: 'dup' },
+    });
+    expect(res.statusCode).toBe(400);
+
+    res = await app.inject({
+      method: 'PUT',
+      url: '/users/user2/binance-key',
+      payload: { key: 'bkey2' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ key: 'bkey2' });
+
+    res = await app.inject({ method: 'DELETE', url: '/users/user2/binance-key' });
+    expect(res.statusCode).toBe(200);
+
+    res = await app.inject({ method: 'GET', url: '/users/user2/binance-key' });
+    expect(res.statusCode).toBe(404);
+
+    await app.close();
+  });
+});

--- a/backend/test/db.test.ts
+++ b/backend/test/db.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 
 // Use in-memory database for testing
 process.env.DATABASE_URL = ':memory:';
+process.env.KEY_PASSWORD = 'test-pass';
 
 const { db } = await import('../src/db/index.js');
 

--- a/backend/test/health.test.ts
+++ b/backend/test/health.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import buildServer from '../src/server.js';
 
+process.env.DATABASE_URL = ':memory:';
 process.env.KEY_PASSWORD = 'test-pass';
+
+const { default: buildServer } = await import('../src/server.js');
 
 describe('health route', () => {
   it('returns ok', async () => {

--- a/backend/test/health.test.ts
+++ b/backend/test/health.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import buildServer from '../src/server.js';
 
+process.env.KEY_PASSWORD = 'test-pass';
+
 describe('health route', () => {
   it('returns ok', async () => {
     const app = await buildServer();


### PR DESCRIPTION
## Summary
- encrypt API keys using password from env
- add CRUD endpoints for AI and Binance API keys
- test key management and encryption

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b418fd4b4832c9afe752e5844ca98