### PR TITLE
feat: namespace API routes to avoid path conflicts

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -12,7 +12,7 @@ export default async function buildServer(): Promise<FastifyInstance> {
   for (const file of fs.readdirSync(routesDir)) {
     if (file.endsWith('.js') || (file.endsWith('.ts') && !file.endsWith('.d.ts'))) {
       const route = await import(pathToFileURL(path.join(routesDir, file)).href);
-      app.register(route.default);
+      app.register(route.default, { prefix: '/api' });
     }
   }
 

--- a/backend/test/apiKeys.test.ts
+++ b/backend/test/apiKeys.test.ts
@@ -24,7 +24,7 @@ describe('AI API key routes', () => {
     fetchMock.mockResolvedValueOnce({ ok: false } as any);
     let res = await app.inject({
       method: 'POST',
-      url: '/users/user1/ai-key',
+      url: '/api/users/user1/ai-key',
       payload: { key: 'bad' },
     });
     expect(res.statusCode).toBe(400);
@@ -37,7 +37,7 @@ describe('AI API key routes', () => {
     fetchMock.mockResolvedValueOnce({ ok: true } as any);
     res = await app.inject({
       method: 'POST',
-      url: '/users/user1/ai-key',
+      url: '/api/users/user1/ai-key',
       payload: { key: key1 },
     });
     expect(res.statusCode).toBe(200);
@@ -47,13 +47,13 @@ describe('AI API key routes', () => {
       .get('user1');
     expect(row.ai_api_key_enc).not.toBe(key1);
 
-    res = await app.inject({ method: 'GET', url: '/users/user1/ai-key' });
+    res = await app.inject({ method: 'GET', url: '/api/users/user1/ai-key' });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ key: 'aike...7890' });
 
     res = await app.inject({
       method: 'POST',
-      url: '/users/user1/ai-key',
+      url: '/api/users/user1/ai-key',
       payload: { key: 'dup' },
     });
     expect(res.statusCode).toBe(400);
@@ -61,27 +61,27 @@ describe('AI API key routes', () => {
     fetchMock.mockResolvedValueOnce({ ok: false } as any);
     res = await app.inject({
       method: 'PUT',
-      url: '/users/user1/ai-key',
+      url: '/api/users/user1/ai-key',
       payload: { key: 'bad2' },
     });
     expect(res.statusCode).toBe(400);
     expect(res.json()).toMatchObject({ error: 'verification failed' });
-    res = await app.inject({ method: 'GET', url: '/users/user1/ai-key' });
+    res = await app.inject({ method: 'GET', url: '/api/users/user1/ai-key' });
     expect(res.json()).toMatchObject({ key: 'aike...7890' });
 
     fetchMock.mockResolvedValueOnce({ ok: true } as any);
     res = await app.inject({
       method: 'PUT',
-      url: '/users/user1/ai-key',
+      url: '/api/users/user1/ai-key',
       payload: { key: key2 },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ key: 'aike...ghij' });
 
-    res = await app.inject({ method: 'DELETE', url: '/users/user1/ai-key' });
+    res = await app.inject({ method: 'DELETE', url: '/api/users/user1/ai-key' });
     expect(res.statusCode).toBe(200);
 
-    res = await app.inject({ method: 'GET', url: '/users/user1/ai-key' });
+    res = await app.inject({ method: 'GET', url: '/api/users/user1/ai-key' });
     expect(res.statusCode).toBe(404);
 
     await app.close();
@@ -106,7 +106,7 @@ describe('Binance API key routes', () => {
     fetchMock.mockResolvedValueOnce({ ok: false } as any);
     let res = await app.inject({
       method: 'POST',
-      url: '/users/user2/binance-key',
+      url: '/api/users/user2/binance-key',
       payload: { key: 'bad', secret: 'bad' },
     });
     expect(res.statusCode).toBe(400);
@@ -122,7 +122,7 @@ describe('Binance API key routes', () => {
     fetchMock.mockResolvedValueOnce({ ok: true } as any);
     res = await app.inject({
       method: 'POST',
-      url: '/users/user2/binance-key',
+      url: '/api/users/user2/binance-key',
       payload: { key: key1, secret: secret1 },
     });
     expect(res.statusCode).toBe(200);
@@ -138,7 +138,7 @@ describe('Binance API key routes', () => {
     expect(row.binance_api_key_enc).not.toBe(key1);
     expect(row.binance_api_secret_enc).not.toBe(secret1);
 
-    res = await app.inject({ method: 'GET', url: '/users/user2/binance-key' });
+    res = await app.inject({ method: 'GET', url: '/api/users/user2/binance-key' });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({
       key: 'bkey...7890',
@@ -147,7 +147,7 @@ describe('Binance API key routes', () => {
 
     res = await app.inject({
       method: 'POST',
-      url: '/users/user2/binance-key',
+      url: '/api/users/user2/binance-key',
       payload: { key: 'dup', secret: 'dup' },
     });
     expect(res.statusCode).toBe(400);
@@ -155,12 +155,12 @@ describe('Binance API key routes', () => {
     fetchMock.mockResolvedValueOnce({ ok: false } as any);
     res = await app.inject({
       method: 'PUT',
-      url: '/users/user2/binance-key',
+      url: '/api/users/user2/binance-key',
       payload: { key: 'bad2', secret: 'bad2' },
     });
     expect(res.statusCode).toBe(400);
     expect(res.json()).toMatchObject({ error: 'verification failed' });
-    res = await app.inject({ method: 'GET', url: '/users/user2/binance-key' });
+    res = await app.inject({ method: 'GET', url: '/api/users/user2/binance-key' });
     expect(res.json()).toMatchObject({
       key: 'bkey...7890',
       secret: 'bsec...7890',
@@ -169,7 +169,7 @@ describe('Binance API key routes', () => {
     fetchMock.mockResolvedValueOnce({ ok: true } as any);
     res = await app.inject({
       method: 'PUT',
-      url: '/users/user2/binance-key',
+      url: '/api/users/user2/binance-key',
       payload: { key: key2, secret: secret2 },
     });
     expect(res.statusCode).toBe(200);
@@ -178,10 +178,10 @@ describe('Binance API key routes', () => {
       secret: 'bsec...ghij',
     });
 
-    res = await app.inject({ method: 'DELETE', url: '/users/user2/binance-key' });
+    res = await app.inject({ method: 'DELETE', url: '/api/users/user2/binance-key' });
     expect(res.statusCode).toBe(200);
 
-    res = await app.inject({ method: 'GET', url: '/users/user2/binance-key' });
+    res = await app.inject({ method: 'GET', url: '/api/users/user2/binance-key' });
     expect(res.statusCode).toBe(404);
 
     await app.close();

--- a/backend/test/binanceBalance.test.ts
+++ b/backend/test/binanceBalance.test.ts
@@ -40,7 +40,7 @@ describe('binance balance route', () => {
 
     const res = await app.inject({
       method: 'GET',
-      url: '/users/user1/binance-balance',
+      url: '/api/users/user1/binance-balance',
       headers: { 'x-user-id': 'user1' },
     });
     expect(res.statusCode).toBe(200);
@@ -72,7 +72,7 @@ describe('binance balance route', () => {
 
     const res = await app.inject({
       method: 'GET',
-      url: '/users/user2/binance-balance/BTC',
+      url: '/api/users/user2/binance-balance/BTC',
       headers: { 'x-user-id': 'user2' },
     });
     expect(res.statusCode).toBe(200);
@@ -86,7 +86,7 @@ describe('binance balance route', () => {
     const app = await buildServer();
     const res = await app.inject({
       method: 'GET',
-      url: '/users/other/binance-balance',
+      url: '/api/users/other/binance-balance',
       headers: { 'x-user-id': 'user1' },
     });
     expect(res.statusCode).toBe(403);

--- a/backend/test/health.test.ts
+++ b/backend/test/health.test.ts
@@ -9,7 +9,7 @@ const { default: buildServer } = await import('../src/server.js');
 describe('health route', () => {
   it('returns ok', async () => {
     const app = await buildServer();
-    const res = await app.inject({ method: 'GET', url: '/health' });
+    const res = await app.inject({ method: 'GET', url: '/api/health' });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ ok: true });
     await app.close();

--- a/backend/test/indexes.test.ts
+++ b/backend/test/indexes.test.ts
@@ -27,35 +27,35 @@ describe('index routes', () => {
       systemPrompt: 'prompt',
     };
 
-    let res = await app.inject({ method: 'POST', url: '/indexes', payload });
+    let res = await app.inject({ method: 'POST', url: '/api/indexes', payload });
     expect(res.statusCode).toBe(200);
     const id = res.json().id as string;
 
-    res = await app.inject({ method: 'GET', url: `/indexes/${id}` });
+    res = await app.inject({ method: 'GET', url: `/api/indexes/${id}` });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ id, ...payload, tvl: 0 });
 
-    res = await app.inject({ method: 'GET', url: '/indexes' });
+    res = await app.inject({ method: 'GET', url: '/api/indexes' });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toHaveLength(1);
 
     res = await app.inject({
       method: 'GET',
-      url: '/indexes/paginated?page=1&pageSize=10&userId=user1',
+      url: '/api/indexes/paginated?page=1&pageSize=10&userId=user1',
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ total: 1, page: 1, pageSize: 10 });
     expect(res.json().items).toHaveLength(1);
 
     const update = { ...payload, targetAllocation: 70, risk: 'medium', model: 'o3' };
-    res = await app.inject({ method: 'PUT', url: `/indexes/${id}`, payload: update });
+    res = await app.inject({ method: 'PUT', url: `/api/indexes/${id}`, payload: update });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ id, ...update, tvl: 0 });
 
-    res = await app.inject({ method: 'DELETE', url: `/indexes/${id}` });
+    res = await app.inject({ method: 'DELETE', url: `/api/indexes/${id}` });
     expect(res.statusCode).toBe(200);
 
-    res = await app.inject({ method: 'GET', url: `/indexes/${id}` });
+    res = await app.inject({ method: 'GET', url: `/api/indexes/${id}` });
     expect(res.statusCode).toBe(404);
 
     await app.close();
@@ -77,28 +77,28 @@ describe('index routes', () => {
 
     let res = await app.inject({
       method: 'POST',
-      url: '/indexes',
+      url: '/api/indexes',
       payload: { ...base, targetAllocation: 50, minTokenAAllocation: 80, minTokenBAllocation: 30 },
     });
     expect(res.json()).toMatchObject({ targetAllocation: 70, minTokenAAllocation: 70, minTokenBAllocation: 30 });
 
     res = await app.inject({
       method: 'POST',
-      url: '/indexes',
+      url: '/api/indexes',
       payload: { ...base, targetAllocation: 50, minTokenAAllocation: 20, minTokenBAllocation: 90 },
     });
     expect(res.json()).toMatchObject({ targetAllocation: 20, minTokenAAllocation: 20, minTokenBAllocation: 80 });
 
     res = await app.inject({
       method: 'POST',
-      url: '/indexes',
+      url: '/api/indexes',
       payload: { ...base, targetAllocation: 5, minTokenAAllocation: 10, minTokenBAllocation: 10 },
     });
     expect(res.json()).toMatchObject({ targetAllocation: 10, minTokenAAllocation: 10, minTokenBAllocation: 10 });
 
     res = await app.inject({
       method: 'POST',
-      url: '/indexes',
+      url: '/api/indexes',
       payload: { ...base, targetAllocation: 95, minTokenAAllocation: 10, minTokenBAllocation: 10 },
     });
     expect(res.json()).toMatchObject({ targetAllocation: 90, minTokenAAllocation: 10, minTokenBAllocation: 10 });

--- a/backend/test/login.test.ts
+++ b/backend/test/login.test.ts
@@ -18,7 +18,7 @@ describe('login route', () => {
 
     const res = await app.inject({
       method: 'POST',
-      url: '/login',
+      url: '/api/login',
       payload: { token: 'test-token' },
     });
     expect(res.statusCode).toBe(200);

--- a/backend/test/models.test.ts
+++ b/backend/test/models.test.ts
@@ -35,7 +35,7 @@ describe('model routes', () => {
       }),
     } as any);
 
-    const res = await app.inject({ method: 'GET', url: '/users/user1/models' });
+    const res = await app.inject({ method: 'GET', url: '/api/users/user1/models' });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ models: ['gpt-4.1-mini', 'o3-mini', 'gpt-5'] });
 
@@ -46,7 +46,7 @@ describe('model routes', () => {
   it('requires a key', async () => {
     const app = await buildServer();
     db.prepare('INSERT INTO users (id) VALUES (?)').run('user2');
-    const res = await app.inject({ method: 'GET', url: '/users/user2/models' });
+    const res = await app.inject({ method: 'GET', url: '/api/users/user2/models' });
     expect(res.statusCode).toBe(404);
     await app.close();
   });

--- a/frontend/src/lib/axios.ts
+++ b/frontend/src/lib/axios.ts
@@ -4,7 +4,7 @@ import axios from 'axios';
 // and avoid CORS. An explicit base URL can still be provided via VITE_API_BASE
 // for deployments where the API lives elsewhere.
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE || '/',
+  baseURL: import.meta.env.VITE_API_BASE || '/api',
 });
 
 export default api;

--- a/frontend/src/lib/mocks.ts
+++ b/frontend/src/lib/mocks.ts
@@ -5,10 +5,10 @@ export function setupMocks() {
 
   axios.interceptors.request.use(async (config) => {
     const { method, url } = config;
-    if (method === 'get' && url === '/indexes') {
+    if (method === 'get' && url === '/api/indexes') {
       config.adapter = async () => ({ data: [], status: 200, statusText: 'OK', headers: {}, config });
     }
-    if (method === 'get' && url?.startsWith('/indexes/paginated')) {
+    if (method === 'get' && url?.startsWith('/api/indexes/paginated')) {
       config.adapter = async () => ({
         data: { items: [], total: 0, page: 1, pageSize: 10 },
         status: 200,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,10 +10,10 @@ export default defineConfig({
       'Cross-Origin-Embedder-Policy': 'unsafe-none',
     },
     proxy: {
-      '/login': 'http://localhost:3000',
-      // Covers /users/:id/ai-key and /users/:id/binance-key
-      '/users': 'http://localhost:3000',
-      '/indexes': 'http://localhost:3000',
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- prefix backend routes under `/api`
- update frontend axios base URL and Vite proxy to match
- adjust mocks and tests for new API paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ed1f96600832c971bb7c5b26351d5