### PR TITLE
feat(frontend): add yearly price candles

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@hookform/resolvers": "^5.2.1",
         "@tanstack/react-query": "^5.84.2",
         "axios": "^1.11.0",
+        "lightweight-charts": "^4.2.3",
         "lucide-react": "^0.539.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -2858,6 +2859,12 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
     },
+    "node_modules/fancy-canvas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fancy-canvas/-/fancy-canvas-2.1.0.tgz",
+      "integrity": "sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3510,6 +3517,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightweight-charts": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-4.2.3.tgz",
+      "integrity": "sha512-5kS/2hY3wNYNzhnS8Gb+GAS07DX8GPF2YVDnd2NMC85gJVQ6RLU6YrXNgNJ6eg0AnWPwCnvaGtYmGky3HiLQEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fancy-canvas": "2.1.0"
       }
     },
     "node_modules/lilconfig": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@hookform/resolvers": "^5.2.1",
     "@tanstack/react-query": "^5.84.2",
     "axios": "^1.11.0",
+    "lightweight-charts": "^4.2.3",
     "lucide-react": "^0.539.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/frontend/src/components/PriceChart.tsx
+++ b/frontend/src/components/PriceChart.tsx
@@ -1,0 +1,50 @@
+import {useEffect, useRef} from 'react';
+import {createChart, CandlestickData} from 'lightweight-charts';
+
+interface PriceChartProps {
+  symbol: string;
+}
+
+export default function PriceChart({symbol}: PriceChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const chart = createChart(container, {
+      width: container.clientWidth,
+      height: 300,
+    });
+    const series = chart.addCandlestickSeries();
+
+    async function load() {
+      const res = await fetch(
+        `https://api.binance.com/api/v3/klines?symbol=${symbol}&interval=1d&limit=365`
+      );
+      if (!res.ok) return;
+      const json = (await res.json()) as any[];
+      const data: CandlestickData[] = json.map((k) => ({
+        time: k[0] / 1000,
+        open: parseFloat(k[1]),
+        high: parseFloat(k[2]),
+        low: parseFloat(k[3]),
+        close: parseFloat(k[4]),
+      }));
+      series.setData(data);
+    }
+    load();
+
+    const handleResize = () => {
+      chart.applyOptions({ width: container.clientWidth });
+    };
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      chart.remove();
+    };
+  }, [symbol]);
+
+  return <div ref={containerRef} className="w-full h-[300px]" />;
+}

--- a/frontend/src/routes/ViewIndex.tsx
+++ b/frontend/src/routes/ViewIndex.tsx
@@ -3,6 +3,7 @@ import {useQuery} from '@tanstack/react-query';
 import api from '../lib/axios';
 import {useUser} from '../lib/user';
 import React from "react";
+import PriceChart from '../components/PriceChart';
 
 interface IndexDetails {
     id: string;
@@ -69,6 +70,9 @@ export default function ViewIndex() {
             <h1 className="text-2xl font-bold mb-4">
                 {`${data.tokenA.toUpperCase()} ${data.targetAllocation} / ${data.tokenB.toUpperCase()} ${100 - data.targetAllocation}`}
             </h1>
+            <PriceChart
+                symbol={`${data.tokenA.toUpperCase()}${data.tokenB.toUpperCase()}`}
+            />
             <p>
                 <strong>User ID:</strong> {data.userId}
             </p>


### PR DESCRIPTION
## Summary
- add lightweight-charts dependency
- display 1-year price candlesticks for index tokens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689feb6cac80832c8f2b70cf8b2d49da