### PR TITLE
Add API key management in settings

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,13 +1,14 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 import AppShell from './components/layout/AppShell';
 import Index from './routes/Index';
+import Settings from './routes/Settings';
 
 export default function App() {
   return (
     <Routes>
       <Route element={<AppShell />}>
         <Route path="/" element={<Index />} />
-        <Route path="/settings" element={<div>Settings</div>} />
+        <Route path="/settings" element={<Settings />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Route>
     </Routes>

--- a/frontend/src/components/GoogleLoginButton.tsx
+++ b/frontend/src/components/GoogleLoginButton.tsx
@@ -1,24 +1,28 @@
 import { useEffect, useRef } from 'react';
 import api from '../lib/axios';
+import { useUser } from '../lib/user';
 
 export default function GoogleLoginButton() {
   const btnRef = useRef<HTMLDivElement>(null);
+  const { user, setUser } = useUser();
 
   useEffect(() => {
     const google = (window as any).google;
-    if (!google || !btnRef.current) return;
+    if (!google || !btnRef.current || user) return;
 
     google.accounts.id.initialize({
       client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID,
       callback: async (resp: any) => {
-        await api.post('/login', { token: resp.credential });
+        const res = await api.post('/login', { token: resp.credential });
+        setUser(res.data);
       },
     });
     google.accounts.id.renderButton(btnRef.current, {
       theme: 'outline',
       size: 'large',
     });
-  }, []);
+  }, [user, setUser]);
 
+  if (user) return <span className="text-sm">{user.email}</span>;
   return <div ref={btnRef}></div>;
 }

--- a/frontend/src/lib/user.tsx
+++ b/frontend/src/lib/user.tsx
@@ -1,0 +1,17 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+export type User = { id: string; email?: string } | null;
+
+const UserContext = createContext<{ user: User; setUser: (u: User) => void }>({
+  user: null,
+  setUser: () => {},
+});
+
+export function UserProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User>(null);
+  return <UserContext.Provider value={{ user, setUser }}>{children}</UserContext.Provider>;
+}
+
+export function useUser() {
+  return useContext(UserContext);
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import queryClient from './lib/queryClient';
 import { setupMocks } from './lib/mocks';
+import { UserProvider } from './lib/user';
 import './index.css';
 
 setupMocks();
@@ -12,9 +13,11 @@ setupMocks();
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <UserProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </UserProvider>
     </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/frontend/src/routes/Settings.tsx
+++ b/frontend/src/routes/Settings.tsx
@@ -1,0 +1,85 @@
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import api from '../lib/axios';
+import { useUser } from '../lib/user';
+
+type KeyType = 'ai' | 'binance';
+
+function KeySection({ type, label }: { type: KeyType; label: string }) {
+  const { user } = useUser();
+  const form = useForm<{ key: string }>({ defaultValues: { key: '' } });
+  const id = user!.id;
+  const query = useQuery({
+    queryKey: [type, id],
+    enabled: !!user,
+    queryFn: async () => {
+      const res = await api.get(`/users/${id}/${type}-key`);
+      return res.data.key as string;
+    },
+  });
+
+  useEffect(() => {
+    if (query.data) form.setValue('key', query.data);
+  }, [query.data, form]);
+
+  const saveMut = useMutation({
+    mutationFn: async (key: string) => {
+      const method = query.data ? 'put' : 'post';
+      const res = await api[method](`/users/${id}/${type}-key`, { key });
+      return res.data.key as string;
+    },
+    onSuccess: () => query.refetch(),
+  });
+
+  const delMut = useMutation({
+    mutationFn: async () => {
+      await api.delete(`/users/${id}/${type}-key`);
+    },
+    onSuccess: () => query.refetch(),
+  });
+
+  const onSubmit = form.handleSubmit((data) => saveMut.mutate(data.key));
+
+  return (
+    <div className="space-y-2">
+      <h2 className="text-lg font-bold">{label}</h2>
+      {query.isLoading ? (
+        <p>Loading...</p>
+      ) : (
+        <form onSubmit={onSubmit} className="space-y-2">
+          <input
+            type="text"
+            {...form.register('key')}
+            className="border rounded p-2 w-full"
+          />
+          <div className="flex gap-2">
+            <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
+              {query.data ? 'Update' : 'Save'}
+            </button>
+            {query.data && (
+              <button
+                type="button"
+                onClick={() => delMut.mutate()}
+                className="bg-red-600 text-white px-4 py-2 rounded"
+              >
+                Delete
+              </button>
+            )}
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}
+
+export default function Settings() {
+  const { user } = useUser();
+  if (!user) return <p>Please log in.</p>;
+  return (
+    <div className="space-y-8 max-w-md">
+      <KeySection type="ai" label="OpenAI API Key" />
+      <KeySection type="binance" label="Binance API Key" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Introduce `UserProvider` to hold login state
- Enable Google login to populate user context and show email
- Add settings page to create, update, and delete OpenAI and Binance API keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b551fd5e8832c99d5c1b528e28dbb