### PR TITLE
feat(frontend): add token selector with icons

### DIFF
--- a/frontend/src/components/TokenDisplay.tsx
+++ b/frontend/src/components/TokenDisplay.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const ICONS: Record<string, string> = {
+  BTC: '/tokens/bitcoin-btc-logo.svg',
+  ETH: '/tokens/ethereum-eth-logo.svg',
+  SOL: '/tokens/solana-sol-logo.svg',
+  USDT: '/tokens/tether-usdt-logo.svg',
+};
+
+export default function TokenDisplay({ token, className = '' }: { token: string; className?: string }) {
+  const symbol = token.toUpperCase();
+  const src = ICONS[symbol];
+  return (
+    <span className={`inline-flex items-center gap-1 ${className}`}>
+      {src && <img src={src} alt={`${symbol} logo`} className="w-4 h-4" />}
+      <span className="uppercase">{symbol}</span>
+    </span>
+  );
+}

--- a/frontend/src/components/forms/BinanceKeySection.tsx
+++ b/frontend/src/components/forms/BinanceKeySection.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import axios from 'axios';
 import api from '../../lib/axios';
-import { useUser } from '../../lib/user';
+import { useUser } from '../../lib/useUser';
 
 export default function BinanceKeySection({ label }: { label: string }) {
   const { user } = useUser();

--- a/frontend/src/components/forms/IndexForm.tsx
+++ b/frontend/src/components/forms/IndexForm.tsx
@@ -1,6 +1,6 @@
 import {useEffect} from 'react';
 import {useNavigate} from 'react-router-dom';
-import {useForm} from 'react-hook-form';
+import {Controller, useForm} from 'react-hook-form';
 import {z} from 'zod';
 import {zodResolver} from '@hookform/resolvers/zod';
 import {useQuery} from '@tanstack/react-query';
@@ -10,6 +10,7 @@ import {useUser} from '../../lib/user';
 import {normalizeAllocations} from '../../lib/allocations';
 import KeySection from './KeySection';
 import BinanceKeySection from './BinanceKeySection';
+import TokenSelect from './TokenSelect';
 
 const schema = z
     .object({
@@ -87,6 +88,7 @@ export default function IndexForm({
         handleSubmit,
         watch,
         setValue,
+        control,
         formState: {isSubmitting},
     } = useForm<FormValues>({
         resolver: zodResolver(schema),
@@ -185,35 +187,39 @@ export default function IndexForm({
                         <label className="block text-sm font-medium mb-1" htmlFor="tokenA">
                             Token A
                         </label>
-                        <select id="tokenA" {...register('tokenA')} className="w-full border rounded p-2">
-                            <option value="" disabled>
-                                Select a token
-                            </option>
-                            {tokens
-                                .filter((t) => t.value === tokenA || t.value !== tokenB)
-                                .map((t) => (
-                                    <option key={t.value} value={t.value}>
-                                        {t.label}
-                                    </option>
-                                ))}
-                        </select>
+                        <Controller
+                            name="tokenA"
+                            control={control}
+                            render={({field}) => (
+                                <TokenSelect
+                                    id="tokenA"
+                                    value={field.value}
+                                    onChange={field.onChange}
+                                    options={tokens.filter(
+                                        (t) => t.value === tokenA || t.value !== tokenB
+                                    )}
+                                />
+                            )}
+                        />
                     </div>
                     <div>
                         <label className="block text-sm font-medium mb-1" htmlFor="tokenB">
                             Token B
                         </label>
-                        <select id="tokenB" {...register('tokenB')} className="w-full border rounded p-2">
-                            <option value="" disabled>
-                                Select a token
-                            </option>
-                            {tokens
-                                .filter((t) => t.value === tokenB || t.value !== tokenA)
-                                .map((t) => (
-                                    <option key={t.value} value={t.value}>
-                                        {t.label}
-                                    </option>
-                                ))}
-                        </select>
+                        <Controller
+                            name="tokenB"
+                            control={control}
+                            render={({field}) => (
+                                <TokenSelect
+                                    id="tokenB"
+                                    value={field.value}
+                                    onChange={field.onChange}
+                                    options={tokens.filter(
+                                        (t) => t.value === tokenB || t.value !== tokenA
+                                    )}
+                                />
+                            )}
+                        />
                     </div>
                 </div>
                 <div>

--- a/frontend/src/components/forms/IndexForm.tsx
+++ b/frontend/src/components/forms/IndexForm.tsx
@@ -6,7 +6,7 @@ import {zodResolver} from '@hookform/resolvers/zod';
 import {useQuery} from '@tanstack/react-query';
 import axios from 'axios';
 import api from '../../lib/axios';
-import {useUser} from '../../lib/user';
+import {useUser} from '../../lib/useUser';
 import {normalizeAllocations} from '../../lib/allocations';
 import KeySection from './KeySection';
 import BinanceKeySection from './BinanceKeySection';

--- a/frontend/src/components/forms/KeySection.tsx
+++ b/frontend/src/components/forms/KeySection.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import axios from 'axios';
 import api from '../../lib/axios';
-import { useUser } from '../../lib/user';
+import { useUser } from '../../lib/useUser';
 
 export default function KeySection({ label }: { label: string }) {
   const { user } = useUser();

--- a/frontend/src/components/forms/TokenPriceGraph.tsx
+++ b/frontend/src/components/forms/TokenPriceGraph.tsx
@@ -17,12 +17,14 @@ function generateStablecoinData(): PricePoint[] {
   }));
 }
 
+type Kline = [number, string, string, string, string, ...unknown[]];
+
 async function fetchHistory(token: string): Promise<PricePoint[]> {
   const symbol = token.toUpperCase();
-  const res = await axios.get(
+  const res = await axios.get<Kline[]>(
     `https://api.binance.com/api/v3/klines?symbol=${symbol}USDT&interval=1d&limit=365`
   );
-  return (res.data as any[]).map((d) => ({
+  return res.data.map((d) => ({
     time: d[0],
     open: Number(d[1]),
     high: Number(d[2]),

--- a/frontend/src/components/forms/TokenSelect.tsx
+++ b/frontend/src/components/forms/TokenSelect.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import TokenDisplay from '../TokenDisplay';
+
+interface Option {
+  value: string;
+}
+
+export default function TokenSelect({
+  value,
+  onChange,
+  options,
+  id,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  options: Option[];
+  id: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const selected = options.find((o) => o.value === value);
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        id={id}
+        onClick={() => setOpen(!open)}
+        className="w-full border rounded px-2 py-1 flex items-center justify-between"
+      >
+        {selected ? (
+          <TokenDisplay token={selected.value} />
+        ) : (
+          <span className="text-gray-500">Select a token</span>
+        )}
+        <span className="ml-2">▾</span>
+      </button>
+      {open && (
+        <ul className="absolute z-10 w-full bg-white border rounded mt-1 max-h-40 overflow-auto">
+          {options.map((opt) => (
+            <li key={opt.value}>
+              <button
+                type="button"
+                className="w-full text-left px-2 py-1 hover:bg-gray-100 flex items-center"
+                onClick={() => {
+                  onChange(opt.value);
+                  setOpen(false);
+                }}
+              >
+                <TokenDisplay token={opt.value} />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/UserProvider.tsx
+++ b/frontend/src/lib/UserProvider.tsx
@@ -1,18 +1,6 @@
-import { createContext, useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
-
-export type User = {
-  id: string;
-  email?: string;
-  openaiKey?: string;
-  binanceKey?: string;
-  binanceSecret?: string;
-} | null;
-
-const UserContext = createContext<{ user: User; setUser: (u: User) => void }>({
-  user: null,
-  setUser: () => {},
-});
+import { UserContext, type User } from './user-context';
 
 export function UserProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User>(() => {
@@ -26,8 +14,4 @@ export function UserProvider({ children }: { children: ReactNode }) {
   }, [user]);
 
   return <UserContext.Provider value={{ user, setUser }}>{children}</UserContext.Provider>;
-}
-
-export function useUser() {
-  return useContext(UserContext);
 }

--- a/frontend/src/lib/useUser.ts
+++ b/frontend/src/lib/useUser.ts
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import { UserContext } from './user-context';
+
+export function useUser() {
+  return useContext(UserContext);
+}

--- a/frontend/src/lib/user-context.ts
+++ b/frontend/src/lib/user-context.ts
@@ -1,0 +1,14 @@
+import { createContext } from 'react';
+
+export type User = {
+  id: string;
+  email?: string;
+  openaiKey?: string;
+  binanceKey?: string;
+  binanceSecret?: string;
+} | null;
+
+export const UserContext = createContext<{ user: User; setUser: (u: User) => void }>({
+  user: null,
+  setUser: () => {},
+});

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,7 +5,7 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import queryClient from './lib/queryClient';
 import { setupMocks } from './lib/mocks';
-import { UserProvider } from './lib/user';
+import { UserProvider } from './lib/UserProvider';
 import './index.css';
 
 setupMocks();

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import api from '../lib/axios';
-import { useUser } from '../lib/user';
+import { useUser } from '../lib/useUser';
 
 interface IndexTemplateItem {
   id: string;
@@ -21,7 +21,10 @@ export default function Dashboard() {
   const { data } = useQuery({
     queryKey: ['index-templates', page, onlyMine, user?.id],
     queryFn: async () => {
-      const params: any = { page, pageSize: 10 };
+      const params: { page: number; pageSize: number; userId?: string } = {
+        page,
+        pageSize: 10,
+      };
       if (onlyMine && user?.id) params.userId = user.id;
       const res = await api.get('/index-templates/paginated', { params });
       return res.data as {

--- a/frontend/src/routes/Settings.tsx
+++ b/frontend/src/routes/Settings.tsx
@@ -1,4 +1,4 @@
-import { useUser } from '../lib/user';
+import { useUser } from '../lib/useUser';
 import KeySection from '../components/forms/KeySection';
 import BinanceKeySection from '../components/forms/BinanceKeySection';
 

--- a/frontend/src/routes/ViewIndex.tsx
+++ b/frontend/src/routes/ViewIndex.tsx
@@ -1,7 +1,7 @@
 import {useParams} from 'react-router-dom';
 import {useQuery} from '@tanstack/react-query';
 import api from '../lib/axios';
-import {useUser} from '../lib/user';
+import {useUser} from '../lib/useUser';
 import React from "react";
 
 interface IndexDetails {


### PR DESCRIPTION
## Summary
- add `TokenDisplay` component to show token symbol and icon
- create `TokenSelect` for choosing tokens compactly
- update index form to use iconified token selectors

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Fast refresh only works when a file only exports components)*

------
https://chatgpt.com/codex/tasks/task_e_68a01db6dfa4832ca445fa226600cc37