### PR TITLE
Adjust default index allocations

### DIFF
--- a/frontend/src/components/forms/IndexForm.tsx
+++ b/frontend/src/components/forms/IndexForm.tsx
@@ -82,9 +82,9 @@ export default function IndexForm() {
     defaultValues: {
       tokenA: 'usdt',
       tokenB: 'sol',
-      targetAllocation: 50,
-      minTokenAAllocation: 50,
-      minTokenBAllocation: 50,
+      targetAllocation: 20,
+      minTokenAAllocation: 0,
+      minTokenBAllocation: 30,
       risk: 'low',
       rebalance: '1h',
       model: '',


### PR DESCRIPTION
## Summary
- set index creation defaults to 20%/80% target allocation
- zero minimum Token A allocation and require 30% minimum Token B allocation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689eaab785b8832c83235a1b341432b4