### PR TITLE
persist google auth across page reloads

### DIFF
--- a/frontend/src/lib/user.tsx
+++ b/frontend/src/lib/user.tsx
@@ -1,5 +1,6 @@
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
+import api from './axios';
 
 export type User = {
   id: string;
@@ -15,7 +16,70 @@ const UserContext = createContext<{ user: User; setUser: (u: User) => void }>({
 });
 
 export function UserProvider({ children }: { children: ReactNode }) {
-  const [user, setUser] = useState<User>(null);
+  const [user, setUser] = useState<User>(() => {
+    if (typeof window === 'undefined') return null;
+    try {
+      const stored = window.localStorage.getItem('user');
+      return stored ? (JSON.parse(stored) as User) : null;
+    } catch {
+      return null;
+    }
+  });
+
+  // Re-validate the stored user with Google on load to ensure the session
+  // hasn't been invalidated. If the Google credential cannot be obtained the
+  // user is cleared so stale localStorage does not keep them signed in.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const init = () => {
+      const google = (window as any).google;
+      if (!google) return;
+
+      google.accounts.id.initialize({
+        client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID,
+        callback: async (resp: any) => {
+          try {
+            const res = await api.post('/login', { token: resp.credential });
+            setUser(res.data);
+          } catch {
+            setUser(null);
+          }
+        },
+      });
+
+      google.accounts.id.prompt((notification: any) => {
+        if (
+          notification.isNotDisplayed() ||
+          notification.isSkippedMoment()
+        ) {
+          setUser(null);
+        }
+      });
+    };
+
+    if ((window as any).google) {
+      init();
+    } else {
+      const id = setInterval(() => {
+        if ((window as any).google) {
+          clearInterval(id);
+          init();
+        }
+      }, 100);
+      return () => clearInterval(id);
+    }
+  }, [setUser]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (user) {
+      window.localStorage.setItem('user', JSON.stringify(user));
+    } else {
+      window.localStorage.removeItem('user');
+    }
+  }, [user]);
+
   return <UserContext.Provider value={{ user, setUser }}>{children}</UserContext.Provider>;
 }
 


### PR DESCRIPTION
## Summary
- store logged in user in localStorage
- restore user from localStorage on app start
- revalidate stored user with Google and clear when session invalid

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ec95413c0832cb3134a34f42afc9e