### PR TITLE
Refactor index form inputs into reusable components

### DIFF
--- a/frontend/src/components/forms/IndexForm.tsx
+++ b/frontend/src/components/forms/IndexForm.tsx
@@ -7,6 +7,8 @@ import api from '../../lib/axios';
 import {useUser} from '../../lib/useUser';
 import {normalizeAllocations} from '../../lib/allocations';
 import TokenSelect from './TokenSelect';
+import TextInput from './TextInput';
+import SelectInput from './SelectInput';
 
 const schema = z
     .object({
@@ -42,6 +44,22 @@ const tokens = [
     {value: 'ETH', label: 'ETH'},
     {value: 'SOL', label: 'SOL'},
     {value: 'USDT', label: 'USDT'},
+];
+
+const riskOptions = [
+    {value: 'low', label: 'Low'},
+    {value: 'medium', label: 'Medium'},
+    {value: 'high', label: 'High'},
+];
+
+const rebalanceOptions = [
+    {value: '1h', label: '1 hour'},
+    {value: '3h', label: '3 hours'},
+    {value: '5h', label: '5 hours'},
+    {value: '12h', label: '12 hours'},
+    {value: '24h', label: '1 day'},
+    {value: '3d', label: '3 days'},
+    {value: '1w', label: '1 week'},
 ];
 
 export default function IndexForm({
@@ -209,13 +227,25 @@ export default function IndexForm({
                         >
                             Min {tokenA.toUpperCase()} allocation
                         </label>
-                        <input
-                            id="minTokenAAllocation"
-                            type="number"
-                            {...register('minTokenAAllocation', {valueAsNumber: true})}
-                            min={0}
-                            max={100}
-                            className="w-full border rounded p-2"
+                        <Controller
+                            name="minTokenAAllocation"
+                            control={control}
+                            render={({field}) => (
+                                <TextInput
+                                    id="minTokenAAllocation"
+                                    type="number"
+                                    min={0}
+                                    max={100}
+                                    {...field}
+                                    onChange={(e) =>
+                                        field.onChange(
+                                            e.target.value === ''
+                                                ? ''
+                                                : Number(e.target.value)
+                                        )
+                                    }
+                                />
+                            )}
                         />
                     </div>
                     <div>
@@ -225,13 +255,25 @@ export default function IndexForm({
                         >
                             Min {tokenB.toUpperCase()} allocation
                         </label>
-                        <input
-                            id="minTokenBAllocation"
-                            type="number"
-                            {...register('minTokenBAllocation', {valueAsNumber: true})}
-                            min={0}
-                            max={100}
-                            className="w-full border rounded p-2"
+                        <Controller
+                            name="minTokenBAllocation"
+                            control={control}
+                            render={({field}) => (
+                                <TextInput
+                                    id="minTokenBAllocation"
+                                    type="number"
+                                    min={0}
+                                    max={100}
+                                    {...field}
+                                    onChange={(e) =>
+                                        field.onChange(
+                                            e.target.value === ''
+                                                ? ''
+                                                : Number(e.target.value)
+                                        )
+                                    }
+                                />
+                            )}
                         />
                     </div>
                 </div>
@@ -240,33 +282,35 @@ export default function IndexForm({
                         <label className="block text-sm font-medium mb-1" htmlFor="risk">
                             Risk Tolerance
                         </label>
-                        <select
-                            id="risk"
-                            {...register('risk')}
-                            className="w-full border rounded p-2"
-                        >
-                            <option value="low">Low</option>
-                            <option value="medium">Medium</option>
-                            <option value="high">High</option>
-                        </select>
+                        <Controller
+                            name="risk"
+                            control={control}
+                            render={({field}) => (
+                                <SelectInput
+                                    id="risk"
+                                    value={field.value}
+                                    onChange={field.onChange}
+                                    options={riskOptions}
+                                />
+                            )}
+                        />
                     </div>
                     <div>
                         <label className="block text-sm font-medium mb-1" htmlFor="rebalance">
                             Rebalance Frequency
                         </label>
-                        <select
-                            id="rebalance"
-                            {...register('rebalance')}
-                            className="w-full border rounded p-2"
-                        >
-                            <option value="1h">1 hour</option>
-                            <option value="3h">3 hours</option>
-                            <option value="5h">5 hours</option>
-                            <option value="12h">12 hours</option>
-                            <option value="24h">1 day</option>
-                            <option value="3d">3 days</option>
-                            <option value="1w">1 week</option>
-                        </select>
+                        <Controller
+                            name="rebalance"
+                            control={control}
+                            render={({field}) => (
+                                <SelectInput
+                                    id="rebalance"
+                                    value={field.value}
+                                    onChange={field.onChange}
+                                    options={rebalanceOptions}
+                                />
+                            )}
+                        />
                     </div>
                 </div>
                 <div>
@@ -279,7 +323,7 @@ export default function IndexForm({
                     <textarea
                         id="agentInstructions"
                         {...register('agentInstructions')}
-                        className="w-full border rounded p-2 h-32"
+                        className="w-full border rounded p-2 h-28"
                     />
                 </div>
                 {!user && (
@@ -294,7 +338,7 @@ export default function IndexForm({
                     }`}
                     disabled={!user || isSubmitting}
                 >
-                    Save template
+                    Save Template
                 </button>
             </form>
         </>

--- a/frontend/src/components/forms/SelectInput.tsx
+++ b/frontend/src/components/forms/SelectInput.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+
+interface Option {
+  value: string;
+  label: string;
+}
+
+export default function SelectInput({
+  value,
+  onChange,
+  options,
+  id,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  options: Option[];
+  id: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const selected = options.find((o) => o.value === value);
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        id={id}
+        onClick={() => setOpen(!open)}
+        className="w-full border rounded px-2 py-1 flex items-center justify-between"
+      >
+        <span className={selected ? '' : 'text-gray-500'}>
+          {selected ? selected.label : 'Select'}
+        </span>
+        <span className="ml-2">▾</span>
+      </button>
+      {open && (
+        <ul className="absolute z-10 w-full bg-white border rounded mt-1 max-h-40 overflow-auto">
+          {options.map((opt) => (
+            <li key={opt.value}>
+              <button
+                type="button"
+                className="w-full text-left px-2 py-1 hover:bg-gray-100"
+                onClick={() => {
+                  onChange(opt.value);
+                  setOpen(false);
+                }}
+              >
+                {opt.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/forms/TextInput.tsx
+++ b/frontend/src/components/forms/TextInput.tsx
@@ -1,0 +1,7 @@
+import { forwardRef, InputHTMLAttributes } from 'react';
+
+const TextInput = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(function TextInput({ className = '', ...props }, ref) {
+  return <input ref={ref} className={`w-full border rounded px-2 py-1 ${className}`} {...props} />;
+});
+
+export default TextInput;


### PR DESCRIPTION
## Summary
- Extract reusable `TextInput` to match token select height
- Add generic `SelectInput` for risk tolerance and rebalance frequency
- Tweak index form instructions height and rename submit button to **Save Template**

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a03c2ffca4832caabc7e3a5f0ce2cc