### PR TITLE
Enforce user ownership for index templates and agents

### DIFF
--- a/backend/src/routes/index-templates.ts
+++ b/backend/src/routes/index-templates.ts
@@ -34,32 +34,35 @@ function toApi(row: IndexTemplateRow) {
 }
 
 export default async function indexTemplateRoutes(app: FastifyInstance) {
-  app.get('/index-templates', async () => {
-    const rows = db.prepare<[], IndexTemplateRow>('SELECT * FROM index_templates').all();
+  app.get('/index-templates', async (req, reply) => {
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (!userId)
+      return reply.code(403).send({ error: 'forbidden' });
+    const rows = db
+      .prepare<[], IndexTemplateRow>(
+        'SELECT * FROM index_templates WHERE user_id = ?'
+      )
+      .all(userId);
     return rows.map(toApi);
   });
 
-  app.get('/index-templates/paginated', async (req) => {
-    const {
-      page = '1',
-      pageSize = '10',
-      userId,
-    } = req.query as { page?: string; pageSize?: string; userId?: string };
+  app.get('/index-templates/paginated', async (req, reply) => {
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (!userId)
+      return reply.code(403).send({ error: 'forbidden' });
+    const { page = '1', pageSize = '10' } = req.query as {
+      page?: string;
+      pageSize?: string;
+    };
     const p = Math.max(parseInt(page, 10), 1);
     const ps = Math.max(parseInt(pageSize, 10), 1);
     const offset = (p - 1) * ps;
-    const params: any[] = [];
-    let where = '';
-    if (userId) {
-      where = 'WHERE user_id = ?';
-      params.push(userId);
-    }
     const totalRow = db
-      .prepare(`SELECT COUNT(*) as count FROM index_templates ${where}`)
-      .get(...params) as { count: number };
+      .prepare('SELECT COUNT(*) as count FROM index_templates WHERE user_id = ?')
+      .get(userId) as { count: number };
     const rows = db
-      .prepare(`SELECT * FROM index_templates ${where} LIMIT ? OFFSET ?`)
-      .all(...params, ps, offset) as IndexTemplateRow[];
+      .prepare('SELECT * FROM index_templates WHERE user_id = ? LIMIT ? OFFSET ?')
+      .all(userId, ps, offset) as IndexTemplateRow[];
     return {
       items: rows.map(toApi),
       total: totalRow.count,
@@ -68,7 +71,7 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
     };
   });
 
-  app.post('/index-templates', async (req) => {
+  app.post('/index-templates', async (req, reply) => {
     const body = req.body as {
       userId: string;
       tokenA: string;
@@ -81,6 +84,9 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
       model: string;
       agentInstructions: string;
     };
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (!userId || body.userId !== userId)
+      return reply.code(403).send({ error: 'forbidden' });
     const id = randomUUID();
     const tokenA = body.tokenA.toUpperCase();
     const tokenB = body.tokenB.toUpperCase();
@@ -117,15 +123,19 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
   });
 
   app.get('/index-templates/:id', async (req, reply) => {
+    const userId = req.headers['x-user-id'] as string | undefined;
     const id = (req.params as any).id;
     const row = db
       .prepare('SELECT * FROM index_templates WHERE id = ?')
       .get(id) as IndexTemplateRow | undefined;
     if (!row) return reply.code(404).send({ error: 'not found' });
+    if (!userId || row.user_id !== userId)
+      return reply.code(403).send({ error: 'forbidden' });
     return toApi(row);
   });
 
   app.put('/index-templates/:id', async (req, reply) => {
+    const userId = req.headers['x-user-id'] as string | undefined;
     const id = (req.params as any).id;
     const body = req.body as {
       userId: string;
@@ -140,9 +150,11 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
       agentInstructions: string;
     };
     const existing = db
-      .prepare('SELECT id FROM index_templates WHERE id = ?')
-      .get(id) as { id: string } | undefined;
+      .prepare('SELECT * FROM index_templates WHERE id = ?')
+      .get(id) as IndexTemplateRow | undefined;
     if (!existing) return reply.code(404).send({ error: 'not found' });
+    if (!userId || existing.user_id !== userId || body.userId !== userId)
+      return reply.code(403).send({ error: 'forbidden' });
     const tokenA = body.tokenA.toUpperCase();
     const tokenB = body.tokenB.toUpperCase();
     const { targetAllocation, minTokenAAllocation, minTokenBAllocation } = normalizeAllocations(
@@ -172,9 +184,15 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
   });
 
   app.delete('/index-templates/:id', async (req, reply) => {
+    const userId = req.headers['x-user-id'] as string | undefined;
     const id = (req.params as any).id;
-    const res = db.prepare('DELETE FROM index_templates WHERE id = ?').run(id);
-    if (res.changes === 0) return reply.code(404).send({ error: 'not found' });
+    const existing = db
+      .prepare('SELECT user_id FROM index_templates WHERE id = ?')
+      .get(id) as { user_id: string } | undefined;
+    if (!existing) return reply.code(404).send({ error: 'not found' });
+    if (!userId || existing.user_id !== userId)
+      return reply.code(403).send({ error: 'forbidden' });
+    db.prepare('DELETE FROM index_templates WHERE id = ?').run(id);
     return { ok: true };
   });
 }

--- a/backend/test/indexAgents.test.ts
+++ b/backend/test/indexAgents.test.ts
@@ -19,36 +19,116 @@ describe('index agent routes', () => {
 
     const payload = { templateId: 'tmpl1', userId: 'user1', status: 'inactive' };
 
-    let res = await app.inject({ method: 'POST', url: '/api/index-agents', payload });
+    let res = await app.inject({
+      method: 'POST',
+      url: '/api/index-agents',
+      headers: { 'x-user-id': 'user1' },
+      payload,
+    });
     expect(res.statusCode).toBe(200);
     const id = res.json().id as string;
 
-    res = await app.inject({ method: 'GET', url: `/api/index-agents/${id}` });
+    res = await app.inject({
+      method: 'GET',
+      url: `/api/index-agents/${id}`,
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ id, ...payload });
 
-    res = await app.inject({ method: 'GET', url: '/api/index-agents' });
+    res = await app.inject({
+      method: 'GET',
+      url: '/api/index-agents',
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toHaveLength(1);
 
     res = await app.inject({
       method: 'GET',
-      url: '/api/index-agents/paginated?page=1&pageSize=10&userId=user1',
+      url: '/api/index-agents/paginated?page=1&pageSize=10',
+      headers: { 'x-user-id': 'user1' },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ total: 1, page: 1, pageSize: 10 });
     expect(res.json().items).toHaveLength(1);
 
     const update = { templateId: 'tmpl1', userId: 'user1', status: 'active' };
-    res = await app.inject({ method: 'PUT', url: `/api/index-agents/${id}`, payload: update });
+    res = await app.inject({
+      method: 'PUT',
+      url: `/api/index-agents/${id}`,
+      headers: { 'x-user-id': 'user1' },
+      payload: update,
+    });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ id, ...update });
 
-    res = await app.inject({ method: 'DELETE', url: `/api/index-agents/${id}` });
+    res = await app.inject({
+      method: 'DELETE',
+      url: `/api/index-agents/${id}`,
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(200);
 
-    res = await app.inject({ method: 'GET', url: `/api/index-agents/${id}` });
+    res = await app.inject({
+      method: 'GET',
+      url: `/api/index-agents/${id}`,
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(404);
+
+    await app.close();
+  });
+
+  it('enforces user ownership', async () => {
+    const app = await buildServer();
+    db.prepare('INSERT INTO users (id) VALUES (?)').run('user2');
+    db.prepare('INSERT INTO users (id) VALUES (?)').run('user3');
+    db.prepare(
+      `INSERT INTO index_templates (id, user_id, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, model, agent_instructions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run('tmpl2', 'user2', 'BTC', 'ETH', 60, 10, 20, 'low', '1h', 'gpt-5', 'prompt');
+    db.prepare(
+      `INSERT INTO index_templates (id, user_id, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, model, agent_instructions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run('tmpl3', 'user3', 'BTC', 'ETH', 60, 10, 20, 'low', '1h', 'gpt-5', 'prompt');
+
+    let res = await app.inject({
+      method: 'POST',
+      url: '/api/index-agents',
+      headers: { 'x-user-id': 'user2' },
+      payload: { templateId: 'tmpl2', userId: 'user2', status: 'inactive' },
+    });
+    const id1 = res.json().id as string;
+
+    res = await app.inject({
+      method: 'POST',
+      url: '/api/index-agents',
+      headers: { 'x-user-id': 'user3' },
+      payload: { templateId: 'tmpl3', userId: 'user3', status: 'inactive' },
+    });
+    const id2 = res.json().id as string;
+
+    res = await app.inject({
+      method: 'GET',
+      url: '/api/index-agents',
+      headers: { 'x-user-id': 'user2' },
+    });
+    expect(res.json()).toHaveLength(1);
+    expect(res.json()[0].id).toBe(id1);
+
+    res = await app.inject({
+      method: 'GET',
+      url: `/api/index-agents/${id2}`,
+      headers: { 'x-user-id': 'user2' },
+    });
+    expect(res.statusCode).toBe(403);
+
+    res = await app.inject({
+      method: 'POST',
+      url: '/api/index-agents',
+      headers: { 'x-user-id': 'user2' },
+      payload: { templateId: 'tmpl2', userId: 'user3', status: 'inactive' },
+    });
+    expect(res.statusCode).toBe(403);
 
     await app.close();
   });

--- a/backend/test/indexTemplates.test.ts
+++ b/backend/test/indexTemplates.test.ts
@@ -27,46 +27,133 @@ describe('index template routes', () => {
       agentInstructions: 'prompt',
     };
 
-    let res = await app.inject({ method: 'POST', url: '/api/index-templates', payload });
+    let res = await app.inject({
+      method: 'POST',
+      url: '/api/index-templates',
+      headers: { 'x-user-id': 'user1' },
+      payload,
+    });
     expect(res.statusCode).toBe(200);
     const id = res.json().id as string;
 
-    res = await app.inject({ method: 'GET', url: `/api/index-templates/${id}` });
+    res = await app.inject({
+      method: 'GET',
+      url: `/api/index-templates/${id}`,
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ id, ...payload });
 
-    res = await app.inject({ method: 'GET', url: '/api/index-templates' });
+    res = await app.inject({
+      method: 'GET',
+      url: '/api/index-templates',
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toHaveLength(1);
 
     res = await app.inject({
       method: 'GET',
-      url: '/api/index-templates/paginated?page=1&pageSize=10&userId=user1',
+      url: '/api/index-templates/paginated?page=1&pageSize=10',
+      headers: { 'x-user-id': 'user1' },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ total: 1, page: 1, pageSize: 10 });
     expect(res.json().items).toHaveLength(1);
 
     const update = { ...payload, targetAllocation: 70, risk: 'medium', model: 'o3' };
-    res = await app.inject({ method: 'PUT', url: `/api/index-templates/${id}`, payload: update });
+    res = await app.inject({
+      method: 'PUT',
+      url: `/api/index-templates/${id}`,
+      headers: { 'x-user-id': 'user1' },
+      payload: update,
+    });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ id, ...update });
 
-    res = await app.inject({ method: 'DELETE', url: `/api/index-templates/${id}` });
+    res = await app.inject({
+      method: 'DELETE',
+      url: `/api/index-templates/${id}`,
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(200);
 
-    res = await app.inject({ method: 'GET', url: `/api/index-templates/${id}` });
+    res = await app.inject({
+      method: 'GET',
+      url: `/api/index-templates/${id}`,
+      headers: { 'x-user-id': 'user1' },
+    });
     expect(res.statusCode).toBe(404);
+
+    await app.close();
+  });
+
+  it('enforces user ownership', async () => {
+    const app = await buildServer();
+    db.prepare('INSERT INTO users (id) VALUES (?)').run('user3');
+    db.prepare('INSERT INTO users (id) VALUES (?)').run('user4');
+
+    const payload = {
+      userId: 'user3',
+      tokenA: 'BTC',
+      tokenB: 'ETH',
+      targetAllocation: 60,
+      minTokenAAllocation: 10,
+      minTokenBAllocation: 20,
+      risk: 'low',
+      rebalance: '1h',
+      model: 'gpt-5',
+      agentInstructions: 'prompt',
+    };
+
+    let res = await app.inject({
+      method: 'POST',
+      url: '/api/index-templates',
+      headers: { 'x-user-id': 'user3' },
+      payload,
+    });
+    const id1 = res.json().id as string;
+
+    res = await app.inject({
+      method: 'POST',
+      url: '/api/index-templates',
+      headers: { 'x-user-id': 'user4' },
+      payload: { ...payload, userId: 'user4' },
+    });
+    const id2 = res.json().id as string;
+
+    res = await app.inject({
+      method: 'GET',
+      url: '/api/index-templates',
+      headers: { 'x-user-id': 'user3' },
+    });
+    expect(res.json()).toHaveLength(1);
+    expect(res.json()[0].id).toBe(id1);
+
+    res = await app.inject({
+      method: 'GET',
+      url: `/api/index-templates/${id2}`,
+      headers: { 'x-user-id': 'user3' },
+    });
+    expect(res.statusCode).toBe(403);
+
+    res = await app.inject({
+      method: 'POST',
+      url: '/api/index-templates',
+      headers: { 'x-user-id': 'user3' },
+      payload: { ...payload, userId: 'user4' },
+    });
+    expect(res.statusCode).toBe(403);
 
     await app.close();
   });
 
   it('auto-corrects allocation inputs', async () => {
     const app = await buildServer();
-    db.prepare('INSERT INTO users (id) VALUES (?)').run('user2');
+    db.prepare('INSERT INTO users (id) VALUES (?)').run('user5');
 
     const base = {
-      userId: 'user2',
+      userId: 'user5',
       tokenA: 'BTC',
       tokenB: 'ETH',
       risk: 'low',
@@ -78,6 +165,7 @@ describe('index template routes', () => {
     let res = await app.inject({
       method: 'POST',
       url: '/api/index-templates',
+      headers: { 'x-user-id': 'user5' },
       payload: { ...base, targetAllocation: 50, minTokenAAllocation: 80, minTokenBAllocation: 30 },
     });
     expect(res.json()).toMatchObject({ targetAllocation: 70, minTokenAAllocation: 70, minTokenBAllocation: 30 });
@@ -85,6 +173,7 @@ describe('index template routes', () => {
     res = await app.inject({
       method: 'POST',
       url: '/api/index-templates',
+      headers: { 'x-user-id': 'user5' },
       payload: { ...base, targetAllocation: 50, minTokenAAllocation: 20, minTokenBAllocation: 90 },
     });
     expect(res.json()).toMatchObject({ targetAllocation: 20, minTokenAAllocation: 20, minTokenBAllocation: 80 });
@@ -92,6 +181,7 @@ describe('index template routes', () => {
     res = await app.inject({
       method: 'POST',
       url: '/api/index-templates',
+      headers: { 'x-user-id': 'user5' },
       payload: { ...base, targetAllocation: 5, minTokenAAllocation: 10, minTokenBAllocation: 10 },
     });
     expect(res.json()).toMatchObject({ targetAllocation: 10, minTokenAAllocation: 10, minTokenBAllocation: 10 });
@@ -99,6 +189,7 @@ describe('index template routes', () => {
     res = await app.inject({
       method: 'POST',
       url: '/api/index-templates',
+      headers: { 'x-user-id': 'user5' },
       payload: { ...base, targetAllocation: 95, minTokenAAllocation: 10, minTokenBAllocation: 10 },
     });
     expect(res.json()).toMatchObject({ targetAllocation: 90, minTokenAAllocation: 10, minTokenBAllocation: 10 });


### PR DESCRIPTION
## Summary
- restrict index template routes to resources owned by `x-user-id`
- restrict index agent routes to resources owned by `x-user-id`
- test access control for templates and agents

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a02ce35438832c8afd0425d0bce79f