### PR TITLE
Fix login button and infinite renders

### DIFF
--- a/frontend/src/components/GoogleLoginButton.tsx
+++ b/frontend/src/components/GoogleLoginButton.tsx
@@ -9,7 +9,16 @@ export default function GoogleLoginButton() {
 
   useEffect(() => {
     const google = (window as any).google;
-    if (!google || !btnRef.current || user) return;
+    if (!google || !btnRef.current) return;
+
+    // Clear any previously rendered buttons (StrictMode runs effects twice)
+    btnRef.current.innerHTML = '';
+
+    if (user) {
+      // Remove the Google button once the user logs in so it doesn't overlay
+      // the navigation links.
+      return;
+    }
 
     google.accounts.id.initialize({
       client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID,

--- a/frontend/src/routes/CreateIndex.tsx
+++ b/frontend/src/routes/CreateIndex.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import IndexForm from '../components/forms/IndexForm';
 import TokenPriceGraph from '../components/forms/TokenPriceGraph';
 import ErrorBoundary from '../components/ErrorBoundary';
@@ -6,12 +6,21 @@ import ErrorBoundary from '../components/ErrorBoundary';
 export default function CreateIndex() {
   const [tokens, setTokens] = useState({ tokenA: 'USDT', tokenB: 'SOL' });
 
+  // Avoid creating a new callback on every render which triggered an
+  // infinite update loop inside IndexForm's effect. Update the state only
+  // when the tokens actually change.
+  const handleTokensChange = useCallback((a: string, b: string) => {
+    setTokens((prev) =>
+      prev.tokenA === a && prev.tokenB === b ? prev : { tokenA: a, tokenB: b }
+    );
+  }, []);
+
   return (
     <div className="flex items-start p-3 gap-3 w-full">
       <ErrorBoundary>
         <TokenPriceGraph tokenA={tokens.tokenA} tokenB={tokens.tokenB} />
       </ErrorBoundary>
-      <IndexForm onTokensChange={(a, b) => setTokens({ tokenA: a, tokenB: b })} />
+      <IndexForm onTokensChange={handleTokensChange} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Prevent CreateIndex from triggering repeated renders by stabilizing token change handler
- Remove Google login button after authentication so navigation works

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a01848e6b4832c852613bc97486c20