### PR TITLE
feat: add index agents CRUD

### DIFF
--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -30,16 +30,17 @@ CREATE TABLE IF NOT EXISTS index_templates(
   agent_instructions TEXT
 );
 
-CREATE TABLE IF NOT EXISTS index_instances(
+CREATE TABLE IF NOT EXISTS index_agents(
   id TEXT PRIMARY KEY,
   template_id TEXT,
   user_id TEXT,
+  status TEXT,
   created_at INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS index_exec_log(
   id TEXT PRIMARY KEY,
-  instance_id TEXT,
+  agent_id TEXT,
   log TEXT,
   created_at INTEGER
 );

--- a/backend/src/routes/index-agents.ts
+++ b/backend/src/routes/index-agents.ts
@@ -3,9 +3,8 @@ import { randomUUID } from 'node:crypto';
 import { db } from '../db/index.js';
 
 export enum IndexAgentStatus {
-  Idle = 'idle',
-  Running = 'running',
-  Error = 'error',
+  Active = 'active',
+  Inactive = 'inactive',
 }
 
 interface IndexAgentRow {
@@ -68,7 +67,7 @@ export default async function indexAgentRoutes(app: FastifyInstance) {
       status?: IndexAgentStatus;
     };
     const id = randomUUID();
-    const status = body.status ?? IndexAgentStatus.Idle;
+    const status = body.status ?? IndexAgentStatus.Inactive;
     const createdAt = Date.now();
     db.prepare(
       `INSERT INTO index_agents (id, template_id, user_id, status, created_at) VALUES (?, ?, ?, ?, ?)`

--- a/backend/src/routes/index-agents.ts
+++ b/backend/src/routes/index-agents.ts
@@ -1,0 +1,121 @@
+import type { FastifyInstance } from 'fastify';
+import { randomUUID } from 'node:crypto';
+import { db } from '../db/index.js';
+
+export enum IndexAgentStatus {
+  Idle = 'idle',
+  Running = 'running',
+  Error = 'error',
+}
+
+interface IndexAgentRow {
+  id: string;
+  template_id: string;
+  user_id: string;
+  status: string;
+  created_at: number;
+}
+
+function toApi(row: IndexAgentRow) {
+  return {
+    id: row.id,
+    templateId: row.template_id,
+    userId: row.user_id,
+    status: row.status as IndexAgentStatus,
+    createdAt: row.created_at,
+  };
+}
+
+export default async function indexAgentRoutes(app: FastifyInstance) {
+  app.get('/index-agents', async () => {
+    const rows = db.prepare<[], IndexAgentRow>('SELECT * FROM index_agents').all();
+    return rows.map(toApi);
+  });
+
+  app.get('/index-agents/paginated', async (req) => {
+    const {
+      page = '1',
+      pageSize = '10',
+      userId,
+    } = req.query as { page?: string; pageSize?: string; userId?: string };
+    const p = Math.max(parseInt(page, 10), 1);
+    const ps = Math.max(parseInt(pageSize, 10), 1);
+    const offset = (p - 1) * ps;
+    const params: any[] = [];
+    let where = '';
+    if (userId) {
+      where = 'WHERE user_id = ?';
+      params.push(userId);
+    }
+    const totalRow = db
+      .prepare(`SELECT COUNT(*) as count FROM index_agents ${where}`)
+      .get(...params) as { count: number };
+    const rows = db
+      .prepare(`SELECT * FROM index_agents ${where} LIMIT ? OFFSET ?`)
+      .all(...params, ps, offset) as IndexAgentRow[];
+    return {
+      items: rows.map(toApi),
+      total: totalRow.count,
+      page: p,
+      pageSize: ps,
+    };
+  });
+
+  app.post('/index-agents', async (req) => {
+    const body = req.body as {
+      templateId: string;
+      userId: string;
+      status?: IndexAgentStatus;
+    };
+    const id = randomUUID();
+    const status = body.status ?? IndexAgentStatus.Idle;
+    const createdAt = Date.now();
+    db.prepare(
+      `INSERT INTO index_agents (id, template_id, user_id, status, created_at) VALUES (?, ?, ?, ?, ?)`
+    ).run(id, body.templateId, body.userId, status, createdAt);
+    return {
+      id,
+      templateId: body.templateId,
+      userId: body.userId,
+      status,
+      createdAt,
+    };
+  });
+
+  app.get('/index-agents/:id', async (req, reply) => {
+    const id = (req.params as any).id;
+    const row = db
+      .prepare('SELECT * FROM index_agents WHERE id = ?')
+      .get(id) as IndexAgentRow | undefined;
+    if (!row) return reply.code(404).send({ error: 'not found' });
+    return toApi(row);
+  });
+
+  app.put('/index-agents/:id', async (req, reply) => {
+    const id = (req.params as any).id;
+    const body = req.body as {
+      templateId: string;
+      userId: string;
+      status: IndexAgentStatus;
+    };
+    const existing = db
+      .prepare('SELECT id FROM index_agents WHERE id = ?')
+      .get(id) as { id: string } | undefined;
+    if (!existing) return reply.code(404).send({ error: 'not found' });
+    db.prepare(
+      `UPDATE index_agents SET template_id = ?, user_id = ?, status = ? WHERE id = ?`
+    ).run(body.templateId, body.userId, body.status, id);
+    const row = db
+      .prepare('SELECT * FROM index_agents WHERE id = ?')
+      .get(id) as IndexAgentRow;
+    return toApi(row);
+  });
+
+  app.delete('/index-agents/:id', async (req, reply) => {
+    const id = (req.params as any).id;
+    const res = db.prepare('DELETE FROM index_agents WHERE id = ?').run(id);
+    if (res.changes === 0) return reply.code(404).send({ error: 'not found' });
+    return { ok: true };
+  });
+}
+

--- a/backend/test/indexAgents.test.ts
+++ b/backend/test/indexAgents.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+
+process.env.DATABASE_URL = ':memory:';
+process.env.KEY_PASSWORD = 'test-pass';
+process.env.GOOGLE_CLIENT_ID = 'test-client';
+
+const { db, migrate } = await import('../src/db/index.js');
+import buildServer from '../src/server.js';
+
+migrate();
+
+describe('index agent routes', () => {
+  it('performs CRUD operations', async () => {
+    const app = await buildServer();
+    db.prepare('INSERT INTO users (id) VALUES (?)').run('user1');
+    db.prepare(
+      `INSERT INTO index_templates (id, user_id, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, model, agent_instructions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run('tmpl1', 'user1', 'BTC', 'ETH', 60, 10, 20, 'low', '1h', 'gpt-5', 'prompt');
+
+    const payload = { templateId: 'tmpl1', userId: 'user1', status: 'idle' };
+
+    let res = await app.inject({ method: 'POST', url: '/api/index-agents', payload });
+    expect(res.statusCode).toBe(200);
+    const id = res.json().id as string;
+
+    res = await app.inject({ method: 'GET', url: `/api/index-agents/${id}` });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ id, ...payload });
+
+    res = await app.inject({ method: 'GET', url: '/api/index-agents' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveLength(1);
+
+    res = await app.inject({
+      method: 'GET',
+      url: '/api/index-agents/paginated?page=1&pageSize=10&userId=user1',
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ total: 1, page: 1, pageSize: 10 });
+    expect(res.json().items).toHaveLength(1);
+
+    const update = { templateId: 'tmpl1', userId: 'user1', status: 'running' };
+    res = await app.inject({ method: 'PUT', url: `/api/index-agents/${id}`, payload: update });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ id, ...update });
+
+    res = await app.inject({ method: 'DELETE', url: `/api/index-agents/${id}` });
+    expect(res.statusCode).toBe(200);
+
+    res = await app.inject({ method: 'GET', url: `/api/index-agents/${id}` });
+    expect(res.statusCode).toBe(404);
+
+    await app.close();
+  });
+});
+

--- a/backend/test/indexAgents.test.ts
+++ b/backend/test/indexAgents.test.ts
@@ -17,7 +17,7 @@ describe('index agent routes', () => {
       `INSERT INTO index_templates (id, user_id, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, model, agent_instructions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run('tmpl1', 'user1', 'BTC', 'ETH', 60, 10, 20, 'low', '1h', 'gpt-5', 'prompt');
 
-    const payload = { templateId: 'tmpl1', userId: 'user1', status: 'idle' };
+    const payload = { templateId: 'tmpl1', userId: 'user1', status: 'inactive' };
 
     let res = await app.inject({ method: 'POST', url: '/api/index-agents', payload });
     expect(res.statusCode).toBe(200);
@@ -39,7 +39,7 @@ describe('index agent routes', () => {
     expect(res.json()).toMatchObject({ total: 1, page: 1, pageSize: 10 });
     expect(res.json().items).toHaveLength(1);
 
-    const update = { templateId: 'tmpl1', userId: 'user1', status: 'running' };
+    const update = { templateId: 'tmpl1', userId: 'user1', status: 'active' };
     res = await app.inject({ method: 'PUT', url: `/api/index-agents/${id}`, payload: update });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ id, ...update });


### PR DESCRIPTION
## Summary
- rename index_instances table to index_agents with status field
- add IndexAgentStatus enum and CRUD routes
- cover index agent APIs with tests

## Testing
- `npm --prefix backend run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0232b5500832c9b1c299fda8ef722