### PR TITLE
Redact API keys in backend responses

### DIFF
--- a/backend/src/routes/api-keys.ts
+++ b/backend/src/routes/api-keys.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from 'fastify';
 import { db } from '../db/index.js';
 import { env } from '../util/env.js';
 import { encrypt, decrypt } from '../util/crypto.js';
+import { redactKey } from '../util/redact.js';
 
 export default async function apiKeyRoutes(app: FastifyInstance) {
   app.post('/users/:id/ai-key', async (req, reply) => {
@@ -16,7 +17,7 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
     if (row.ai_api_key_enc) return reply.code(400).send({ error: 'key exists' });
     const enc = encrypt(key, env.KEY_PASSWORD);
     db.prepare('UPDATE users SET ai_api_key_enc = ? WHERE id = ?').run(enc, id);
-    return { key };
+    return { key: redactKey(key) };
   });
 
   app.get('/users/:id/ai-key', async (req, reply) => {
@@ -27,7 +28,7 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
     if (!row || !row.ai_api_key_enc)
       return reply.code(404).send({ error: 'not found' });
     const key = decrypt(row.ai_api_key_enc, env.KEY_PASSWORD);
-    return { key };
+    return { key: redactKey(key) };
   });
 
   app.put('/users/:id/ai-key', async (req, reply) => {
@@ -40,7 +41,7 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
       return reply.code(404).send({ error: 'not found' });
     const enc = encrypt(key, env.KEY_PASSWORD);
     db.prepare('UPDATE users SET ai_api_key_enc = ? WHERE id = ?').run(enc, id);
-    return { key };
+    return { key: redactKey(key) };
   });
 
   app.delete('/users/:id/ai-key', async (req, reply) => {
@@ -66,7 +67,7 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
     if (row.binance_api_key_enc) return reply.code(400).send({ error: 'key exists' });
     const enc = encrypt(key, env.KEY_PASSWORD);
     db.prepare('UPDATE users SET binance_api_key_enc = ? WHERE id = ?').run(enc, id);
-    return { key };
+    return { key: redactKey(key) };
   });
 
   app.get('/users/:id/binance-key', async (req, reply) => {
@@ -77,7 +78,7 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
     if (!row || !row.binance_api_key_enc)
       return reply.code(404).send({ error: 'not found' });
     const key = decrypt(row.binance_api_key_enc, env.KEY_PASSWORD);
-    return { key };
+    return { key: redactKey(key) };
   });
 
   app.put('/users/:id/binance-key', async (req, reply) => {
@@ -90,7 +91,7 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
       return reply.code(404).send({ error: 'not found' });
     const enc = encrypt(key, env.KEY_PASSWORD);
     db.prepare('UPDATE users SET binance_api_key_enc = ? WHERE id = ?').run(enc, id);
-    return { key };
+    return { key: redactKey(key) };
   });
 
   app.delete('/users/:id/binance-key', async (req, reply) => {

--- a/backend/src/util/redact.ts
+++ b/backend/src/util/redact.ts
@@ -1,0 +1,5 @@
+export function redactKey(key: string, visible = 4): string {
+  if (key.length <= visible) return key[0] + '...';
+  if (key.length <= visible * 2) return key.slice(0, visible) + '...';
+  return key.slice(0, visible) + '...' + key.slice(-visible);
+}

--- a/backend/test/apiKeys.test.ts
+++ b/backend/test/apiKeys.test.ts
@@ -14,20 +14,24 @@ describe('AI API key routes', () => {
     const app = await buildServer();
     db.prepare('INSERT INTO users (id) VALUES (?)').run('user1');
 
+    const key1 = 'aikey1234567890';
+    const key2 = 'aikeyabcdefghij';
+
     let res = await app.inject({
       method: 'POST',
       url: '/users/user1/ai-key',
-      payload: { key: 'aikey1' },
+      payload: { key: key1 },
     });
     expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ key: 'aike...7890' });
     const row = db
       .prepare('SELECT ai_api_key_enc FROM users WHERE id = ?')
       .get('user1');
-    expect(row.ai_api_key_enc).not.toBe('aikey1');
+    expect(row.ai_api_key_enc).not.toBe(key1);
 
     res = await app.inject({ method: 'GET', url: '/users/user1/ai-key' });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toMatchObject({ key: 'aikey1' });
+    expect(res.json()).toMatchObject({ key: 'aike...7890' });
 
     res = await app.inject({
       method: 'POST',
@@ -39,10 +43,10 @@ describe('AI API key routes', () => {
     res = await app.inject({
       method: 'PUT',
       url: '/users/user1/ai-key',
-      payload: { key: 'aikey2' },
+      payload: { key: key2 },
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toMatchObject({ key: 'aikey2' });
+    expect(res.json()).toMatchObject({ key: 'aike...ghij' });
 
     res = await app.inject({ method: 'DELETE', url: '/users/user1/ai-key' });
     expect(res.statusCode).toBe(200);
@@ -59,20 +63,24 @@ describe('Binance API key routes', () => {
     const app = await buildServer();
     db.prepare('INSERT INTO users (id) VALUES (?)').run('user2');
 
+    const key1 = 'bkey1234567890';
+    const key2 = 'bkeyabcdefghij';
+
     let res = await app.inject({
       method: 'POST',
       url: '/users/user2/binance-key',
-      payload: { key: 'bkey1' },
+      payload: { key: key1 },
     });
     expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ key: 'bkey...7890' });
     const row = db
       .prepare('SELECT binance_api_key_enc FROM users WHERE id = ?')
       .get('user2');
-    expect(row.binance_api_key_enc).not.toBe('bkey1');
+    expect(row.binance_api_key_enc).not.toBe(key1);
 
     res = await app.inject({ method: 'GET', url: '/users/user2/binance-key' });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toMatchObject({ key: 'bkey1' });
+    expect(res.json()).toMatchObject({ key: 'bkey...7890' });
 
     res = await app.inject({
       method: 'POST',
@@ -84,10 +92,10 @@ describe('Binance API key routes', () => {
     res = await app.inject({
       method: 'PUT',
       url: '/users/user2/binance-key',
-      payload: { key: 'bkey2' },
+      payload: { key: key2 },
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toMatchObject({ key: 'bkey2' });
+    expect(res.json()).toMatchObject({ key: 'bkey...ghij' });
 
     res = await app.inject({ method: 'DELETE', url: '/users/user2/binance-key' });
     expect(res.statusCode).toBe(200);


### PR DESCRIPTION
## Summary
- add helper to redact API keys before returning from backend
- mask AI and Binance API key endpoints with redaction utility
- update tests for redacted API key responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c0e905e58832cb5f1fb5c17796d3e