### PR TITLE
Add Binance price history graph to index creation form

### DIFF
--- a/backend/src/routes/binance-prices.ts
+++ b/backend/src/routes/binance-prices.ts
@@ -1,0 +1,38 @@
+import type { FastifyInstance, FastifyReply } from 'fastify';
+import { db } from '../db/index.js';
+
+export default async function binancePricesRoutes(app: FastifyInstance) {
+  app.get('/users/:id/binance-prices/:symbol', async (req, reply: FastifyReply) => {
+    const { id, symbol } = req.params as any;
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (!userId || userId !== id) {
+      reply.code(403).send({ error: 'forbidden' });
+      return;
+    }
+    const row = db
+      .prepare(
+        'SELECT binance_api_key_enc FROM users WHERE id = ?'
+      )
+      .get(id) as { binance_api_key_enc?: string } | undefined;
+    if (!row || !row.binance_api_key_enc) {
+      reply.code(404).send({ error: 'not found' });
+      return;
+    }
+    const sym = String(symbol).toUpperCase();
+    try {
+      const res = await fetch(
+        `https://api.binance.com/api/v3/klines?symbol=${sym}USDT&interval=1d&limit=30`
+      );
+      if (!res.ok) {
+        reply.code(500).send({ error: 'failed to fetch prices' });
+        return;
+      }
+      const json = (await res.json()) as any[];
+      return {
+        prices: json.map((d) => ({ time: d[0], close: Number(d[4]) })),
+      };
+    } catch {
+      reply.code(500).send({ error: 'failed to fetch prices' });
+    }
+  });
+}

--- a/backend/test/binancePrices.test.ts
+++ b/backend/test/binancePrices.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+
+process.env.DATABASE_URL = ':memory:';
+process.env.KEY_PASSWORD = 'test-pass';
+process.env.GOOGLE_CLIENT_ID = 'test-client';
+
+const { db, migrate } = await import('../src/db/index.js');
+import buildServer from '../src/server.js';
+import { encrypt } from '../src/util/crypto.js';
+
+migrate();
+
+describe('binance prices route', () => {
+  it('returns price history for token', async () => {
+    const app = await buildServer();
+    const key = 'binKey123456';
+    const secret = 'binSecret123456';
+    const encKey = encrypt(key, process.env.KEY_PASSWORD!);
+    const encSecret = encrypt(secret, process.env.KEY_PASSWORD!);
+    db.prepare(
+      'INSERT INTO users (id, binance_api_key_enc, binance_api_secret_enc) VALUES (?, ?, ?)'
+    ).run('user1', encKey, encSecret);
+
+    const fetchMock = vi.fn();
+    const originalFetch = globalThis.fetch;
+    (globalThis as any).fetch = fetchMock;
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        [1, '1', '1', '1', '2'],
+        [2, '1', '1', '1', '3'],
+      ],
+    } as any);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/users/user1/binance-prices/BTC',
+      headers: { 'x-user-id': 'user1' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      prices: [
+        { time: 1, close: 2 },
+        { time: 2, close: 3 },
+      ],
+    });
+
+    await app.close();
+    (globalThis as any).fetch = originalFetch;
+  });
+
+  it("forbids accessing another user's price history", async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/users/other/binance-prices/BTC',
+      headers: { 'x-user-id': 'user1' },
+    });
+    expect(res.statusCode).toBe(403);
+    await app.close();
+  });
+
+  it('returns 404 when user has no binance key', async () => {
+    const app = await buildServer();
+    db.prepare('INSERT INTO users (id) VALUES (?)').run('user2');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/users/user2/binance-prices/BTC',
+      headers: { 'x-user-id': 'user2' },
+    });
+    expect(res.statusCode).toBe(404);
+    await app.close();
+  });
+});

--- a/frontend/src/components/forms/IndexForm.tsx
+++ b/frontend/src/components/forms/IndexForm.tsx
@@ -10,6 +10,7 @@ import { useUser } from '../../lib/user';
 import { normalizeAllocations } from '../../lib/allocations';
 import KeySection from './KeySection';
 import BinanceKeySection from './BinanceKeySection';
+import TokenPriceGraph from './TokenPriceGraph';
 
 const schema = z
   .object({
@@ -208,6 +209,12 @@ export default function IndexForm() {
           </select>
         </div>
       </div>
+      {hasBinanceKey && (
+        <div className="grid grid-cols-2 gap-4 mb-4">
+          <TokenPriceGraph token={tokenA} />
+          <TokenPriceGraph token={tokenB} />
+        </div>
+      )}
       <div>
         <label className="block text-sm font-medium mb-1" htmlFor="targetAllocation">
           Target Allocation

--- a/frontend/src/components/forms/TokenPriceGraph.tsx
+++ b/frontend/src/components/forms/TokenPriceGraph.tsx
@@ -1,0 +1,40 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '../../lib/axios';
+import { useUser } from '../../lib/user';
+
+export default function TokenPriceGraph({ token }: { token: string }) {
+  const { user } = useUser();
+  const { data, isError } = useQuery<{ time: number; close: number }[]>({
+    queryKey: ['price-history', user?.id, token],
+    enabled: !!user && token !== 'USDT',
+    queryFn: async () => {
+      const res = await api.get(`/users/${user!.id}/binance-prices/${token}`);
+      return res.data.prices as { time: number; close: number }[];
+    },
+  });
+
+  if (!data?.length || isError) return null;
+
+  const max = Math.max(...data.map((p) => p.close));
+  const min = Math.min(...data.map((p) => p.close));
+  const points = data
+    .map((p, i) => {
+      const x = (i / (data.length - 1)) * 100;
+      const y = max === min ? 50 : ((max - p.close) / (max - min)) * 100;
+      return `${x},${y}`;
+    })
+    .join(' ');
+
+  return (
+    <div className="w-full h-24">
+      <svg viewBox="0 0 100 100" className="w-full h-full">
+        <polyline
+          fill="none"
+          stroke="blue"
+          strokeWidth="1"
+          points={points}
+        />
+      </svg>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- expose `/users/:id/binance-prices/:symbol` to return last 30 days of prices
- show simple SVG line charts for selected tokens when a Binance key is connected
- cover price endpoint with route tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fcfd761bc832c8a7a5e82575ba930