### PR TITLE
Refine Google sign-in button styling

### DIFF
--- a/frontend/src/components/GoogleLoginButton.tsx
+++ b/frontend/src/components/GoogleLoginButton.tsx
@@ -19,10 +19,14 @@ export default function GoogleLoginButton() {
     });
     google.accounts.id.renderButton(btnRef.current, {
       theme: 'outline',
-      size: 'large',
+      size: 'small',
+      text: 'signin',
     });
   }, [user, setUser]);
 
-  if (user) return <span className="text-sm">{user.email}</span>;
-  return <div ref={btnRef}></div>;
+  if (user)
+    return (
+      <div className="h-5 flex items-center text-sm">{user.email}</div>
+    );
+  return <div ref={btnRef} className="h-5 capitalize" />;
 }


### PR DESCRIPTION
## Summary
- Show "Sign In" text on Google login button
- Render smaller Google login button to keep header height stable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c295ac780832cbaa273641615c519