### PR TITLE
feat: add index CRUD

### DIFF
--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -15,3 +15,14 @@ CREATE TABLE IF NOT EXISTS executions(
   tx_hash TEXT,
   created_at INTEGER
 );
+CREATE TABLE IF NOT EXISTS portfolios(
+  id TEXT PRIMARY KEY,
+  user_id TEXT,
+  token_a TEXT,
+  token_b TEXT,
+  token_a_pct INTEGER,
+  token_b_pct INTEGER,
+  risk TEXT,
+  rebalance TEXT,
+  system_prompt TEXT
+);

--- a/backend/src/routes/indexes.ts
+++ b/backend/src/routes/indexes.ts
@@ -1,0 +1,113 @@
+import type { FastifyInstance } from 'fastify';
+import { randomUUID } from 'node:crypto';
+import { db } from '../db/index.js';
+
+interface PortfolioRow {
+  id: string;
+  user_id: string;
+  token_a: string;
+  token_b: string;
+  token_a_pct: number;
+  token_b_pct: number;
+  risk: string;
+  rebalance: string;
+  system_prompt: string;
+}
+
+function toApi(row: PortfolioRow) {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    tokenA: row.token_a,
+    tokenB: row.token_b,
+    tokenAPercent: row.token_a_pct,
+    tokenBPercent: row.token_b_pct,
+    risk: row.risk,
+    rebalance: row.rebalance,
+    systemPrompt: row.system_prompt,
+  };
+}
+
+export default async function indexRoutes(app: FastifyInstance) {
+  app.get('/indexes', async () => {
+    const rows = db.prepare<[], PortfolioRow>('SELECT * FROM portfolios').all();
+    return rows.map(toApi);
+  });
+
+  app.post('/indexes', async (req) => {
+    const body = req.body as {
+      userId: string;
+      tokenA: string;
+      tokenB: string;
+      tokenAPercent: number;
+      tokenBPercent: number;
+      risk: string;
+      rebalance: string;
+      systemPrompt: string;
+    };
+    const id = randomUUID();
+    db.prepare(
+      `INSERT INTO portfolios (id, user_id, token_a, token_b, token_a_pct, token_b_pct, risk, rebalance, system_prompt)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      id,
+      body.userId,
+      body.tokenA,
+      body.tokenB,
+      body.tokenAPercent,
+      body.tokenBPercent,
+      body.risk,
+      body.rebalance,
+      body.systemPrompt
+    );
+    return { id, ...body };
+  });
+
+  app.get('/indexes/:id', async (req, reply) => {
+    const id = (req.params as any).id;
+    const row = db
+      .prepare('SELECT * FROM portfolios WHERE id = ?')
+      .get(id) as PortfolioRow | undefined;
+    if (!row) return reply.code(404).send({ error: 'not found' });
+    return toApi(row);
+  });
+
+  app.put('/indexes/:id', async (req, reply) => {
+    const id = (req.params as any).id;
+    const body = req.body as {
+      userId: string;
+      tokenA: string;
+      tokenB: string;
+      tokenAPercent: number;
+      tokenBPercent: number;
+      risk: string;
+      rebalance: string;
+      systemPrompt: string;
+    };
+    const existing = db
+      .prepare('SELECT id FROM portfolios WHERE id = ?')
+      .get(id) as { id: string } | undefined;
+    if (!existing) return reply.code(404).send({ error: 'not found' });
+    db.prepare(
+      `UPDATE portfolios SET user_id = ?, token_a = ?, token_b = ?, token_a_pct = ?, token_b_pct = ?, risk = ?, rebalance = ?, system_prompt = ? WHERE id = ?`
+    ).run(
+      body.userId,
+      body.tokenA,
+      body.tokenB,
+      body.tokenAPercent,
+      body.tokenBPercent,
+      body.risk,
+      body.rebalance,
+      body.systemPrompt,
+      id
+    );
+    return { id, ...body };
+  });
+
+  app.delete('/indexes/:id', async (req, reply) => {
+    const id = (req.params as any).id;
+    const res = db.prepare('DELETE FROM portfolios WHERE id = ?').run(id);
+    if (res.changes === 0) return reply.code(404).send({ error: 'not found' });
+    return { ok: true };
+  });
+}

--- a/backend/test/indexes.test.ts
+++ b/backend/test/indexes.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+
+process.env.DATABASE_URL = ':memory:';
+process.env.KEY_PASSWORD = 'test-pass';
+process.env.GOOGLE_CLIENT_ID = 'test-client';
+
+const { db, migrate } = await import('../src/db/index.js');
+import buildServer from '../src/server.js';
+
+migrate();
+
+describe('index routes', () => {
+  it('performs CRUD operations', async () => {
+    const app = await buildServer();
+    db.prepare('INSERT INTO users (id) VALUES (?)').run('user1');
+
+    const payload = {
+      userId: 'user1',
+      tokenA: 'btc',
+      tokenB: 'eth',
+      tokenAPercent: 60,
+      tokenBPercent: 40,
+      risk: 'low',
+      rebalance: '1h',
+      systemPrompt: 'prompt',
+    };
+
+    let res = await app.inject({ method: 'POST', url: '/indexes', payload });
+    expect(res.statusCode).toBe(200);
+    const id = res.json().id as string;
+
+    res = await app.inject({ method: 'GET', url: `/indexes/${id}` });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ id, ...payload });
+
+    res = await app.inject({ method: 'GET', url: '/indexes' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveLength(1);
+
+    const update = { ...payload, tokenAPercent: 70, tokenBPercent: 30, risk: 'medium' };
+    res = await app.inject({ method: 'PUT', url: `/indexes/${id}`, payload: update });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ id, ...update });
+
+    res = await app.inject({ method: 'DELETE', url: `/indexes/${id}` });
+    expect(res.statusCode).toBe(200);
+
+    res = await app.inject({ method: 'GET', url: `/indexes/${id}` });
+    expect(res.statusCode).toBe(404);
+
+    await app.close();
+  });
+});

--- a/frontend/src/components/forms/IndexForm.tsx
+++ b/frontend/src/components/forms/IndexForm.tsx
@@ -1,6 +1,8 @@
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
+import api from '../../lib/axios';
+import { useUser } from '../../lib/user';
 
 const schema = z
   .object({
@@ -39,6 +41,7 @@ const tokens = [
 ];
 
 export default function IndexForm() {
+  const { user } = useUser();
   const { register, handleSubmit, watch, setValue } = useForm<FormValues>({
     resolver: zodResolver(schema),
     defaultValues: {
@@ -56,8 +59,9 @@ export default function IndexForm() {
   const tokenA = watch('tokenA');
   const tokenB = watch('tokenB');
 
-  const onSubmit = handleSubmit((values) => {
-    console.log(values);
+  const onSubmit = handleSubmit(async (values) => {
+    if (!user) return;
+    await api.post('/indexes', { userId: user.id, ...values });
   });
 
   return (


### PR DESCRIPTION
## Summary
- add `portfolios` table to store index configurations
- implement `/indexes` Fastify routes for CRUD operations
- post new indexes from the React form with the logged-in user ID

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bf64fb8e0832cb6c3c511bfbdd23a