### PR TITLE
fix dev proxy for index route

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     proxy: {
       '/login': 'http://localhost:3000',
       '/users': 'http://localhost:3000',
+      '/indexes': 'http://localhost:3000',
     },
   },
 });


### PR DESCRIPTION
## Summary
- proxy /indexes in vite config to backend to support index creation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bfe77bc80832c8826c83c132e9819