### PR TITLE
fix dev api key routing

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,3 @@
-VITE_API_BASE=http://localhost:4000
+VITE_API_BASE=http://localhost:3000
 VITE_USE_MOCKS=true
 VITE_GOOGLE_CLIENT_ID=your-google-client-id

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     },
     proxy: {
       '/login': 'http://localhost:3000',
+      '/users': 'http://localhost:3000',
     },
   },
 });


### PR DESCRIPTION
## Summary
- proxy `/users` requests to the backend in Vite dev server
- update env example to point to backend port 3000

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bf0ebe808832cba11dd2f5b195735