### PR TITLE
Add labels for API key sections on template view

### DIFF
--- a/frontend/src/routes/ViewIndex.tsx
+++ b/frontend/src/routes/ViewIndex.tsx
@@ -139,7 +139,7 @@ export default function ViewIndex() {
             </div>
             {user && !hasOpenAIKey && (
                 <div className="mt-4">
-                    <KeySection label=""/>
+                    <KeySection label="OpenAI API Key"/>
                 </div>
             )}
             {user && hasOpenAIKey && modelsQuery.data && modelsQuery.data.length > 0 && (
@@ -161,7 +161,7 @@ export default function ViewIndex() {
             )}
             {user && !hasBinanceKey && (
                 <div className="mt-4">
-                    <BinanceKeySection label=""/>
+                    <BinanceKeySection label="Binance API Credentials"/>
                 </div>
             )}
 


### PR DESCRIPTION
## Summary
- Show "OpenAI API Key" label when prompting for AI key on index templates without a saved key
- Show "Binance API Credentials" label when prompting for Binance keys on index templates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a03a92c5c4832cb8e08b3e54287282