### PR TITLE
feat: add trading warning and start button

### DIFF
--- a/frontend/src/routes/ViewIndex.tsx
+++ b/frontend/src/routes/ViewIndex.tsx
@@ -98,6 +98,16 @@ export default function ViewIndex() {
             ? 'Loading...'
             : (balanceB.data?.free ?? 0) + (balanceB.data?.locked ?? 0)}
         </p>
+        <p className="mt-2 text-sm text-red-600">
+          Trading agent will use all available balance for chosen tokens on spot
+          wallet. Move excess funds to futures before trading.
+        </p>
+        <button
+          className="mt-4 px-4 py-2 bg-blue-600 text-white rounded"
+          onClick={() => console.log('Start trading')}
+        >
+          Start trading
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- warn users that trading agent uses full spot balance and suggest moving extra funds
- add "Start trading" button on index view

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f3e10ea84832cbc1af1fa3c91cf17