### PR TITLE
Validate Binance API key like OpenAI

### DIFF
--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -4,7 +4,8 @@ CREATE TABLE IF NOT EXISTS users(
   policy_json TEXT,
   session_key_expires_at INTEGER,
   ai_api_key_enc TEXT,
-  binance_api_key_enc TEXT
+  binance_api_key_enc TEXT,
+  binance_api_secret_enc TEXT
 );
 
 CREATE TABLE IF NOT EXISTS executions(

--- a/backend/src/routes/api-keys.ts
+++ b/backend/src/routes/api-keys.ts
@@ -3,12 +3,32 @@ import { db } from '../db/index.js';
 import { env } from '../util/env.js';
 import { encrypt, decrypt } from '../util/crypto.js';
 import { redactKey } from '../util/redact.js';
+import { createHmac } from 'node:crypto';
 
 async function isValidOpenAIKey(key: string) {
   try {
     const res = await fetch('https://api.openai.com/v1/models', {
       headers: { Authorization: `Bearer ${key}` },
     });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function isValidBinanceKey(key: string, secret: string) {
+  try {
+    const timestamp = Date.now();
+    const query = `timestamp=${timestamp}`;
+    const signature = createHmac('sha256', secret)
+      .update(query)
+      .digest('hex');
+    const res = await fetch(
+      `https://api.binance.com/api/v3/account?${query}&signature=${signature}`,
+      {
+        headers: { 'X-MBX-APIKEY': key },
+      }
+    );
     return res.ok;
   } catch {
     return false;
@@ -72,51 +92,78 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
 
   app.post('/users/:id/binance-key', async (req, reply) => {
     const id = (req.params as any).id;
-    const { key } = req.body as { key: string };
+    const { key, secret } = req.body as { key: string; secret: string };
     const row = db
-      .prepare<[string], { binance_api_key_enc?: string }>(
-        'SELECT binance_api_key_enc FROM users WHERE id = ?'
-      )
+      .prepare<
+        [string],
+        { binance_api_key_enc?: string; binance_api_secret_enc?: string }
+      >('SELECT binance_api_key_enc, binance_api_secret_enc FROM users WHERE id = ?')
       .get(id);
     if (!row) return reply.code(404).send({ error: 'user not found' });
-    if (row.binance_api_key_enc) return reply.code(400).send({ error: 'key exists' });
-    const enc = encrypt(key, env.KEY_PASSWORD);
-    db.prepare('UPDATE users SET binance_api_key_enc = ? WHERE id = ?').run(enc, id);
-    return { key: redactKey(key) };
+    if (row.binance_api_key_enc || row.binance_api_secret_enc)
+      return reply.code(400).send({ error: 'key exists' });
+    if (!(await isValidBinanceKey(key, secret)))
+      return reply.code(400).send({ error: 'invalid key' });
+    const encKey = encrypt(key, env.KEY_PASSWORD);
+    const encSecret = encrypt(secret, env.KEY_PASSWORD);
+    db.prepare(
+      'UPDATE users SET binance_api_key_enc = ?, binance_api_secret_enc = ? WHERE id = ?'
+    ).run(encKey, encSecret, id);
+    return { key: redactKey(key), secret: redactKey(secret) };
   });
 
   app.get('/users/:id/binance-key', async (req, reply) => {
     const id = (req.params as any).id;
     const row = db
-      .prepare('SELECT binance_api_key_enc FROM users WHERE id = ?')
-      .get(id) as { binance_api_key_enc?: string } | undefined;
-    if (!row || !row.binance_api_key_enc)
+      .prepare(
+        'SELECT binance_api_key_enc, binance_api_secret_enc FROM users WHERE id = ?'
+      )
+      .get(id) as
+      | { binance_api_key_enc?: string; binance_api_secret_enc?: string }
+      | undefined;
+    if (!row || !row.binance_api_key_enc || !row.binance_api_secret_enc)
       return reply.code(404).send({ error: 'not found' });
     const key = decrypt(row.binance_api_key_enc, env.KEY_PASSWORD);
-    return { key: redactKey(key) };
+    const secret = decrypt(row.binance_api_secret_enc, env.KEY_PASSWORD);
+    return { key: redactKey(key), secret: redactKey(secret) };
   });
 
   app.put('/users/:id/binance-key', async (req, reply) => {
     const id = (req.params as any).id;
-    const { key } = req.body as { key: string };
+    const { key, secret } = req.body as { key: string; secret: string };
     const row = db
-      .prepare('SELECT binance_api_key_enc FROM users WHERE id = ?')
-      .get(id) as { binance_api_key_enc?: string } | undefined;
-    if (!row || !row.binance_api_key_enc)
+      .prepare(
+        'SELECT binance_api_key_enc, binance_api_secret_enc FROM users WHERE id = ?'
+      )
+      .get(id) as
+      | { binance_api_key_enc?: string; binance_api_secret_enc?: string }
+      | undefined;
+    if (!row || !row.binance_api_key_enc || !row.binance_api_secret_enc)
       return reply.code(404).send({ error: 'not found' });
-    const enc = encrypt(key, env.KEY_PASSWORD);
-    db.prepare('UPDATE users SET binance_api_key_enc = ? WHERE id = ?').run(enc, id);
-    return { key: redactKey(key) };
+    if (!(await isValidBinanceKey(key, secret)))
+      return reply.code(400).send({ error: 'invalid key' });
+    const encKey = encrypt(key, env.KEY_PASSWORD);
+    const encSecret = encrypt(secret, env.KEY_PASSWORD);
+    db.prepare(
+      'UPDATE users SET binance_api_key_enc = ?, binance_api_secret_enc = ? WHERE id = ?'
+    ).run(encKey, encSecret, id);
+    return { key: redactKey(key), secret: redactKey(secret) };
   });
 
   app.delete('/users/:id/binance-key', async (req, reply) => {
     const id = (req.params as any).id;
     const row = db
-      .prepare('SELECT binance_api_key_enc FROM users WHERE id = ?')
-      .get(id) as { binance_api_key_enc?: string } | undefined;
-    if (!row || !row.binance_api_key_enc)
+      .prepare(
+        'SELECT binance_api_key_enc, binance_api_secret_enc FROM users WHERE id = ?'
+      )
+      .get(id) as
+      | { binance_api_key_enc?: string; binance_api_secret_enc?: string }
+      | undefined;
+    if (!row || !row.binance_api_key_enc || !row.binance_api_secret_enc)
       return reply.code(404).send({ error: 'not found' });
-    db.prepare('UPDATE users SET binance_api_key_enc = NULL WHERE id = ?').run(id);
+    db.prepare(
+      'UPDATE users SET binance_api_key_enc = NULL, binance_api_secret_enc = NULL WHERE id = ?'
+    ).run(id);
     return { ok: true };
   });
 }

--- a/frontend/src/components/forms/BinanceKeySection.tsx
+++ b/frontend/src/components/forms/BinanceKeySection.tsx
@@ -5,17 +5,34 @@ import axios from 'axios';
 import api from '../../lib/axios';
 import { useUser } from '../../lib/user';
 
-export default function KeySection({ label }: { label: string }) {
+async function hmacSHA256(message: string, secret: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(message));
+  return Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export default function BinanceKeySection({ label }: { label: string }) {
   const { user } = useUser();
-  const form = useForm<{ key: string }>({ defaultValues: { key: '' } });
+  const form = useForm<{ key: string; secret: string }>({
+    defaultValues: { key: '', secret: '' },
+  });
   const id = user!.id;
-  const query = useQuery<string | null>({
-    queryKey: ['ai-key', id],
+  const query = useQuery<{ key: string; secret: string } | null>({
+    queryKey: ['binance-key', id],
     enabled: !!user,
     queryFn: async () => {
       try {
-        const res = await api.get(`/users/${id}/ai-key`);
-        return res.data.key as string;
+        const res = await api.get(`/users/${id}/binance-key`);
+        return res.data as { key: string; secret: string };
       } catch (err) {
         if (axios.isAxiosError(err) && err.response?.status === 404) return null;
         throw err;
@@ -24,43 +41,48 @@ export default function KeySection({ label }: { label: string }) {
   });
 
   useEffect(() => {
-    form.setValue('key', query.data ?? '');
+    form.reset(query.data ?? { key: '', secret: '' });
   }, [query.data, form]);
 
-  const [isKeyValid, setIsKeyValid] = useState<boolean | null>(null);
+  const [isValid, setIsValid] = useState<boolean | null>(null);
   const [editing, setEditing] = useState(false);
 
   useEffect(() => {
     setEditing(!query.data);
-    setIsKeyValid(query.data ? true : null);
+    setIsValid(query.data ? true : null);
   }, [query.data]);
 
   const keyValue = form.watch('key');
+  const secretValue = form.watch('secret');
 
   useEffect(() => {
     if (!editing) return;
-    if (!keyValue) {
-      setIsKeyValid(null);
+    if (!keyValue || !secretValue) {
+      setIsValid(null);
       return;
     }
     const handle = setTimeout(async () => {
       try {
-        const res = await fetch('https://api.openai.com/v1/models', {
-          headers: { Authorization: `Bearer ${keyValue}` },
-        });
-        setIsKeyValid(res.ok);
+        const timestamp = Date.now();
+        const qs = `timestamp=${timestamp}`;
+        const signature = await hmacSHA256(qs, secretValue);
+        const res = await fetch(
+          `https://api.binance.com/api/v3/account?${qs}&signature=${signature}`,
+          { headers: { 'X-MBX-APIKEY': keyValue } }
+        );
+        setIsValid(res.ok);
       } catch {
-        setIsKeyValid(false);
+        setIsValid(false);
       }
     }, 500);
     return () => clearTimeout(handle);
-  }, [keyValue, editing]);
+  }, [keyValue, secretValue, editing]);
 
   const saveMut = useMutation({
-    mutationFn: async (key: string) => {
+    mutationFn: async (vals: { key: string; secret: string }) => {
       const method = query.data ? 'put' : 'post';
-      const res = await api[method](`/users/${id}/ai-key`, { key });
-      return res.data.key as string;
+      const res = await api[method](`/users/${id}/binance-key`, vals);
+      return res.data as { key: string; secret: string };
     },
     onSuccess: () => {
       query.refetch();
@@ -68,22 +90,21 @@ export default function KeySection({ label }: { label: string }) {
     },
     onError: (err) => {
       if (axios.isAxiosError(err) && err.response?.data?.error === 'invalid key') {
-        alert('Invalid OpenAI API key');
-        setIsKeyValid(false);
+        alert('Invalid Binance API credentials');
+        setIsValid(false);
       }
     },
   });
 
   const delMut = useMutation({
     mutationFn: async () => {
-      await api.delete(`/users/${id}/ai-key`);
+      await api.delete(`/users/${id}/binance-key`);
     },
     onSuccess: () => query.refetch(),
   });
 
-  const onSubmit = form.handleSubmit((data) => saveMut.mutate(data.key));
-
-  const buttonsDisabled = isKeyValid !== true;
+  const onSubmit = form.handleSubmit((data) => saveMut.mutate(data));
+  const buttonsDisabled = isValid !== true;
 
   return (
     <div className="space-y-2">
@@ -94,13 +115,22 @@ export default function KeySection({ label }: { label: string }) {
         <form onSubmit={onSubmit} className="space-y-2">
           <input
             type="text"
+            placeholder="API Key"
             {...form.register('key')}
             className={`border rounded p-2 w-full ${
-              isKeyValid === false ? 'border-red-500' : ''
+              isValid === false ? 'border-red-500' : ''
             }`}
           />
-          {isKeyValid === false && (
-            <p className="text-sm text-red-600">Invalid OpenAI key</p>
+          <input
+            type="text"
+            placeholder="API Secret"
+            {...form.register('secret')}
+            className={`border rounded p-2 w-full ${
+              isValid === false ? 'border-red-500' : ''
+            }`}
+          />
+          {isValid === false && (
+            <p className="text-sm text-red-600">Invalid Binance credentials</p>
           )}
           <div className="flex gap-2">
             <button
@@ -117,8 +147,8 @@ export default function KeySection({ label }: { label: string }) {
                 type="button"
                 onClick={() => {
                   setEditing(false);
-                  form.setValue('key', query.data ?? '');
-                  setIsKeyValid(true);
+                  form.reset(query.data ?? { key: '', secret: '' });
+                  setIsValid(true);
                 }}
                 className="bg-gray-300 px-4 py-2 rounded"
               >
@@ -131,7 +161,7 @@ export default function KeySection({ label }: { label: string }) {
         <div className="flex gap-2">
           <input
             type="text"
-            value={query.data ?? ''}
+            value={query.data?.key ?? ''}
             disabled
             className="border rounded p-2 w-full"
           />
@@ -139,8 +169,8 @@ export default function KeySection({ label }: { label: string }) {
             type="button"
             onClick={() => {
               setEditing(true);
-              form.setValue('key', '');
-              setIsKeyValid(null);
+              form.reset({ key: '', secret: '' });
+              setIsValid(null);
             }}
             className="bg-blue-600 text-white px-4 py-2 rounded"
           >

--- a/frontend/src/lib/user.tsx
+++ b/frontend/src/lib/user.tsx
@@ -1,7 +1,13 @@
 import { createContext, useContext, useState } from 'react';
 import type { ReactNode } from 'react';
 
-export type User = { id: string; email?: string; openaiKey?: string } | null;
+export type User = {
+  id: string;
+  email?: string;
+  openaiKey?: string;
+  binanceKey?: string;
+  binanceSecret?: string;
+} | null;
 
 const UserContext = createContext<{ user: User; setUser: (u: User) => void }>({
   user: null,

--- a/frontend/src/routes/Settings.tsx
+++ b/frontend/src/routes/Settings.tsx
@@ -1,13 +1,14 @@
 import { useUser } from '../lib/user';
 import KeySection from '../components/forms/KeySection';
+import BinanceKeySection from '../components/forms/BinanceKeySection';
 
 export default function Settings() {
   const { user } = useUser();
   if (!user) return <p>Please log in.</p>;
   return (
     <div className="space-y-8 max-w-md">
-      <KeySection type="ai" label="OpenAI API Key" />
-      <KeySection type="binance" label="Binance API Key" />
+      <KeySection label="OpenAI API Key" />
+      <BinanceKeySection label="Binance API Credentials" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- validate Binance API key and secret against Binance's signed account endpoint
- store encrypted Binance API secret alongside key
- add frontend component to manage and validate Binance credentials

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d398ce420832c9e5c4b1f56cf004f