### PR TITLE
Add Binance balance endpoint and UI display

### DIFF
--- a/backend/src/routes/binance-balance.ts
+++ b/backend/src/routes/binance-balance.ts
@@ -1,0 +1,56 @@
+import type { FastifyInstance } from 'fastify';
+import { db } from '../db/index.js';
+import { env } from '../util/env.js';
+import { decrypt } from '../util/crypto.js';
+import { createHmac } from 'node:crypto';
+
+export default async function binanceBalanceRoutes(app: FastifyInstance) {
+  app.get('/users/:id/binance-balance', async (req, reply) => {
+    const id = (req.params as any).id;
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (!userId || userId !== id) {
+      return reply.code(403).send({ error: 'forbidden' });
+    }
+    const row = db
+      .prepare(
+        'SELECT binance_api_key_enc, binance_api_secret_enc FROM users WHERE id = ?'
+      )
+      .get(id) as
+      | { binance_api_key_enc?: string; binance_api_secret_enc?: string }
+      | undefined;
+    if (!row || !row.binance_api_key_enc || !row.binance_api_secret_enc) {
+      return reply.code(404).send({ error: 'not found' });
+    }
+    const key = decrypt(row.binance_api_key_enc, env.KEY_PASSWORD);
+    const secret = decrypt(row.binance_api_secret_enc, env.KEY_PASSWORD);
+    const timestamp = Date.now();
+    const query = `timestamp=${timestamp}`;
+    const signature = createHmac('sha256', secret)
+      .update(query)
+      .digest('hex');
+    const accountRes = await fetch(
+      `https://api.binance.com/api/v3/account?${query}&signature=${signature}`,
+      { headers: { 'X-MBX-APIKEY': key } }
+    );
+    if (!accountRes.ok) return reply.code(500).send({ error: 'failed to fetch account' });
+    const account = (await accountRes.json()) as {
+      balances: { asset: string; free: string; locked: string }[];
+    };
+    let total = 0;
+    for (const b of account.balances) {
+      const amount = Number(b.free) + Number(b.locked);
+      if (!amount) continue;
+      if (b.asset === 'USDT') {
+        total += amount;
+        continue;
+      }
+      const priceRes = await fetch(
+        `https://api.binance.com/api/v3/ticker/price?symbol=${b.asset}USDT`
+      );
+      if (!priceRes.ok) continue;
+      const priceJson = (await priceRes.json()) as { price: string };
+      total += amount * Number(priceJson.price);
+    }
+    return { totalUsd: total };
+  });
+}

--- a/backend/test/binanceBalance.test.ts
+++ b/backend/test/binanceBalance.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+
+process.env.DATABASE_URL = ':memory:';
+process.env.KEY_PASSWORD = 'test-pass';
+process.env.GOOGLE_CLIENT_ID = 'test-client';
+
+const { db, migrate } = await import('../src/db/index.js');
+import buildServer from '../src/server.js';
+import { encrypt } from '../src/util/crypto.js';
+
+migrate();
+
+describe('binance balance route', () => {
+  it('returns aggregated balance for user', async () => {
+    const app = await buildServer();
+    const key = 'binKey123456';
+    const secret = 'binSecret123456';
+    const encKey = encrypt(key, process.env.KEY_PASSWORD!);
+    const encSecret = encrypt(secret, process.env.KEY_PASSWORD!);
+    db.prepare(
+      'INSERT INTO users (id, binance_api_key_enc, binance_api_secret_enc) VALUES (?, ?, ?)'
+    ).run('user1', encKey, encSecret);
+
+    const fetchMock = vi.fn();
+    const originalFetch = globalThis.fetch;
+    (globalThis as any).fetch = fetchMock;
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        balances: [
+          { asset: 'BTC', free: '1', locked: '0' },
+          { asset: 'USDT', free: '100', locked: '0' },
+        ],
+      }),
+    } as any);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ price: '20000' }),
+    } as any);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/users/user1/binance-balance',
+      headers: { 'x-user-id': 'user1' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ totalUsd: 20100 });
+
+    await app.close();
+    (globalThis as any).fetch = originalFetch;
+  });
+
+  it('forbids accessing another user\'s balance', async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/users/other/binance-balance',
+      headers: { 'x-user-id': 'user1' },
+    });
+    expect(res.statusCode).toBe(403);
+    await app.close();
+  });
+});

--- a/frontend/src/components/forms/BinanceKeySection.tsx
+++ b/frontend/src/components/forms/BinanceKeySection.tsx
@@ -62,6 +62,17 @@ export default function BinanceKeySection({ label }: { label: string }) {
     onSuccess: () => query.refetch(),
   });
 
+  const balanceQuery = useQuery<{ totalUsd: number }>({
+    queryKey: ['binance-balance', id],
+    enabled: !!query.data && !editing,
+    queryFn: async () => {
+      const res = await api.get(`/users/${id}/binance-balance`, {
+        headers: { 'x-user-id': id },
+      });
+      return res.data as { totalUsd: number };
+    },
+  });
+
   const onSubmit = form.handleSubmit((data) => saveMut.mutate(data));
   const buttonsDisabled = !form.formState.isValid;
 
@@ -115,30 +126,39 @@ export default function BinanceKeySection({ label }: { label: string }) {
           </div>
         </div>
       ) : (
-        <div className="flex gap-2">
-          <input
-            type="text"
-            value={query.data?.key ?? ''}
-            disabled
-            className="border rounded p-2 w-full"
-          />
-          <button
-            type="button"
-            onClick={() => {
-              setEditing(true);
-              form.reset({ key: '', secret: '' });
-            }}
-            className="bg-blue-600 text-white px-4 py-2 rounded"
-          >
-            Edit
-          </button>
-          <button
-            type="button"
-            onClick={() => delMut.mutate()}
-            className="bg-red-600 text-white px-4 py-2 rounded"
-          >
-            Delete
-          </button>
+        <div className="space-y-2">
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={query.data?.key ?? ''}
+              disabled
+              className="border rounded p-2 w-full"
+            />
+            <button
+              type="button"
+              onClick={() => {
+                setEditing(true);
+                form.reset({ key: '', secret: '' });
+              }}
+              className="bg-blue-600 text-white px-4 py-2 rounded"
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              onClick={() => delMut.mutate()}
+              className="bg-red-600 text-white px-4 py-2 rounded"
+            >
+              Delete
+            </button>
+          </div>
+          {balanceQuery.isLoading ? (
+            <p>Loading balance...</p>
+          ) : balanceQuery.data ? (
+            <p className="text-sm text-gray-600">
+              Total balance: ${balanceQuery.data.totalUsd.toFixed(2)}
+            </p>
+          ) : null}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- fetch and display user's aggregated Binance balance
- add backend route with ownership check and tests
- show USD balance in settings when Binance key is saved

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ec0848aa8832c9008fc41e290c470