### PR TITLE
Fetch OpenAI models server-side and gate index form

### DIFF
--- a/backend/src/routes/models.ts
+++ b/backend/src/routes/models.ts
@@ -1,0 +1,28 @@
+import type { FastifyInstance } from 'fastify';
+import { db } from '../db/index.js';
+import { env } from '../util/env.js';
+import { decrypt } from '../util/crypto.js';
+
+export default async function modelsRoutes(app: FastifyInstance) {
+  app.get('/users/:id/models', async (req, reply) => {
+    const id = (req.params as any).id;
+    const row = db
+      .prepare('SELECT ai_api_key_enc FROM users WHERE id = ?')
+      .get(id) as { ai_api_key_enc?: string } | undefined;
+    if (!row?.ai_api_key_enc) return reply.code(404).send({ error: 'not found' });
+    const key = decrypt(row.ai_api_key_enc, env.KEY_PASSWORD);
+    try {
+      const res = await fetch('https://api.openai.com/v1/models', {
+        headers: { Authorization: `Bearer ${key}` },
+      });
+      if (!res.ok) return reply.code(500).send({ error: 'failed to fetch models' });
+      const json = await res.json();
+      const models = (json.data as { id: string }[])
+        .map((m) => m.id)
+        .filter((id: string) => /^(gpt-5|o3|gpt-4\.1|gpt-4o)/.test(id));
+      return { models };
+    } catch {
+      return reply.code(500).send({ error: 'failed to fetch models' });
+    }
+  });
+}

--- a/frontend/src/components/forms/KeySection.tsx
+++ b/frontend/src/components/forms/KeySection.tsx
@@ -87,7 +87,7 @@ export default function KeySection({ label }: { label: string }) {
 
   return (
     <div className="space-y-2">
-      <h2 className="text-lg font-bold">{label}</h2>
+      {label && <h2 className="text-lg font-bold">{label}</h2>}
       {query.isLoading ? (
         <p>Loading...</p>
       ) : editing ? (


### PR DESCRIPTION
## Summary
- expose `/users/:id/models` endpoint to query OpenAI with stored key and return supported models
- load model list from new endpoint and show dropdown only after models arrive
- hide key section heading when no label is provided

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d41bd1440832c934d95b2d63d212e