### PR TITLE
Add dual-token index form with rebalancing options

### DIFF
--- a/frontend/src/components/forms/IndexForm.tsx
+++ b/frontend/src/components/forms/IndexForm.tsx
@@ -36,17 +36,20 @@ const tokens = [
 ];
 
 export default function IndexForm() {
-  const { register, handleSubmit } = useForm<FormValues>({
+  const { register, handleSubmit, watch, setValue } = useForm<FormValues>({
     resolver: zodResolver(schema),
     defaultValues: {
-      tokenA: '',
-      tokenB: '',
+      tokenA: 'usdt',
+      tokenB: 'sol',
       tokenAPercent: 50,
       tokenBPercent: 50,
       risk: 'low',
       rebalance: '1h',
     },
   });
+
+  const tokenA = watch('tokenA');
+  const tokenB = watch('tokenB');
 
   const onSubmit = handleSubmit((values) => {
     console.log(values);
@@ -64,11 +67,13 @@ export default function IndexForm() {
             <option value="" disabled>
               Select a token
             </option>
-            {tokens.map((t) => (
-              <option key={t.value} value={t.value}>
-                {t.label}
-              </option>
-            ))}
+            {tokens
+              .filter((t) => t.value === tokenA || t.value !== tokenB)
+              .map((t) => (
+                <option key={t.value} value={t.value}>
+                  {t.label}
+                </option>
+              ))}
           </select>
         </div>
         <div>
@@ -78,7 +83,16 @@ export default function IndexForm() {
           <input
             id="tokenAPercent"
             type="number"
-            {...register('tokenAPercent', { valueAsNumber: true })}
+            {...register('tokenAPercent', {
+              valueAsNumber: true,
+              onChange: (e) => {
+                let val = Number(e.target.value);
+                if (isNaN(val)) val = 0;
+                val = Math.max(0, Math.min(100, val));
+                setValue('tokenAPercent', val, { shouldValidate: true });
+                setValue('tokenBPercent', 100 - val, { shouldValidate: true });
+              },
+            })}
             className="w-full border rounded p-2"
           />
         </div>
@@ -92,11 +106,13 @@ export default function IndexForm() {
             <option value="" disabled>
               Select a token
             </option>
-            {tokens.map((t) => (
-              <option key={t.value} value={t.value}>
-                {t.label}
-              </option>
-            ))}
+            {tokens
+              .filter((t) => t.value === tokenB || t.value !== tokenA)
+              .map((t) => (
+                <option key={t.value} value={t.value}>
+                  {t.label}
+                </option>
+              ))}
           </select>
         </div>
         <div>
@@ -106,14 +122,23 @@ export default function IndexForm() {
           <input
             id="tokenBPercent"
             type="number"
-            {...register('tokenBPercent', { valueAsNumber: true })}
+            {...register('tokenBPercent', {
+              valueAsNumber: true,
+              onChange: (e) => {
+                let val = Number(e.target.value);
+                if (isNaN(val)) val = 0;
+                val = Math.max(0, Math.min(100, val));
+                setValue('tokenBPercent', val, { shouldValidate: true });
+                setValue('tokenAPercent', 100 - val, { shouldValidate: true });
+              },
+            })}
             className="w-full border rounded p-2"
           />
         </div>
       </div>
       <div>
         <label className="block text-sm font-medium mb-1" htmlFor="risk">
-          Risk
+          Risk Tolerance
         </label>
         <select id="risk" {...register('risk')} className="w-full border rounded p-2">
           <option value="low">Low</option>
@@ -130,13 +155,13 @@ export default function IndexForm() {
           {...register('rebalance')}
           className="w-full border rounded p-2"
         >
-          <option value="1h">1h</option>
-          <option value="3h">3h</option>
-          <option value="5h">5h</option>
-          <option value="12h">12h</option>
-          <option value="24h">24h</option>
-          <option value="3d">3d</option>
-          <option value="1w">1w</option>
+          <option value="1h">1 hour</option>
+          <option value="3h">3 hours</option>
+          <option value="5h">5 hours</option>
+          <option value="12h">12 hours</option>
+          <option value="24h">1 day</option>
+          <option value="3d">3 days</option>
+          <option value="1w">1 week</option>
         </select>
       </div>
       <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">

--- a/frontend/src/components/forms/IndexForm.tsx
+++ b/frontend/src/components/forms/IndexForm.tsx
@@ -2,10 +2,29 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 
-const schema = z.object({
-  token: z.string().min(1, 'Token is required'),
-  risk: z.enum(['low', 'medium', 'high']),
-});
+const schema = z
+  .object({
+    tokenA: z.string().min(1, 'Token A is required'),
+    tokenB: z.string().min(1, 'Token B is required'),
+    tokenAPercent: z
+      .coerce.number()
+      .min(1, 'Must be at least 1')
+      .max(100, 'Must be 100 or less'),
+    tokenBPercent: z
+      .coerce.number()
+      .min(1, 'Must be at least 1')
+      .max(100, 'Must be 100 or less'),
+    risk: z.enum(['low', 'medium', 'high']),
+    rebalance: z.enum(['1h', '3h', '5h', '12h', '24h', '3d', '1w']),
+  })
+  .refine((data) => data.tokenA !== data.tokenB, {
+    message: 'Tokens must be different',
+    path: ['tokenB'],
+  })
+  .refine((data) => data.tokenAPercent + data.tokenBPercent === 100, {
+    message: 'Percentages must total 100',
+    path: ['tokenBPercent'],
+  });
 
 type FormValues = z.infer<typeof schema>;
 
@@ -13,12 +32,20 @@ const tokens = [
   { value: 'btc', label: 'BTC' },
   { value: 'eth', label: 'ETH' },
   { value: 'sol', label: 'SOL' },
+  { value: 'usdt', label: 'USDT' },
 ];
 
 export default function IndexForm() {
   const { register, handleSubmit } = useForm<FormValues>({
     resolver: zodResolver(schema),
-    defaultValues: { token: '', risk: 'low' },
+    defaultValues: {
+      tokenA: '',
+      tokenB: '',
+      tokenAPercent: 50,
+      tokenBPercent: 50,
+      risk: 'low',
+      rebalance: '1h',
+    },
   });
 
   const onSubmit = handleSubmit((values) => {
@@ -28,20 +55,61 @@ export default function IndexForm() {
   return (
     <form onSubmit={onSubmit} className="bg-white shadow-md rounded p-6 space-y-4">
       <h2 className="text-xl font-bold">Create Index</h2>
-      <div>
-        <label className="block text-sm font-medium mb-1" htmlFor="token">
-          Token
-        </label>
-        <select id="token" {...register('token')} className="w-full border rounded p-2">
-          <option value="" disabled>
-            Select a token
-          </option>
-          {tokens.map((t) => (
-            <option key={t.value} value={t.value}>
-              {t.label}
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="tokenA">
+            Token A
+          </label>
+          <select id="tokenA" {...register('tokenA')} className="w-full border rounded p-2">
+            <option value="" disabled>
+              Select a token
             </option>
-          ))}
-        </select>
+            {tokens.map((t) => (
+              <option key={t.value} value={t.value}>
+                {t.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="tokenAPercent">
+            % Token A
+          </label>
+          <input
+            id="tokenAPercent"
+            type="number"
+            {...register('tokenAPercent', { valueAsNumber: true })}
+            className="w-full border rounded p-2"
+          />
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="tokenB">
+            Token B
+          </label>
+          <select id="tokenB" {...register('tokenB')} className="w-full border rounded p-2">
+            <option value="" disabled>
+              Select a token
+            </option>
+            {tokens.map((t) => (
+              <option key={t.value} value={t.value}>
+                {t.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="tokenBPercent">
+            % Token B
+          </label>
+          <input
+            id="tokenBPercent"
+            type="number"
+            {...register('tokenBPercent', { valueAsNumber: true })}
+            className="w-full border rounded p-2"
+          />
+        </div>
       </div>
       <div>
         <label className="block text-sm font-medium mb-1" htmlFor="risk">
@@ -51,6 +119,24 @@ export default function IndexForm() {
           <option value="low">Low</option>
           <option value="medium">Medium</option>
           <option value="high">High</option>
+        </select>
+      </div>
+      <div>
+        <label className="block text-sm font-medium mb-1" htmlFor="rebalance">
+          Rebalance Frequency
+        </label>
+        <select
+          id="rebalance"
+          {...register('rebalance')}
+          className="w-full border rounded p-2"
+        >
+          <option value="1h">1h</option>
+          <option value="3h">3h</option>
+          <option value="5h">5h</option>
+          <option value="12h">12h</option>
+          <option value="24h">24h</option>
+          <option value="3d">3d</option>
+          <option value="1w">1w</option>
         </select>
       </div>
       <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">


### PR DESCRIPTION
## Summary
- support two-token indexes with percentage allocation that must total 100
- add USDT to token list and ensure tokens are unique
- include selectable rebalance frequency options

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b4ca71184832cb37b511155150cf5