### PR TITLE
refactor: rename portfolios to token indexes

### DIFF
--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS executions(
   tx_hash TEXT,
   created_at INTEGER
 );
-CREATE TABLE IF NOT EXISTS portfolios(
+CREATE TABLE IF NOT EXISTS token_indexes(
   id TEXT PRIMARY KEY,
   user_id TEXT,
   token_a TEXT,


### PR DESCRIPTION
## Summary
- rename portfolio references to token_indexes in DB schema and routes
- remove portfolio mentions from indexes API types

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c140e5170832c8fa19e8ec5cfafd6