### PR TITLE
Rename token index table and API to index templates

### DIFF
--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS index_templates(
   risk TEXT,
   rebalance TEXT,
   model TEXT,
-  system_prompt TEXT
+  agent_instructions TEXT
 );
 
 CREATE TABLE IF NOT EXISTS index_instances(

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS executions(
   tx_hash TEXT,
   created_at INTEGER
 );
-CREATE TABLE IF NOT EXISTS token_indexes(
+CREATE TABLE IF NOT EXISTS index_templates(
   id TEXT PRIMARY KEY,
   user_id TEXT,
   token_a TEXT,
@@ -27,6 +27,19 @@ CREATE TABLE IF NOT EXISTS token_indexes(
   risk TEXT,
   rebalance TEXT,
   model TEXT,
-  tvl REAL,
   system_prompt TEXT
+);
+
+CREATE TABLE IF NOT EXISTS index_instances(
+  id TEXT PRIMARY KEY,
+  template_id TEXT,
+  user_id TEXT,
+  created_at INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS index_exec_log(
+  id TEXT PRIMARY KEY,
+  instance_id TEXT,
+  log TEXT,
+  created_at INTEGER
 );

--- a/backend/src/routes/index-templates.ts
+++ b/backend/src/routes/index-templates.ts
@@ -14,7 +14,7 @@ interface IndexTemplateRow {
   risk: string;
   rebalance: string;
   model: string;
-  system_prompt: string;
+  agent_instructions: string;
 }
 
 function toApi(row: IndexTemplateRow) {
@@ -29,7 +29,7 @@ function toApi(row: IndexTemplateRow) {
     risk: row.risk,
     rebalance: row.rebalance,
     model: row.model,
-    systemPrompt: row.system_prompt,
+    agentInstructions: row.agent_instructions,
   };
 }
 
@@ -79,7 +79,7 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
       risk: string;
       rebalance: string;
       model: string;
-      systemPrompt: string;
+      agentInstructions: string;
     };
     const id = randomUUID();
     const tokenA = body.tokenA.toUpperCase();
@@ -90,7 +90,7 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
       body.minTokenBAllocation
     );
     db.prepare(
-      `INSERT INTO index_templates (id, user_id, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, model, system_prompt)
+      `INSERT INTO index_templates (id, user_id, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, model, agent_instructions)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       id,
@@ -103,7 +103,7 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
       body.risk,
       body.rebalance,
       body.model,
-      body.systemPrompt
+      body.agentInstructions
     );
     return {
       id,
@@ -137,7 +137,7 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
       risk: string;
       rebalance: string;
       model: string;
-      systemPrompt: string;
+      agentInstructions: string;
     };
     const existing = db
       .prepare('SELECT id FROM index_templates WHERE id = ?')
@@ -151,7 +151,7 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
       body.minTokenBAllocation
     );
     db.prepare(
-      `UPDATE index_templates SET user_id = ?, token_a = ?, token_b = ?, target_allocation = ?, min_a_allocation = ?, min_b_allocation = ?, risk = ?, rebalance = ?, model = ?, system_prompt = ? WHERE id = ?`
+      `UPDATE index_templates SET user_id = ?, token_a = ?, token_b = ?, target_allocation = ?, min_a_allocation = ?, min_b_allocation = ?, risk = ?, rebalance = ?, model = ?, agent_instructions = ? WHERE id = ?`
     ).run(
       body.userId,
       tokenA,
@@ -162,7 +162,7 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
       body.risk,
       body.rebalance,
       body.model,
-      body.systemPrompt,
+      body.agentInstructions,
       id
     );
     const row = db

--- a/backend/test/indexTemplates.test.ts
+++ b/backend/test/indexTemplates.test.ts
@@ -9,7 +9,7 @@ import buildServer from '../src/server.js';
 
 migrate();
 
-describe('index routes', () => {
+describe('index template routes', () => {
   it('performs CRUD operations', async () => {
     const app = await buildServer();
     db.prepare('INSERT INTO users (id) VALUES (?)').run('user1');
@@ -27,35 +27,35 @@ describe('index routes', () => {
       systemPrompt: 'prompt',
     };
 
-    let res = await app.inject({ method: 'POST', url: '/api/indexes', payload });
+    let res = await app.inject({ method: 'POST', url: '/api/index-templates', payload });
     expect(res.statusCode).toBe(200);
     const id = res.json().id as string;
 
-    res = await app.inject({ method: 'GET', url: `/api/indexes/${id}` });
+    res = await app.inject({ method: 'GET', url: `/api/index-templates/${id}` });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toMatchObject({ id, ...payload, tvl: 0 });
+    expect(res.json()).toMatchObject({ id, ...payload });
 
-    res = await app.inject({ method: 'GET', url: '/api/indexes' });
+    res = await app.inject({ method: 'GET', url: '/api/index-templates' });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toHaveLength(1);
 
     res = await app.inject({
       method: 'GET',
-      url: '/api/indexes/paginated?page=1&pageSize=10&userId=user1',
+      url: '/api/index-templates/paginated?page=1&pageSize=10&userId=user1',
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ total: 1, page: 1, pageSize: 10 });
     expect(res.json().items).toHaveLength(1);
 
     const update = { ...payload, targetAllocation: 70, risk: 'medium', model: 'o3' };
-    res = await app.inject({ method: 'PUT', url: `/api/indexes/${id}`, payload: update });
+    res = await app.inject({ method: 'PUT', url: `/api/index-templates/${id}`, payload: update });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toMatchObject({ id, ...update, tvl: 0 });
+    expect(res.json()).toMatchObject({ id, ...update });
 
-    res = await app.inject({ method: 'DELETE', url: `/api/indexes/${id}` });
+    res = await app.inject({ method: 'DELETE', url: `/api/index-templates/${id}` });
     expect(res.statusCode).toBe(200);
 
-    res = await app.inject({ method: 'GET', url: `/api/indexes/${id}` });
+    res = await app.inject({ method: 'GET', url: `/api/index-templates/${id}` });
     expect(res.statusCode).toBe(404);
 
     await app.close();
@@ -77,28 +77,28 @@ describe('index routes', () => {
 
     let res = await app.inject({
       method: 'POST',
-      url: '/api/indexes',
+      url: '/api/index-templates',
       payload: { ...base, targetAllocation: 50, minTokenAAllocation: 80, minTokenBAllocation: 30 },
     });
     expect(res.json()).toMatchObject({ targetAllocation: 70, minTokenAAllocation: 70, minTokenBAllocation: 30 });
 
     res = await app.inject({
       method: 'POST',
-      url: '/api/indexes',
+      url: '/api/index-templates',
       payload: { ...base, targetAllocation: 50, minTokenAAllocation: 20, minTokenBAllocation: 90 },
     });
     expect(res.json()).toMatchObject({ targetAllocation: 20, minTokenAAllocation: 20, minTokenBAllocation: 80 });
 
     res = await app.inject({
       method: 'POST',
-      url: '/api/indexes',
+      url: '/api/index-templates',
       payload: { ...base, targetAllocation: 5, minTokenAAllocation: 10, minTokenBAllocation: 10 },
     });
     expect(res.json()).toMatchObject({ targetAllocation: 10, minTokenAAllocation: 10, minTokenBAllocation: 10 });
 
     res = await app.inject({
       method: 'POST',
-      url: '/api/indexes',
+      url: '/api/index-templates',
       payload: { ...base, targetAllocation: 95, minTokenAAllocation: 10, minTokenBAllocation: 10 },
     });
     expect(res.json()).toMatchObject({ targetAllocation: 90, minTokenAAllocation: 10, minTokenBAllocation: 10 });

--- a/backend/test/indexTemplates.test.ts
+++ b/backend/test/indexTemplates.test.ts
@@ -24,7 +24,7 @@ describe('index template routes', () => {
       risk: 'low',
       rebalance: '1h',
       model: 'gpt-5',
-      systemPrompt: 'prompt',
+      agentInstructions: 'prompt',
     };
 
     let res = await app.inject({ method: 'POST', url: '/api/index-templates', payload });
@@ -72,7 +72,7 @@ describe('index template routes', () => {
       risk: 'low',
       rebalance: '1h',
       model: 'gpt-5',
-      systemPrompt: 'prompt',
+      agentInstructions: 'prompt',
     };
 
     let res = await app.inject({

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,7 +12,7 @@ export default function App() {
         <Route path="/" element={<Dashboard />} />
         <Route path="/create-index" element={<CreateIndex />} />
         <Route path="/settings" element={<Settings />} />
-        <Route path="/indexes/:id" element={<ViewIndex />} />
+        <Route path="/index-templates/:id" element={<ViewIndex />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Route>
     </Routes>

--- a/frontend/src/components/forms/IndexForm.tsx
+++ b/frontend/src/components/forms/IndexForm.tsx
@@ -156,13 +156,13 @@ export default function IndexForm() {
 
   const onSubmit = handleSubmit(async (values) => {
     if (!user) return;
-    const res = await api.post('/indexes', {
+    const res = await api.post('/index-templates', {
       userId: user.id,
       ...values,
       tokenA: values.tokenA.toUpperCase(),
       tokenB: values.tokenB.toUpperCase(),
     });
-    navigate(`/indexes/${res.data.id}`);
+    navigate(`/index-templates/${res.data.id}`);
   });
 
   return (

--- a/frontend/src/components/forms/IndexForm.tsx
+++ b/frontend/src/components/forms/IndexForm.tsx
@@ -30,9 +30,9 @@ const schema = z
     risk: z.enum(['low', 'medium', 'high']),
     rebalance: z.enum(['1h', '3h', '5h', '12h', '24h', '3d', '1w']),
     model: z.string().min(1, 'Model is required'),
-    systemPrompt: z
+    agentInstructions: z
       .string()
-      .min(1, 'System prompt is required'),
+      .min(1, 'Trading agent instructions are required'),
   })
   .refine((data) => data.tokenA !== data.tokenB, {
     message: 'Tokens must be different',
@@ -95,7 +95,7 @@ export default function IndexForm() {
       risk: 'low',
       rebalance: '1h',
       model: '',
-      systemPrompt:
+      agentInstructions:
         'Manage this index using the defined parameters. Use news and real market data to catch lows and highs.',
     },
   });
@@ -326,13 +326,13 @@ export default function IndexForm() {
       <div>
         <label
           className="block text-sm font-medium mb-1"
-          htmlFor="systemPrompt"
+          htmlFor="agentInstructions"
         >
-          System Prompt
+          Trading Agent Instructions
         </label>
         <textarea
-          id="systemPrompt"
-          {...register('systemPrompt')}
+          id="agentInstructions"
+          {...register('agentInstructions')}
           className="w-full border rounded p-2 h-32"
         />
       </div>

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -6,7 +6,7 @@ import GoogleLoginButton from '../GoogleLoginButton';
 function ApiStatus() {
   const { isSuccess } = useQuery({
     queryKey: ['api-status'],
-    queryFn: () => axios.get('/indexes'),
+    queryFn: () => axios.get('/index-templates'),
   });
 
   return <span className="text-sm">API: {isSuccess ? 'Online' : 'Offline'}</span>;

--- a/frontend/src/lib/mocks.ts
+++ b/frontend/src/lib/mocks.ts
@@ -5,10 +5,10 @@ export function setupMocks() {
 
   axios.interceptors.request.use(async (config) => {
     const { method, url } = config;
-    if (method === 'get' && url === '/api/indexes') {
+    if (method === 'get' && url === '/api/index-templates') {
       config.adapter = async () => ({ data: [], status: 200, statusText: 'OK', headers: {}, config });
     }
-    if (method === 'get' && url?.startsWith('/api/indexes/paginated')) {
+    if (method === 'get' && url?.startsWith('/api/index-templates/paginated')) {
       config.adapter = async () => ({
         data: { items: [], total: 0, page: 1, pageSize: 10 },
         status: 200,

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import api from '../lib/axios';
 import { useUser } from '../lib/user';
 
-interface IndexItem {
+interface IndexTemplateItem {
   id: string;
   userId: string;
   tokenA: string;
@@ -19,13 +19,13 @@ export default function Dashboard() {
   const [onlyMine, setOnlyMine] = useState(false);
 
   const { data } = useQuery({
-    queryKey: ['indexes', page, onlyMine, user?.id],
+    queryKey: ['index-templates', page, onlyMine, user?.id],
     queryFn: async () => {
       const params: any = { page, pageSize: 10 };
       if (onlyMine && user?.id) params.userId = user.id;
-      const res = await api.get('/indexes/paginated', { params });
+      const res = await api.get('/index-templates/paginated', { params });
       return res.data as {
-        items: IndexItem[];
+        items: IndexTemplateItem[];
         total: number;
         page: number;
         pageSize: number;
@@ -48,14 +48,14 @@ export default function Dashboard() {
               setPage(1);
             }}
           />
-          Only my indexes
+          Only my index templates
         </label>
       )}
       <table className="w-full mb-4">
         <thead>
           <tr>
             <th className="text-left">User</th>
-            <th className="text-left">Index</th>
+            <th className="text-left">Index Template</th>
             <th className="text-left">Target</th>
             <th className="text-left">Risk</th>
             <th className="text-left">Actions</th>
@@ -70,7 +70,7 @@ export default function Dashboard() {
               <td>{idx.risk}</td>
               <td>
                 <Link
-                  to={`/indexes/${idx.id}`}
+                  to={`/index-templates/${idx.id}`}
                   className="px-2 py-1 border inline-block"
                 >
                   View

--- a/frontend/src/routes/ViewIndex.tsx
+++ b/frontend/src/routes/ViewIndex.tsx
@@ -15,7 +15,7 @@ interface IndexDetails {
     risk: string;
     rebalance: string;
     model: string;
-    systemPrompt: string;
+    agentInstructions: string;
 }
 
 export default function ViewIndex() {
@@ -92,7 +92,7 @@ export default function ViewIndex() {
             </p>
             <div className="mt-4">
                 <h2 className="text-xl font-bold mb-2">Trading Agent Instructions</h2>
-                <pre className="whitespace-pre-wrap">{data.systemPrompt}</pre>
+                <pre className="whitespace-pre-wrap">{data.agentInstructions}</pre>
             </div>
             <div className="mt-4">
                 <h2 className="text-xl font-bold mb-2">Binance Balances</h2>

--- a/frontend/src/routes/ViewIndex.tsx
+++ b/frontend/src/routes/ViewIndex.tsx
@@ -15,7 +15,6 @@ interface IndexDetails {
     risk: string;
     rebalance: string;
     model: string;
-    tvl: number;
     systemPrompt: string;
 }
 
@@ -23,9 +22,9 @@ export default function ViewIndex() {
     const {id} = useParams();
     const {user} = useUser();
     const {data} = useQuery({
-        queryKey: ['index', id],
+        queryKey: ['index-template', id],
         queryFn: async () => {
-            const res = await api.get(`/indexes/${id}`);
+            const res = await api.get(`/index-templates/${id}`);
             return res.data as IndexDetails;
         },
         enabled: !!id,


### PR DESCRIPTION
## Summary
- rename `token_indexes` table to `index_templates` and add `index_instances` and `index_exec_log`
- switch index API to `/index-templates` and drop unused `tvl` field
- update frontend to use new index template endpoints and labels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fca61e990832c97e5873b6803dc3e