### PR TITLE
Allow template creation without API keys

### DIFF
--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -26,7 +26,6 @@ CREATE TABLE IF NOT EXISTS index_templates(
   min_b_allocation INTEGER,
   risk TEXT,
   rebalance TEXT,
-  model TEXT,
   agent_instructions TEXT
 );
 
@@ -34,6 +33,7 @@ CREATE TABLE IF NOT EXISTS index_agents(
   id TEXT PRIMARY KEY,
   template_id TEXT,
   user_id TEXT,
+  model TEXT,
   status TEXT,
   created_at INTEGER
 );

--- a/backend/src/routes/index-templates.ts
+++ b/backend/src/routes/index-templates.ts
@@ -13,7 +13,6 @@ interface IndexTemplateRow {
   min_b_allocation: number;
   risk: string;
   rebalance: string;
-  model: string;
   agent_instructions: string;
 }
 
@@ -28,7 +27,6 @@ function toApi(row: IndexTemplateRow) {
     minTokenBAllocation: row.min_b_allocation,
     risk: row.risk,
     rebalance: row.rebalance,
-    model: row.model,
     agentInstructions: row.agent_instructions,
   };
 }
@@ -81,7 +79,6 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
       minTokenBAllocation: number;
       risk: string;
       rebalance: string;
-      model: string;
       agentInstructions: string;
     };
     const userId = req.headers['x-user-id'] as string | undefined;
@@ -96,8 +93,8 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
       body.minTokenBAllocation
     );
     db.prepare(
-      `INSERT INTO index_templates (id, user_id, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, model, agent_instructions)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO index_templates (id, user_id, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, agent_instructions)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       id,
       body.userId,
@@ -108,7 +105,6 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
       minTokenBAllocation,
       body.risk,
       body.rebalance,
-      body.model,
       body.agentInstructions
     );
     return {
@@ -146,7 +142,6 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
       minTokenBAllocation: number;
       risk: string;
       rebalance: string;
-      model: string;
       agentInstructions: string;
     };
     const existing = db
@@ -163,7 +158,7 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
       body.minTokenBAllocation
     );
     db.prepare(
-      `UPDATE index_templates SET user_id = ?, token_a = ?, token_b = ?, target_allocation = ?, min_a_allocation = ?, min_b_allocation = ?, risk = ?, rebalance = ?, model = ?, agent_instructions = ? WHERE id = ?`
+      `UPDATE index_templates SET user_id = ?, token_a = ?, token_b = ?, target_allocation = ?, min_a_allocation = ?, min_b_allocation = ?, risk = ?, rebalance = ?, agent_instructions = ? WHERE id = ?`
     ).run(
       body.userId,
       tokenA,
@@ -173,7 +168,6 @@ export default async function indexTemplateRoutes(app: FastifyInstance) {
       minTokenBAllocation,
       body.risk,
       body.rebalance,
-      body.model,
       body.agentInstructions,
       id
     );

--- a/backend/test/indexTemplates.test.ts
+++ b/backend/test/indexTemplates.test.ts
@@ -23,7 +23,6 @@ describe('index template routes', () => {
       minTokenBAllocation: 20,
       risk: 'low',
       rebalance: '1h',
-      model: 'gpt-5',
       agentInstructions: 'prompt',
     };
 
@@ -61,7 +60,7 @@ describe('index template routes', () => {
     expect(res.json()).toMatchObject({ total: 1, page: 1, pageSize: 10 });
     expect(res.json().items).toHaveLength(1);
 
-    const update = { ...payload, targetAllocation: 70, risk: 'medium', model: 'o3' };
+    const update = { ...payload, targetAllocation: 70, risk: 'medium' };
     res = await app.inject({
       method: 'PUT',
       url: `/api/index-templates/${id}`,
@@ -102,7 +101,6 @@ describe('index template routes', () => {
       minTokenBAllocation: 20,
       risk: 'low',
       rebalance: '1h',
-      model: 'gpt-5',
       agentInstructions: 'prompt',
     };
 
@@ -158,7 +156,6 @@ describe('index template routes', () => {
       tokenB: 'ETH',
       risk: 'low',
       rebalance: '1h',
-      model: 'gpt-5',
       agentInstructions: 'prompt',
     };
 

--- a/frontend/src/components/forms/IndexForm.tsx
+++ b/frontend/src/components/forms/IndexForm.tsx
@@ -3,13 +3,9 @@ import {useNavigate} from 'react-router-dom';
 import {Controller, useForm} from 'react-hook-form';
 import {z} from 'zod';
 import {zodResolver} from '@hookform/resolvers/zod';
-import {useQuery} from '@tanstack/react-query';
-import axios from 'axios';
 import api from '../../lib/axios';
 import {useUser} from '../../lib/useUser';
 import {normalizeAllocations} from '../../lib/allocations';
-import KeySection from './KeySection';
-import BinanceKeySection from './BinanceKeySection';
 import TokenSelect from './TokenSelect';
 
 const schema = z
@@ -30,7 +26,6 @@ const schema = z
             .max(100, 'Must be 100 or less'),
         risk: z.enum(['low', 'medium', 'high']),
         rebalance: z.enum(['1h', '3h', '5h', '12h', '24h', '3d', '1w']),
-        model: z.string().min(1, 'Model is required'),
         agentInstructions: z
             .string()
             .min(1, 'Trading agent instructions are required'),
@@ -55,34 +50,6 @@ export default function IndexForm({
     onTokensChange?: (tokenA: string, tokenB: string) => void;
 }) {
     const {user} = useUser();
-    const aiKeyQuery = useQuery<string | null>({
-        queryKey: ['ai-key', user?.id],
-        enabled: !!user,
-        queryFn: async () => {
-            try {
-                const res = await api.get(`/users/${user!.id}/ai-key`);
-                return res.data.key as string;
-            } catch (err) {
-                if (axios.isAxiosError(err) && err.response?.status === 404) return null;
-                throw err;
-            }
-        },
-    });
-    const hasOpenAIKey = !!aiKeyQuery.data;
-    const binanceKeyQuery = useQuery<string | null>({
-        queryKey: ['binance-key', user?.id],
-        enabled: !!user,
-        queryFn: async () => {
-            try {
-                const res = await api.get(`/users/${user!.id}/binance-key`);
-                return res.data.key as string;
-            } catch (err) {
-                if (axios.isAxiosError(err) && err.response?.status === 404) return null;
-                throw err;
-            }
-        },
-    });
-    const hasBinanceKey = !!binanceKeyQuery.data;
     const {
         register,
         handleSubmit,
@@ -100,7 +67,6 @@ export default function IndexForm({
             minTokenBAllocation: 30,
             risk: 'low',
             rebalance: '1h',
-            model: '',
             agentInstructions:
                 'Manage this index based on the configured parameters, actively monitoring real-time market data and relevant news to dynamically adjust positions, aiming to capture local highs for exits and local lows for entries to maximize performance within the defined allocation strategy.',
         },
@@ -112,22 +78,7 @@ export default function IndexForm({
     const minTokenAAllocation = watch('minTokenAAllocation');
     const minTokenBAllocation = watch('minTokenBAllocation');
 
-    const modelsQuery = useQuery<string[]>({
-        queryKey: ['openai-models', user?.id],
-        enabled: !!user && hasOpenAIKey,
-        queryFn: async () => {
-            const res = await api.get(`/users/${user!.id}/models`);
-            return res.data.models as string[];
-        },
-    });
-
-    const hasModels = !!modelsQuery.data?.length;
-
-    useEffect(() => {
-        if (modelsQuery.data && modelsQuery.data.length) {
-            setValue('model', modelsQuery.data[0]);
-        }
-    }, [modelsQuery.data, setValue]);
+    
 
     useEffect(() => {
         onTokensChange?.(tokenA, tokenB);
@@ -327,53 +278,19 @@ export default function IndexForm({
                         className="w-full border rounded p-2 h-32"
                     />
                 </div>
-                {modelsQuery.data && modelsQuery.data.length ? (
-                    <div>
-                        <label className="block text-sm font-medium mb-1" htmlFor="model">
-                            Model
-                        </label>
-                        <select
-                            id="model"
-                            {...register('model')}
-                            className="w-full border rounded p-2"
-                        >
-                            {modelsQuery.data.map((m) => (
-                                <option key={m} value={m}>
-                                    {m}
-                                </option>
-                            ))}
-                        </select>
-                    </div>
-                ) : (
-                    <div>
-                        <label className="block text-sm font-medium mb-1">
-                            OpenAI key is required
-                        </label>
-                        {user && !hasOpenAIKey && <KeySection label=""/>}
-                    </div>
-                )}
-                {!hasBinanceKey && (
-                    <div>
-                        <label className="block text-sm font-medium mb-1">
-                            Binance keys are required
-                        </label>
-                        {user && <BinanceKeySection label=""/>}
-                    </div>
-                )}
-
                 {!user && (
                     <p className="text-sm text-gray-600 mb-2">Log in to continue</p>
                 )}
                 <button
                     type="submit"
                     className={`w-full py-2 rounded ${
-                        user && hasModels && hasBinanceKey && !isSubmitting
+                        user && !isSubmitting
                             ? 'bg-blue-600 text-white'
                             : 'bg-gray-300 text-gray-500 cursor-not-allowed'
                     }`}
-                    disabled={!user || !hasModels || !hasBinanceKey || isSubmitting}
+                    disabled={!user || isSubmitting}
                 >
-                    Save
+                    Save template
                 </button>
             </form>
         </>

--- a/frontend/src/components/forms/IndexForm.tsx
+++ b/frontend/src/components/forms/IndexForm.tsx
@@ -119,12 +119,16 @@ export default function IndexForm({
 
     const onSubmit = handleSubmit(async (values) => {
         if (!user) return;
-        const res = await api.post('/index-templates', {
-            userId: user.id,
-            ...values,
-            tokenA: values.tokenA.toUpperCase(),
-            tokenB: values.tokenB.toUpperCase(),
-        });
+        const res = await api.post(
+            '/index-templates',
+            {
+                userId: user.id,
+                ...values,
+                tokenA: values.tokenA.toUpperCase(),
+                tokenB: values.tokenB.toUpperCase(),
+            },
+            {headers: {'x-user-id': user.id}}
+        );
         navigate(`/index-templates/${res.data.id}`);
     });
 

--- a/frontend/src/routes/ViewIndex.tsx
+++ b/frontend/src/routes/ViewIndex.tsx
@@ -1,8 +1,11 @@
+import {useState, useEffect, ReactNode} from 'react';
 import {useParams} from 'react-router-dom';
 import {useQuery} from '@tanstack/react-query';
+import axios from 'axios';
 import api from '../lib/axios';
 import {useUser} from '../lib/useUser';
-import React from "react";
+import KeySection from '../components/forms/KeySection';
+import BinanceKeySection from '../components/forms/BinanceKeySection';
 
 interface IndexDetails {
     id: string;
@@ -14,7 +17,6 @@ interface IndexDetails {
     minTokenBAllocation: number;
     risk: string;
     rebalance: string;
-    model: string;
     agentInstructions: string;
 }
 
@@ -29,10 +31,52 @@ export default function ViewIndex() {
         },
         enabled: !!id,
     });
+    const aiKeyQuery = useQuery<string | null>({
+        queryKey: ['ai-key', user?.id],
+        enabled: !!user,
+        queryFn: async () => {
+            try {
+                const res = await api.get(`/users/${user!.id}/ai-key`);
+                return res.data.key as string;
+            } catch (err) {
+                if (axios.isAxiosError(err) && err.response?.status === 404) return null;
+                throw err;
+            }
+        },
+    });
+    const hasOpenAIKey = !!aiKeyQuery.data;
+    const binanceKeyQuery = useQuery<string | null>({
+        queryKey: ['binance-key', user?.id],
+        enabled: !!user,
+        queryFn: async () => {
+            try {
+                const res = await api.get(`/users/${user!.id}/binance-key`);
+                return res.data.key as string;
+            } catch (err) {
+                if (axios.isAxiosError(err) && err.response?.status === 404) return null;
+                throw err;
+            }
+        },
+    });
+    const hasBinanceKey = !!binanceKeyQuery.data;
+    const modelsQuery = useQuery<string[]>({
+        queryKey: ['openai-models', user?.id],
+        enabled: !!user && hasOpenAIKey,
+        queryFn: async () => {
+            const res = await api.get(`/users/${user!.id}/models`);
+            return res.data.models as string[];
+        },
+    });
+    const [model, setModel] = useState('');
+    useEffect(() => {
+        if (modelsQuery.data && modelsQuery.data.length) {
+            setModel(modelsQuery.data[0]);
+        }
+    }, [modelsQuery.data]);
 
     const balanceA = useQuery({
         queryKey: ['binance-balance', user?.id, data?.tokenA?.toUpperCase()],
-        enabled: !!user && !!data?.tokenA,
+        enabled: !!user && hasBinanceKey && !!data?.tokenA,
         queryFn: async () => {
             const res = await api.get(
                 `/users/${user!.id}/binance-balance/${data!.tokenA.toUpperCase()}`,
@@ -44,7 +88,7 @@ export default function ViewIndex() {
 
     const balanceB = useQuery({
         queryKey: ['binance-balance', user?.id, data?.tokenB?.toUpperCase()],
-        enabled: !!user && !!data?.tokenB,
+        enabled: !!user && hasBinanceKey && !!data?.tokenB,
         queryFn: async () => {
             const res = await api.get(
                 `/users/${user!.id}/binance-balance/${data!.tokenB.toUpperCase()}`,
@@ -56,7 +100,7 @@ export default function ViewIndex() {
 
     if (!data) return <div className="p-4">Loading...</div>;
 
-    function WarningSign({children}: { children: React.ReactNode }) {
+    function WarningSign({children}: { children: ReactNode }) {
         return (
             <div className="mt-2 p-4 text-sm text-red-600 border border-red-600 rounded bg-red-100">
                 <div>{children}</div>
@@ -87,9 +131,33 @@ export default function ViewIndex() {
             <p>
                 <strong>Rebalance Frequency:</strong> {data.rebalance}
             </p>
-            <p>
-                <strong>AI Model:</strong> {data.model}
-            </p>
+            {user && !hasOpenAIKey && (
+                <div className="mt-4">
+                    <KeySection label=""/>
+                </div>
+            )}
+            {user && hasOpenAIKey && modelsQuery.data && modelsQuery.data.length > 0 && (
+                <div className="mt-4">
+                    <label className="block text-sm font-medium mb-1" htmlFor="model">Model</label>
+                    <select
+                        id="model"
+                        value={model}
+                        onChange={(e) => setModel(e.target.value)}
+                        className="border rounded p-2"
+                    >
+                        {modelsQuery.data.map((m) => (
+                            <option key={m} value={m}>
+                                {m}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+            )}
+            {user && !hasBinanceKey && (
+                <div className="mt-4">
+                    <BinanceKeySection label=""/>
+                </div>
+            )}
             <div className="mt-4">
                 <h2 className="text-xl font-bold mb-2">Trading Agent Instructions</h2>
                 <pre className="whitespace-pre-wrap">{data.agentInstructions}</pre>
@@ -116,9 +184,24 @@ export default function ViewIndex() {
                     <strong>DON&#39;T MOVE FUNDS ON SPOT WALLET DURING TRADING!</strong> It will confuse the trading
                     agent and may lead to unexpected results.
                 </WarningSign>
+                {!user && (
+                    <p className="text-sm text-gray-600 mb-2 mt-4">Log in to continue</p>
+                )}
                 <button
-                    className="mt-4 px-4 py-2 bg-blue-600 text-white rounded"
-                    onClick={() => console.log('Start trading')}
+                    className={`mt-4 px-4 py-2 rounded ${
+                        user && hasOpenAIKey && hasBinanceKey && modelsQuery.data?.length
+                            ? 'bg-blue-600 text-white'
+                            : 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                    }`}
+                    disabled={!user || !hasOpenAIKey || !hasBinanceKey || !modelsQuery.data?.length}
+                    onClick={async () => {
+                        if (!user) return;
+                        await api.post('/index-agents', {
+                            templateId: id,
+                            userId: user.id,
+                            model,
+                        });
+                    }}
                 >
                     Start trading
                 </button>

--- a/frontend/src/routes/ViewIndex.tsx
+++ b/frontend/src/routes/ViewIndex.tsx
@@ -24,12 +24,14 @@ export default function ViewIndex() {
     const {id} = useParams();
     const {user} = useUser();
     const {data} = useQuery({
-        queryKey: ['index-template', id],
+        queryKey: ['index-template', id, user?.id],
         queryFn: async () => {
-            const res = await api.get(`/index-templates/${id}`);
+            const res = await api.get(`/index-templates/${id}`, {
+                headers: {'x-user-id': user!.id},
+            });
             return res.data as IndexDetails;
         },
-        enabled: !!id,
+        enabled: !!id && !!user,
     });
     const aiKeyQuery = useQuery<string | null>({
         queryKey: ['ai-key', user?.id],
@@ -196,11 +198,15 @@ export default function ViewIndex() {
                     disabled={!user || !hasOpenAIKey || !hasBinanceKey || !modelsQuery.data?.length}
                     onClick={async () => {
                         if (!user) return;
-                        await api.post('/index-agents', {
-                            templateId: id,
-                            userId: user.id,
-                            model,
-                        });
+                        await api.post(
+                            '/index-agents',
+                            {
+                                templateId: id,
+                                userId: user.id,
+                                model,
+                            },
+                            {headers: {'x-user-id': user.id}}
+                        );
                     }}
                 >
                     Start trading


### PR DESCRIPTION
## Summary
- Move `model` from index templates to agents and validate API keys on agent creation
- Simplify index template API and form so templates can be saved without keys
- Let template view handle OpenAI/Binance keys and model selection before starting an agent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a034268f10832c89c39a9e7d78b443