### PR TITLE
Rename index instances to agents and expose CRUD API

### DIFF
--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -30,16 +30,17 @@ CREATE TABLE IF NOT EXISTS index_templates(
   agent_instructions TEXT
 );
 
-CREATE TABLE IF NOT EXISTS index_instances(
+CREATE TABLE IF NOT EXISTS index_agents(
   id TEXT PRIMARY KEY,
   template_id TEXT,
   user_id TEXT,
+  status TEXT,
   created_at INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS index_exec_log(
   id TEXT PRIMARY KEY,
-  instance_id TEXT,
+  agent_id TEXT,
   log TEXT,
   created_at INTEGER
 );

--- a/backend/src/routes/api-keys.ts
+++ b/backend/src/routes/api-keys.ts
@@ -38,6 +38,8 @@ async function isValidBinanceKey(key: string, secret: string) {
 export default async function apiKeyRoutes(app: FastifyInstance) {
   app.post('/users/:id/ai-key', async (req, reply) => {
     const id = (req.params as any).id;
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (!userId || userId !== id) return reply.code(403).send({ error: 'forbidden' });
     const { key } = req.body as { key: string };
     const row = db
       .prepare<[string], { ai_api_key_enc?: string }>(
@@ -55,6 +57,8 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
 
   app.get('/users/:id/ai-key', async (req, reply) => {
     const id = (req.params as any).id;
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (!userId || userId !== id) return reply.code(403).send({ error: 'forbidden' });
     const row = db
       .prepare('SELECT ai_api_key_enc FROM users WHERE id = ?')
       .get(id) as { ai_api_key_enc?: string } | undefined;
@@ -66,6 +70,8 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
 
   app.put('/users/:id/ai-key', async (req, reply) => {
     const id = (req.params as any).id;
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (!userId || userId !== id) return reply.code(403).send({ error: 'forbidden' });
     const { key } = req.body as { key: string };
     const row = db
       .prepare('SELECT ai_api_key_enc FROM users WHERE id = ?')
@@ -81,6 +87,8 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
 
   app.delete('/users/:id/ai-key', async (req, reply) => {
     const id = (req.params as any).id;
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (!userId || userId !== id) return reply.code(403).send({ error: 'forbidden' });
     const row = db
       .prepare('SELECT ai_api_key_enc FROM users WHERE id = ?')
       .get(id) as { ai_api_key_enc?: string } | undefined;
@@ -92,6 +100,8 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
 
   app.post('/users/:id/binance-key', async (req, reply) => {
     const id = (req.params as any).id;
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (!userId || userId !== id) return reply.code(403).send({ error: 'forbidden' });
     const { key, secret } = req.body as { key: string; secret: string };
     const row = db
       .prepare<
@@ -114,6 +124,8 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
 
   app.get('/users/:id/binance-key', async (req, reply) => {
     const id = (req.params as any).id;
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (!userId || userId !== id) return reply.code(403).send({ error: 'forbidden' });
     const row = db
       .prepare(
         'SELECT binance_api_key_enc, binance_api_secret_enc FROM users WHERE id = ?'
@@ -130,6 +142,8 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
 
   app.put('/users/:id/binance-key', async (req, reply) => {
     const id = (req.params as any).id;
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (!userId || userId !== id) return reply.code(403).send({ error: 'forbidden' });
     const { key, secret } = req.body as { key: string; secret: string };
     const row = db
       .prepare(
@@ -152,6 +166,8 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
 
   app.delete('/users/:id/binance-key', async (req, reply) => {
     const id = (req.params as any).id;
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (!userId || userId !== id) return reply.code(403).send({ error: 'forbidden' });
     const row = db
       .prepare(
         'SELECT binance_api_key_enc, binance_api_secret_enc FROM users WHERE id = ?'

--- a/backend/src/routes/index-agents.ts
+++ b/backend/src/routes/index-agents.ts
@@ -30,7 +30,7 @@ export default async function indexAgentRoutes(app: FastifyInstance) {
     const userId = req.headers['x-user-id'] as string | undefined;
     if (!userId) return reply.code(403).send({ error: 'forbidden' });
     const rows = db
-      .prepare<[], IndexAgentRow>('SELECT * FROM index_agents WHERE user_id = ?')
+      .prepare<[string], IndexAgentRow>('SELECT * FROM index_agents WHERE user_id = ?')
       .all(userId);
     return rows.map(toApi);
   });

--- a/backend/src/routes/index-agents.ts
+++ b/backend/src/routes/index-agents.ts
@@ -1,0 +1,114 @@
+import type { FastifyInstance } from 'fastify';
+import { randomUUID } from 'node:crypto';
+import { db } from '../db/index.js';
+
+export enum IndexAgentStatus {
+  INACTIVE = 'inactive',
+  ACTIVE = 'active',
+}
+
+interface IndexAgentRow {
+  id: string;
+  template_id: string;
+  user_id: string;
+  status: string;
+  created_at: number;
+}
+
+function toApi(row: IndexAgentRow) {
+  return {
+    id: row.id,
+    templateId: row.template_id,
+    userId: row.user_id,
+    status: row.status as IndexAgentStatus,
+    createdAt: row.created_at,
+  };
+}
+
+export default async function indexAgentRoutes(app: FastifyInstance) {
+  app.get('/index-agents', async () => {
+    const rows = db.prepare<[], IndexAgentRow>('SELECT * FROM index_agents').all();
+    return rows.map(toApi);
+  });
+
+  app.get('/index-agents/paginated', async (req) => {
+    const {
+      page = '1',
+      pageSize = '10',
+      userId,
+    } = req.query as { page?: string; pageSize?: string; userId?: string };
+    const p = Math.max(parseInt(page, 10), 1);
+    const ps = Math.max(parseInt(pageSize, 10), 1);
+    const offset = (p - 1) * ps;
+    const params: any[] = [];
+    let where = '';
+    if (userId) {
+      where = 'WHERE user_id = ?';
+      params.push(userId);
+    }
+    const totalRow = db
+      .prepare(`SELECT COUNT(*) as count FROM index_agents ${where}`)
+      .get(...params) as { count: number };
+    const rows = db
+      .prepare(`SELECT * FROM index_agents ${where} LIMIT ? OFFSET ?`)
+      .all(...params, ps, offset) as IndexAgentRow[];
+    return {
+      items: rows.map(toApi),
+      total: totalRow.count,
+      page: p,
+      pageSize: ps,
+    };
+  });
+
+  app.post('/index-agents', async (req) => {
+    const body = req.body as {
+      templateId: string;
+      userId: string;
+      status?: IndexAgentStatus;
+    };
+    const id = randomUUID();
+    const status = body.status ?? IndexAgentStatus.INACTIVE;
+    const createdAt = Date.now();
+    db.prepare(
+      `INSERT INTO index_agents (id, template_id, user_id, status, created_at) VALUES (?, ?, ?, ?, ?)`
+    ).run(id, body.templateId, body.userId, status, createdAt);
+    return { id, templateId: body.templateId, userId: body.userId, status, createdAt };
+  });
+
+  app.get('/index-agents/:id', async (req, reply) => {
+    const id = (req.params as any).id;
+    const row = db
+      .prepare('SELECT * FROM index_agents WHERE id = ?')
+      .get(id) as IndexAgentRow | undefined;
+    if (!row) return reply.code(404).send({ error: 'not found' });
+    return toApi(row);
+  });
+
+  app.put('/index-agents/:id', async (req, reply) => {
+    const id = (req.params as any).id;
+    const body = req.body as {
+      templateId: string;
+      userId: string;
+      status: IndexAgentStatus;
+    };
+    const existing = db
+      .prepare('SELECT id FROM index_agents WHERE id = ?')
+      .get(id) as { id: string } | undefined;
+    if (!existing) return reply.code(404).send({ error: 'not found' });
+    db.prepare(
+      `UPDATE index_agents SET template_id = ?, user_id = ?, status = ? WHERE id = ?`
+    ).run(body.templateId, body.userId, body.status, id);
+    const row = db
+      .prepare('SELECT * FROM index_agents WHERE id = ?')
+      .get(id) as IndexAgentRow;
+    return toApi(row);
+  });
+
+  app.delete('/index-agents/:id', async (req, reply) => {
+    const id = (req.params as any).id;
+    const res = db.prepare('DELETE FROM index_agents WHERE id = ?').run(id);
+    if (res.changes === 0) return reply.code(404).send({ error: 'not found' });
+    return { ok: true };
+  });
+}
+

--- a/backend/src/routes/index-templates.ts
+++ b/backend/src/routes/index-templates.ts
@@ -38,7 +38,9 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
     const userId = req.headers['x-user-id'] as string | undefined;
     if (!userId) return reply.code(403).send({ error: 'forbidden' });
     const rows = db
-      .prepare<[], IndexTemplateRow>('SELECT * FROM index_templates WHERE user_id = ?')
+      .prepare<[string], IndexTemplateRow>(
+        'SELECT * FROM index_templates WHERE user_id = ?'
+      )
       .all(userId);
     return rows.map(toApi);
   });

--- a/backend/src/routes/index-templates.ts
+++ b/backend/src/routes/index-templates.ts
@@ -34,32 +34,31 @@ function toApi(row: IndexTemplateRow) {
 }
 
 export default async function indexTemplateRoutes(app: FastifyInstance) {
-  app.get('/index-templates', async () => {
-    const rows = db.prepare<[], IndexTemplateRow>('SELECT * FROM index_templates').all();
+  app.get('/index-templates', async (req, reply) => {
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (!userId) return reply.code(403).send({ error: 'forbidden' });
+    const rows = db
+      .prepare<[], IndexTemplateRow>('SELECT * FROM index_templates WHERE user_id = ?')
+      .all(userId);
     return rows.map(toApi);
   });
 
-  app.get('/index-templates/paginated', async (req) => {
-    const {
-      page = '1',
-      pageSize = '10',
-      userId,
-    } = req.query as { page?: string; pageSize?: string; userId?: string };
+  app.get('/index-templates/paginated', async (req, reply) => {
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (!userId) return reply.code(403).send({ error: 'forbidden' });
+    const { page = '1', pageSize = '10' } = req.query as {
+      page?: string;
+      pageSize?: string;
+    };
     const p = Math.max(parseInt(page, 10), 1);
     const ps = Math.max(parseInt(pageSize, 10), 1);
     const offset = (p - 1) * ps;
-    const params: any[] = [];
-    let where = '';
-    if (userId) {
-      where = 'WHERE user_id = ?';
-      params.push(userId);
-    }
     const totalRow = db
-      .prepare(`SELECT COUNT(*) as count FROM index_templates ${where}`)
-      .get(...params) as { count: number };
+      .prepare('SELECT COUNT(*) as count FROM index_templates WHERE user_id = ?')
+      .get(userId) as { count: number };
     const rows = db
-      .prepare(`SELECT * FROM index_templates ${where} LIMIT ? OFFSET ?`)
-      .all(...params, ps, offset) as IndexTemplateRow[];
+      .prepare('SELECT * FROM index_templates WHERE user_id = ? LIMIT ? OFFSET ?')
+      .all(userId, ps, offset) as IndexTemplateRow[];
     return {
       items: rows.map(toApi),
       total: totalRow.count,
@@ -68,7 +67,8 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
     };
   });
 
-  app.post('/index-templates', async (req) => {
+  app.post('/index-templates', async (req, reply) => {
+    const userId = req.headers['x-user-id'] as string | undefined;
     const body = req.body as {
       userId: string;
       tokenA: string;
@@ -81,6 +81,8 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
       model: string;
       agentInstructions: string;
     };
+    if (!userId || userId !== body.userId)
+      return reply.code(403).send({ error: 'forbidden' });
     const id = randomUUID();
     const tokenA = body.tokenA.toUpperCase();
     const tokenB = body.tokenB.toUpperCase();
@@ -90,8 +92,7 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
       body.minTokenBAllocation
     );
     db.prepare(
-      `INSERT INTO index_templates (id, user_id, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, model, agent_instructions)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO index_templates (id, user_id, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, model, agent_instructions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       id,
       body.userId,
@@ -118,15 +119,18 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
 
   app.get('/index-templates/:id', async (req, reply) => {
     const id = (req.params as any).id;
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (!userId) return reply.code(403).send({ error: 'forbidden' });
     const row = db
-      .prepare('SELECT * FROM index_templates WHERE id = ?')
-      .get(id) as IndexTemplateRow | undefined;
+      .prepare('SELECT * FROM index_templates WHERE id = ? AND user_id = ?')
+      .get(id, userId) as IndexTemplateRow | undefined;
     if (!row) return reply.code(404).send({ error: 'not found' });
     return toApi(row);
   });
 
   app.put('/index-templates/:id', async (req, reply) => {
     const id = (req.params as any).id;
+    const userId = req.headers['x-user-id'] as string | undefined;
     const body = req.body as {
       userId: string;
       tokenA: string;
@@ -139,9 +143,11 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
       model: string;
       agentInstructions: string;
     };
+    if (!userId || userId !== body.userId)
+      return reply.code(403).send({ error: 'forbidden' });
     const existing = db
-      .prepare('SELECT id FROM index_templates WHERE id = ?')
-      .get(id) as { id: string } | undefined;
+      .prepare('SELECT id FROM index_templates WHERE id = ? AND user_id = ?')
+      .get(id, userId) as { id: string } | undefined;
     if (!existing) return reply.code(404).send({ error: 'not found' });
     const tokenA = body.tokenA.toUpperCase();
     const tokenB = body.tokenB.toUpperCase();
@@ -166,16 +172,19 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
       id
     );
     const row = db
-      .prepare('SELECT * FROM index_templates WHERE id = ?')
-      .get(id) as IndexTemplateRow;
+      .prepare('SELECT * FROM index_templates WHERE id = ? AND user_id = ?')
+      .get(id, userId) as IndexTemplateRow;
     return toApi(row);
   });
 
   app.delete('/index-templates/:id', async (req, reply) => {
     const id = (req.params as any).id;
-    const res = db.prepare('DELETE FROM index_templates WHERE id = ?').run(id);
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (!userId) return reply.code(403).send({ error: 'forbidden' });
+    const res = db
+      .prepare('DELETE FROM index_templates WHERE id = ? AND user_id = ?')
+      .run(id, userId);
     if (res.changes === 0) return reply.code(404).send({ error: 'not found' });
     return { ok: true };
   });
 }
-

--- a/backend/src/routes/models.ts
+++ b/backend/src/routes/models.ts
@@ -6,6 +6,8 @@ import { decrypt } from '../util/crypto.js';
 export default async function modelsRoutes(app: FastifyInstance) {
   app.get('/users/:id/models', async (req, reply) => {
     const id = (req.params as any).id;
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (!userId || userId !== id) return reply.code(403).send({ error: 'forbidden' });
     const row = db
       .prepare('SELECT ai_api_key_enc FROM users WHERE id = ?')
       .get(id) as { ai_api_key_enc?: string } | undefined;

--- a/backend/test/apiKeys.test.ts
+++ b/backend/test/apiKeys.test.ts
@@ -26,6 +26,7 @@ describe('AI API key routes', () => {
       method: 'POST',
       url: '/api/users/user1/ai-key',
       payload: { key: 'bad' },
+      headers: { 'x-user-id': 'user1' },
     });
     expect(res.statusCode).toBe(400);
     expect(res.json()).toMatchObject({ error: 'verification failed' });
@@ -39,6 +40,7 @@ describe('AI API key routes', () => {
       method: 'POST',
       url: '/api/users/user1/ai-key',
       payload: { key: key1 },
+      headers: { 'x-user-id': 'user1' },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ key: 'aike...7890' });
@@ -48,6 +50,13 @@ describe('AI API key routes', () => {
     expect(row.ai_api_key_enc).not.toBe(key1);
 
     res = await app.inject({ method: 'GET', url: '/api/users/user1/ai-key' });
+    expect(res.statusCode).toBe(403);
+
+    res = await app.inject({
+      method: 'GET',
+      url: '/api/users/user1/ai-key',
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ key: 'aike...7890' });
 
@@ -55,6 +64,7 @@ describe('AI API key routes', () => {
       method: 'POST',
       url: '/api/users/user1/ai-key',
       payload: { key: 'dup' },
+      headers: { 'x-user-id': 'user1' },
     });
     expect(res.statusCode).toBe(400);
 
@@ -63,10 +73,15 @@ describe('AI API key routes', () => {
       method: 'PUT',
       url: '/api/users/user1/ai-key',
       payload: { key: 'bad2' },
+      headers: { 'x-user-id': 'user1' },
     });
     expect(res.statusCode).toBe(400);
     expect(res.json()).toMatchObject({ error: 'verification failed' });
-    res = await app.inject({ method: 'GET', url: '/api/users/user1/ai-key' });
+    res = await app.inject({
+      method: 'GET',
+      url: '/api/users/user1/ai-key',
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.json()).toMatchObject({ key: 'aike...7890' });
 
     fetchMock.mockResolvedValueOnce({ ok: true } as any);
@@ -74,14 +89,23 @@ describe('AI API key routes', () => {
       method: 'PUT',
       url: '/api/users/user1/ai-key',
       payload: { key: key2 },
+      headers: { 'x-user-id': 'user1' },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ key: 'aike...ghij' });
 
-    res = await app.inject({ method: 'DELETE', url: '/api/users/user1/ai-key' });
+    res = await app.inject({
+      method: 'DELETE',
+      url: '/api/users/user1/ai-key',
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(200);
 
-    res = await app.inject({ method: 'GET', url: '/api/users/user1/ai-key' });
+    res = await app.inject({
+      method: 'GET',
+      url: '/api/users/user1/ai-key',
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(404);
 
     await app.close();
@@ -108,6 +132,7 @@ describe('Binance API key routes', () => {
       method: 'POST',
       url: '/api/users/user2/binance-key',
       payload: { key: 'bad', secret: 'bad' },
+      headers: { 'x-user-id': 'user2' },
     });
     expect(res.statusCode).toBe(400);
     expect(res.json()).toMatchObject({ error: 'verification failed' });
@@ -124,6 +149,7 @@ describe('Binance API key routes', () => {
       method: 'POST',
       url: '/api/users/user2/binance-key',
       payload: { key: key1, secret: secret1 },
+      headers: { 'x-user-id': 'user2' },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({
@@ -139,6 +165,12 @@ describe('Binance API key routes', () => {
     expect(row.binance_api_secret_enc).not.toBe(secret1);
 
     res = await app.inject({ method: 'GET', url: '/api/users/user2/binance-key' });
+    expect(res.statusCode).toBe(403);
+    res = await app.inject({
+      method: 'GET',
+      url: '/api/users/user2/binance-key',
+      headers: { 'x-user-id': 'user2' },
+    });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({
       key: 'bkey...7890',
@@ -149,6 +181,7 @@ describe('Binance API key routes', () => {
       method: 'POST',
       url: '/api/users/user2/binance-key',
       payload: { key: 'dup', secret: 'dup' },
+      headers: { 'x-user-id': 'user2' },
     });
     expect(res.statusCode).toBe(400);
 
@@ -157,10 +190,15 @@ describe('Binance API key routes', () => {
       method: 'PUT',
       url: '/api/users/user2/binance-key',
       payload: { key: 'bad2', secret: 'bad2' },
+      headers: { 'x-user-id': 'user2' },
     });
     expect(res.statusCode).toBe(400);
     expect(res.json()).toMatchObject({ error: 'verification failed' });
-    res = await app.inject({ method: 'GET', url: '/api/users/user2/binance-key' });
+    res = await app.inject({
+      method: 'GET',
+      url: '/api/users/user2/binance-key',
+      headers: { 'x-user-id': 'user2' },
+    });
     expect(res.json()).toMatchObject({
       key: 'bkey...7890',
       secret: 'bsec...7890',
@@ -171,6 +209,7 @@ describe('Binance API key routes', () => {
       method: 'PUT',
       url: '/api/users/user2/binance-key',
       payload: { key: key2, secret: secret2 },
+      headers: { 'x-user-id': 'user2' },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({
@@ -178,10 +217,18 @@ describe('Binance API key routes', () => {
       secret: 'bsec...ghij',
     });
 
-    res = await app.inject({ method: 'DELETE', url: '/api/users/user2/binance-key' });
+    res = await app.inject({
+      method: 'DELETE',
+      url: '/api/users/user2/binance-key',
+      headers: { 'x-user-id': 'user2' },
+    });
     expect(res.statusCode).toBe(200);
 
-    res = await app.inject({ method: 'GET', url: '/api/users/user2/binance-key' });
+    res = await app.inject({
+      method: 'GET',
+      url: '/api/users/user2/binance-key',
+      headers: { 'x-user-id': 'user2' },
+    });
     expect(res.statusCode).toBe(404);
 
     await app.close();

--- a/backend/test/indexAgents.test.ts
+++ b/backend/test/indexAgents.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+
+process.env.DATABASE_URL = ':memory:';
+process.env.KEY_PASSWORD = 'test-pass';
+process.env.GOOGLE_CLIENT_ID = 'test-client';
+
+const { db, migrate } = await import('../src/db/index.js');
+import buildServer from '../src/server.js';
+
+migrate();
+
+describe('index agent routes', () => {
+  it('performs CRUD operations', async () => {
+    const app = await buildServer();
+    db.prepare('INSERT INTO users (id) VALUES (?)').run('user1');
+    db.prepare(`INSERT INTO index_templates (id, user_id, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, model, agent_instructions)
+                VALUES (?, ?, 'BTC', 'ETH', 60, 10, 20, 'low', '1h', 'gpt-5', 'prompt')`).run('tmpl1', 'user1');
+
+    const payload = {
+      templateId: 'tmpl1',
+      userId: 'user1',
+      status: 'active',
+    };
+
+    let res = await app.inject({ method: 'POST', url: '/api/index-agents', payload });
+    expect(res.statusCode).toBe(200);
+    const id = res.json().id as string;
+
+    res = await app.inject({ method: 'GET', url: `/api/index-agents/${id}` });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ id, ...payload });
+
+    res = await app.inject({ method: 'GET', url: '/api/index-agents' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveLength(1);
+
+    res = await app.inject({
+      method: 'GET',
+      url: '/api/index-agents/paginated?page=1&pageSize=10&userId=user1',
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ total: 1, page: 1, pageSize: 10 });
+    expect(res.json().items).toHaveLength(1);
+
+    const update = { templateId: 'tmpl1', userId: 'user1', status: 'inactive' };
+    res = await app.inject({ method: 'PUT', url: `/api/index-agents/${id}`, payload: update });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ id, ...update });
+
+    res = await app.inject({ method: 'DELETE', url: `/api/index-agents/${id}` });
+    expect(res.statusCode).toBe(200);
+
+    res = await app.inject({ method: 'GET', url: `/api/index-agents/${id}` });
+    expect(res.statusCode).toBe(404);
+
+    await app.close();
+  });
+
+  it('defaults status to inactive', async () => {
+    const app = await buildServer();
+    db.prepare('INSERT INTO users (id) VALUES (?)').run('user2');
+    db.prepare(`INSERT INTO index_templates (id, user_id, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, model, agent_instructions)
+                VALUES (?, ?, 'BTC', 'ETH', 60, 10, 20, 'low', '1h', 'gpt-5', 'prompt')`).run('tmpl2', 'user2');
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/index-agents',
+      payload: { templateId: 'tmpl2', userId: 'user2' },
+    });
+    expect(res.json()).toMatchObject({ status: 'inactive' });
+
+    await app.close();
+  });
+});

--- a/backend/test/indexAgents.test.ts
+++ b/backend/test/indexAgents.test.ts
@@ -22,35 +22,65 @@ describe('index agent routes', () => {
       status: 'active',
     };
 
-    let res = await app.inject({ method: 'POST', url: '/api/index-agents', payload });
+    let res = await app.inject({
+      method: 'POST',
+      url: '/api/index-agents',
+      payload,
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(200);
     const id = res.json().id as string;
 
-    res = await app.inject({ method: 'GET', url: `/api/index-agents/${id}` });
+    res = await app.inject({
+      method: 'GET',
+      url: `/api/index-agents/${id}`,
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ id, ...payload });
 
-    res = await app.inject({ method: 'GET', url: '/api/index-agents' });
+    res = await app.inject({
+      method: 'GET',
+      url: '/api/index-agents',
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toHaveLength(1);
 
+    res = await app.inject({ method: 'GET', url: '/api/index-agents' });
+    expect(res.statusCode).toBe(403);
+
     res = await app.inject({
       method: 'GET',
-      url: '/api/index-agents/paginated?page=1&pageSize=10&userId=user1',
+      url: '/api/index-agents/paginated?page=1&pageSize=10',
+      headers: { 'x-user-id': 'user1' },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ total: 1, page: 1, pageSize: 10 });
     expect(res.json().items).toHaveLength(1);
 
     const update = { templateId: 'tmpl1', userId: 'user1', status: 'inactive' };
-    res = await app.inject({ method: 'PUT', url: `/api/index-agents/${id}`, payload: update });
+    res = await app.inject({
+      method: 'PUT',
+      url: `/api/index-agents/${id}`,
+      payload: update,
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ id, ...update });
 
-    res = await app.inject({ method: 'DELETE', url: `/api/index-agents/${id}` });
+    res = await app.inject({
+      method: 'DELETE',
+      url: `/api/index-agents/${id}`,
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(200);
 
-    res = await app.inject({ method: 'GET', url: `/api/index-agents/${id}` });
+    res = await app.inject({
+      method: 'GET',
+      url: `/api/index-agents/${id}`,
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(404);
 
     await app.close();
@@ -66,6 +96,7 @@ describe('index agent routes', () => {
       method: 'POST',
       url: '/api/index-agents',
       payload: { templateId: 'tmpl2', userId: 'user2' },
+      headers: { 'x-user-id': 'user2' },
     });
     expect(res.json()).toMatchObject({ status: 'inactive' });
 

--- a/backend/test/indexTemplates.test.ts
+++ b/backend/test/indexTemplates.test.ts
@@ -27,35 +27,65 @@ describe('index template routes', () => {
       agentInstructions: 'prompt',
     };
 
-    let res = await app.inject({ method: 'POST', url: '/api/index-templates', payload });
+    let res = await app.inject({
+      method: 'POST',
+      url: '/api/index-templates',
+      payload,
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(200);
     const id = res.json().id as string;
 
-    res = await app.inject({ method: 'GET', url: `/api/index-templates/${id}` });
+    res = await app.inject({
+      method: 'GET',
+      url: `/api/index-templates/${id}`,
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ id, ...payload });
 
     res = await app.inject({ method: 'GET', url: '/api/index-templates' });
+    expect(res.statusCode).toBe(403);
+
+    res = await app.inject({
+      method: 'GET',
+      url: '/api/index-templates',
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toHaveLength(1);
 
     res = await app.inject({
       method: 'GET',
-      url: '/api/index-templates/paginated?page=1&pageSize=10&userId=user1',
+      url: '/api/index-templates/paginated?page=1&pageSize=10',
+      headers: { 'x-user-id': 'user1' },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ total: 1, page: 1, pageSize: 10 });
     expect(res.json().items).toHaveLength(1);
 
     const update = { ...payload, targetAllocation: 70, risk: 'medium', model: 'o3' };
-    res = await app.inject({ method: 'PUT', url: `/api/index-templates/${id}`, payload: update });
+    res = await app.inject({
+      method: 'PUT',
+      url: `/api/index-templates/${id}`,
+      payload: update,
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ id, ...update });
 
-    res = await app.inject({ method: 'DELETE', url: `/api/index-templates/${id}` });
+    res = await app.inject({
+      method: 'DELETE',
+      url: `/api/index-templates/${id}`,
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(200);
 
-    res = await app.inject({ method: 'GET', url: `/api/index-templates/${id}` });
+    res = await app.inject({
+      method: 'GET',
+      url: `/api/index-templates/${id}`,
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(404);
 
     await app.close();
@@ -78,28 +108,52 @@ describe('index template routes', () => {
     let res = await app.inject({
       method: 'POST',
       url: '/api/index-templates',
-      payload: { ...base, targetAllocation: 50, minTokenAAllocation: 80, minTokenBAllocation: 30 },
+      payload: {
+        ...base,
+        targetAllocation: 50,
+        minTokenAAllocation: 80,
+        minTokenBAllocation: 30,
+      },
+      headers: { 'x-user-id': 'user2' },
     });
     expect(res.json()).toMatchObject({ targetAllocation: 70, minTokenAAllocation: 70, minTokenBAllocation: 30 });
 
     res = await app.inject({
       method: 'POST',
       url: '/api/index-templates',
-      payload: { ...base, targetAllocation: 50, minTokenAAllocation: 20, minTokenBAllocation: 90 },
+      payload: {
+        ...base,
+        targetAllocation: 50,
+        minTokenAAllocation: 20,
+        minTokenBAllocation: 90,
+      },
+      headers: { 'x-user-id': 'user2' },
     });
     expect(res.json()).toMatchObject({ targetAllocation: 20, minTokenAAllocation: 20, minTokenBAllocation: 80 });
 
     res = await app.inject({
       method: 'POST',
       url: '/api/index-templates',
-      payload: { ...base, targetAllocation: 5, minTokenAAllocation: 10, minTokenBAllocation: 10 },
+      payload: {
+        ...base,
+        targetAllocation: 5,
+        minTokenAAllocation: 10,
+        minTokenBAllocation: 10,
+      },
+      headers: { 'x-user-id': 'user2' },
     });
     expect(res.json()).toMatchObject({ targetAllocation: 10, minTokenAAllocation: 10, minTokenBAllocation: 10 });
 
     res = await app.inject({
       method: 'POST',
       url: '/api/index-templates',
-      payload: { ...base, targetAllocation: 95, minTokenAAllocation: 10, minTokenBAllocation: 10 },
+      payload: {
+        ...base,
+        targetAllocation: 95,
+        minTokenAAllocation: 10,
+        minTokenBAllocation: 10,
+      },
+      headers: { 'x-user-id': 'user2' },
     });
     expect(res.json()).toMatchObject({ targetAllocation: 90, minTokenAAllocation: 10, minTokenBAllocation: 10 });
 

--- a/backend/test/models.test.ts
+++ b/backend/test/models.test.ts
@@ -35,7 +35,13 @@ describe('model routes', () => {
       }),
     } as any);
 
-    const res = await app.inject({ method: 'GET', url: '/api/users/user1/models' });
+    let res = await app.inject({ method: 'GET', url: '/api/users/user1/models' });
+    expect(res.statusCode).toBe(403);
+    res = await app.inject({
+      method: 'GET',
+      url: '/api/users/user1/models',
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ models: ['gpt-4.1-mini', 'o3-mini', 'gpt-5'] });
 
@@ -46,7 +52,11 @@ describe('model routes', () => {
   it('requires a key', async () => {
     const app = await buildServer();
     db.prepare('INSERT INTO users (id) VALUES (?)').run('user2');
-    const res = await app.inject({ method: 'GET', url: '/api/users/user2/models' });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/users/user2/models',
+      headers: { 'x-user-id': 'user2' },
+    });
     expect(res.statusCode).toBe(404);
     await app.close();
   });

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -1,31 +1,30 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import api from '../lib/axios';
 import { useUser } from '../lib/user';
 
-interface IndexTemplateItem {
+interface IndexAgentItem {
   id: string;
+  templateId: string;
   userId: string;
-  tokenA: string;
-  tokenB: string;
-  targetAllocation: number;
-  risk: string;
+  status: string;
+  createdAt: number;
 }
 
 export default function Dashboard() {
   const { user } = useUser();
   const [page, setPage] = useState(1);
-  const [onlyMine, setOnlyMine] = useState(false);
 
   const { data } = useQuery({
-    queryKey: ['index-templates', page, onlyMine, user?.id],
+    queryKey: ['index-agents', page, user?.id],
+    enabled: !!user?.id,
     queryFn: async () => {
-      const params: any = { page, pageSize: 10 };
-      if (onlyMine && user?.id) params.userId = user.id;
-      const res = await api.get('/index-templates/paginated', { params });
+      const res = await api.get('/index-agents/paginated', {
+        params: { page, pageSize: 10 },
+        headers: { 'x-user-id': user!.id },
+      });
       return res.data as {
-        items: IndexTemplateItem[];
+        items: IndexAgentItem[];
         total: number;
         page: number;
         pageSize: number;
@@ -33,73 +32,64 @@ export default function Dashboard() {
     },
   });
 
+  if (!user) {
+    return (
+      <div className="p-4">
+        <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+        <p>Please log in to view your agents.</p>
+      </div>
+    );
+  }
+
   const totalPages = data ? Math.ceil(data.total / data.pageSize) : 0;
 
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
-      {user && (
-        <label className="flex items-center gap-2 mb-4">
-          <input
-            type="checkbox"
-            checked={onlyMine}
-            onChange={(e) => {
-              setOnlyMine(e.target.checked);
-              setPage(1);
-            }}
-          />
-          Only my index templates
-        </label>
-      )}
-      <table className="w-full mb-4">
-        <thead>
-          <tr>
-            <th className="text-left">User</th>
-            <th className="text-left">Index Template</th>
-            <th className="text-left">Target</th>
-            <th className="text-left">Risk</th>
-            <th className="text-left">Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {data?.items.map((idx) => (
-            <tr key={idx.id}>
-              <td>{idx.userId}</td>
-              <td>{`${idx.tokenA.toUpperCase()}/${idx.tokenB.toUpperCase()}`}</td>
-              <td>{`${idx.targetAllocation}%/${100 - idx.targetAllocation}%`}</td>
-              <td>{idx.risk}</td>
-              <td>
-                <Link
-                  to={`/index-templates/${idx.id}`}
-                  className="px-2 py-1 border inline-block"
-                >
-                  View
-                </Link>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-      {totalPages > 0 && (
-        <div className="flex gap-2 items-center">
-          <button
-            className="px-2 py-1 border"
-            disabled={page <= 1}
-            onClick={() => setPage((p) => p - 1)}
-          >
-            Prev
-          </button>
-          <span>
-            {page} / {totalPages}
-          </span>
-          <button
-            className="px-2 py-1 border"
-            disabled={page >= totalPages}
-            onClick={() => setPage((p) => p + 1)}
-          >
-            Next
-          </button>
-        </div>
+      {data && data.items.length === 0 ? (
+        <p>You don't have running agents yet.</p>
+      ) : (
+        <>
+          <table className="w-full mb-4">
+            <thead>
+              <tr>
+                <th className="text-left">Agent</th>
+                <th className="text-left">Template</th>
+                <th className="text-left">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data?.items?.map((agent) => (
+                <tr key={agent.id}>
+                  <td>{agent.id}</td>
+                  <td>{agent.templateId}</td>
+                  <td>{agent.status}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {totalPages > 0 && (
+            <div className="flex gap-2 items-center">
+              <button
+                className="px-2 py-1 border"
+                disabled={page <= 1}
+                onClick={() => setPage((p) => p - 1)}
+              >
+                Prev
+              </button>
+              <span>
+                {page} / {totalPages}
+              </span>
+              <button
+                className="px-2 py-1 border"
+                disabled={page >= totalPages}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- rename `index_instances` table to `index_agents` and add `status` column
- add `IndexAgentStatus` enum and CRUD routes for index agents
- cover index agent endpoints with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fff15d600832ca9dd15a06b367dee