### PR TITLE
Normalize token symbols to uppercase across app

### DIFF
--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -11,7 +11,4 @@ export const db = new Database(env.DATABASE_URL);
 export function migrate() {
   const schema = fs.readFileSync(path.join(__dirname, 'schema.sql'), 'utf8');
   db.exec(schema);
-  db.exec(
-    'UPDATE token_indexes SET token_a = UPPER(token_a), token_b = UPPER(token_b)'
-  );
 }

--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -11,4 +11,7 @@ export const db = new Database(env.DATABASE_URL);
 export function migrate() {
   const schema = fs.readFileSync(path.join(__dirname, 'schema.sql'), 'utf8');
   db.exec(schema);
+  db.exec(
+    'UPDATE token_indexes SET token_a = UPPER(token_a), token_b = UPPER(token_b)'
+  );
 }

--- a/backend/src/routes/indexes.ts
+++ b/backend/src/routes/indexes.ts
@@ -22,8 +22,8 @@ function toApi(row: TokenIndexRow) {
   return {
     id: row.id,
     userId: row.user_id,
-    tokenA: row.token_a,
-    tokenB: row.token_b,
+    tokenA: row.token_a.toUpperCase(),
+    tokenB: row.token_b.toUpperCase(),
     targetAllocation: row.target_allocation,
     minTokenAAllocation: row.min_a_allocation,
     minTokenBAllocation: row.min_b_allocation,

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -65,7 +65,7 @@ export default function Dashboard() {
           {data?.items.map((idx) => (
             <tr key={idx.id}>
               <td>{idx.userId}</td>
-              <td>{`${idx.tokenA}/${idx.tokenB}`}</td>
+              <td>{`${idx.tokenA.toUpperCase()}/${idx.tokenB.toUpperCase()}`}</td>
               <td>{`${idx.targetAllocation}%/${100 - idx.targetAllocation}%`}</td>
               <td>{idx.risk}</td>
               <td>

--- a/frontend/src/routes/ViewIndex.tsx
+++ b/frontend/src/routes/ViewIndex.tsx
@@ -31,11 +31,11 @@ export default function ViewIndex() {
   });
 
   const balanceA = useQuery({
-    queryKey: ['binance-balance', user?.id, data?.tokenA],
+    queryKey: ['binance-balance', user?.id, data?.tokenA?.toUpperCase()],
     enabled: !!user && !!data?.tokenA,
     queryFn: async () => {
       const res = await api.get(
-        `/users/${user!.id}/binance-balance/${data!.tokenA}`,
+        `/users/${user!.id}/binance-balance/${data!.tokenA.toUpperCase()}`,
         { headers: { 'x-user-id': user!.id } }
       );
       return res.data as { asset: string; free: number; locked: number };
@@ -43,11 +43,11 @@ export default function ViewIndex() {
   });
 
   const balanceB = useQuery({
-    queryKey: ['binance-balance', user?.id, data?.tokenB],
+    queryKey: ['binance-balance', user?.id, data?.tokenB?.toUpperCase()],
     enabled: !!user && !!data?.tokenB,
     queryFn: async () => {
       const res = await api.get(
-        `/users/${user!.id}/binance-balance/${data!.tokenB}`,
+        `/users/${user!.id}/binance-balance/${data!.tokenB.toUpperCase()}`,
         { headers: { 'x-user-id': user!.id } }
       );
       return res.data as { asset: string; free: number; locked: number };
@@ -58,7 +58,7 @@ export default function ViewIndex() {
 
   return (
     <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">{`${data.tokenA}/${data.tokenB}`}</h1>
+      <h1 className="text-2xl font-bold mb-4">{`${data.tokenA.toUpperCase()}/${data.tokenB.toUpperCase()}`}</h1>
       <p>
         <strong>User:</strong> {data.userId}
       </p>
@@ -87,13 +87,13 @@ export default function ViewIndex() {
       <div className="mt-4">
         <h2 className="text-xl font-bold mb-2">Binance Balances</h2>
         <p>
-          <strong>{data.tokenA}:</strong>{' '}
+          <strong>{data.tokenA.toUpperCase()}:</strong>{' '}
           {balanceA.isLoading
             ? 'Loading...'
             : (balanceA.data?.free ?? 0) + (balanceA.data?.locked ?? 0)}
         </p>
         <p>
-          <strong>{data.tokenB}:</strong>{' '}
+          <strong>{data.tokenB.toUpperCase()}:</strong>{' '}
           {balanceB.isLoading
             ? 'Loading...'
             : (balanceB.data?.free ?? 0) + (balanceB.data?.locked ?? 0)}


### PR DESCRIPTION
## Summary
- Uppercase token fields when migrating the database
- Ensure index API returns uppercase token symbols
- Display token symbols in uppercase across dashboard and index pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ecb58a85c832cb1c9925ef01d8721