### PR TITLE
feat: reusable AI API key input

### DIFF
--- a/frontend/src/components/forms/AiApiKeySection.tsx
+++ b/frontend/src/components/forms/AiApiKeySection.tsx
@@ -73,12 +73,15 @@ export default function AiApiKeySection({ label }: { label: string }) {
       ) : editing ? (
         <div className="space-y-2">
           <input
-            type="password"
-            autoComplete="new-password"
+            type="text"
+            autoComplete="off"
             {...form.register('key', { required: true, minLength: 10 })}
             className="border rounded p-2 w-full h-10"
+            style={{ WebkitTextSecurity: 'disc' }}
+            data-lpignore="true"
+            data-1p-ignore="true"
           />
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-gray-600 space-x-2">
             <a
               href="https://platform.openai.com/account/api-keys"
               target="_blank"
@@ -86,6 +89,14 @@ export default function AiApiKeySection({ label }: { label: string }) {
               className="text-blue-600 underline"
             >
               How to create an API key
+            </a>
+            <a
+              href="https://www.youtube.com/watch?v=WjVf80HUvYg"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 underline"
+            >
+              Video guide
             </a>
           </p>
           {form.formState.errors.key && (
@@ -123,10 +134,13 @@ export default function AiApiKeySection({ label }: { label: string }) {
       ) : (
         <div className="flex gap-2">
           <input
-            type="password"
+            type="text"
             value={query.data ?? ''}
             disabled
             className="border rounded p-2 w-full h-10"
+            style={{ WebkitTextSecurity: 'disc' }}
+            data-lpignore="true"
+            data-1p-ignore="true"
           />
           <button
             type="button"

--- a/frontend/src/components/forms/AiApiKeySection.tsx
+++ b/frontend/src/components/forms/AiApiKeySection.tsx
@@ -5,7 +5,7 @@ import axios from 'axios';
 import api from '../../lib/axios';
 import { useUser } from '../../lib/useUser';
 
-export default function KeySection({ label }: { label: string }) {
+export default function AiApiKeySection({ label }: { label: string }) {
   const { user } = useUser();
   const form = useForm<{ key: string }>({
     defaultValues: { key: '' },
@@ -73,10 +73,21 @@ export default function KeySection({ label }: { label: string }) {
       ) : editing ? (
         <div className="space-y-2">
           <input
-            type="text"
+            type="password"
+            autoComplete="new-password"
             {...form.register('key', { required: true, minLength: 10 })}
-            className="border rounded p-2 w-full"
+            className="border rounded p-2 w-full h-10"
           />
+          <p className="text-sm text-gray-600">
+            <a
+              href="https://platform.openai.com/account/api-keys"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 underline"
+            >
+              How to create an API key
+            </a>
+          </p>
           {form.formState.errors.key && (
             <p className="text-sm text-red-600">
               {form.formState.errors.key.type === 'required'
@@ -112,10 +123,10 @@ export default function KeySection({ label }: { label: string }) {
       ) : (
         <div className="flex gap-2">
           <input
-            type="text"
+            type="password"
             value={query.data ?? ''}
             disabled
-            className="border rounded p-2 w-full"
+            className="border rounded p-2 w-full h-10"
           />
           <button
             type="button"

--- a/frontend/src/components/forms/AiApiKeySection.tsx
+++ b/frontend/src/components/forms/AiApiKeySection.tsx
@@ -66,7 +66,7 @@ export default function AiApiKeySection({ label }: { label: string }) {
   const buttonsDisabled = !form.formState.isValid;
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-2 w-full max-w-md">
       {label && <h2 className="text-lg font-bold">{label}</h2>}
       {query.isLoading ? (
         <p>Loading...</p>
@@ -76,7 +76,7 @@ export default function AiApiKeySection({ label }: { label: string }) {
             type="text"
             autoComplete="off"
             {...form.register('key', { required: true, minLength: 10 })}
-            className="border rounded p-2 w-full h-10"
+            className="border rounded px-2 py-1 w-full"
             style={{ WebkitTextSecurity: 'disc' }}
             data-lpignore="true"
             data-1p-ignore="true"
@@ -111,7 +111,7 @@ export default function AiApiKeySection({ label }: { label: string }) {
               type="button"
               onClick={onSubmit}
               disabled={buttonsDisabled}
-              className={`bg-blue-600 text-white px-4 py-2 rounded ${
+              className={`bg-blue-600 text-white px-2 py-1 rounded ${
                 buttonsDisabled ? 'opacity-50 cursor-not-allowed' : ''
               }`}
             >
@@ -124,7 +124,7 @@ export default function AiApiKeySection({ label }: { label: string }) {
                   setEditing(false);
                   form.setValue('key', query.data ?? '');
                 }}
-                className="bg-gray-300 px-4 py-2 rounded"
+                className="bg-gray-300 px-2 py-1 rounded"
               >
                 Cancel
               </button>
@@ -137,7 +137,7 @@ export default function AiApiKeySection({ label }: { label: string }) {
             type="text"
             value={query.data ?? ''}
             disabled
-            className="border rounded p-2 w-full h-10"
+            className="border rounded px-2 py-1 w-full"
             style={{ WebkitTextSecurity: 'disc' }}
             data-lpignore="true"
             data-1p-ignore="true"
@@ -148,14 +148,14 @@ export default function AiApiKeySection({ label }: { label: string }) {
               setEditing(true);
               form.setValue('key', '');
             }}
-            className="bg-blue-600 text-white px-4 py-2 rounded"
+            className="bg-blue-600 text-white px-2 py-1 rounded"
           >
             Edit
           </button>
           <button
             type="button"
             onClick={() => delMut.mutate()}
-            className="bg-red-600 text-white px-4 py-2 rounded"
+            className="bg-red-600 text-white px-2 py-1 rounded"
           >
             Delete
           </button>

--- a/frontend/src/components/forms/AiApiKeySection.tsx
+++ b/frontend/src/components/forms/AiApiKeySection.tsx
@@ -67,7 +67,7 @@ export default function AiApiKeySection({ label }: { label: string }) {
 
   return (
     <div className="space-y-2 w-full max-w-md">
-      {label && <h2 className="text-lg font-bold">{label}</h2>}
+      {label && <h2 className="text-md font-bold">{label}</h2>}
       {query.isLoading ? (
         <p>Loading...</p>
       ) : editing ? (
@@ -82,14 +82,6 @@ export default function AiApiKeySection({ label }: { label: string }) {
             data-1p-ignore="true"
           />
           <p className="text-sm text-gray-600 space-x-2">
-            <a
-              href="https://platform.openai.com/account/api-keys"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-600 underline"
-            >
-              How to create an API key
-            </a>
             <a
               href="https://www.youtube.com/watch?v=WjVf80HUvYg"
               target="_blank"

--- a/frontend/src/routes/Settings.tsx
+++ b/frontend/src/routes/Settings.tsx
@@ -1,5 +1,5 @@
 import { useUser } from '../lib/useUser';
-import KeySection from '../components/forms/KeySection';
+import AiApiKeySection from '../components/forms/AiApiKeySection';
 import BinanceKeySection from '../components/forms/BinanceKeySection';
 
 export default function Settings() {
@@ -7,7 +7,7 @@ export default function Settings() {
   if (!user) return <p>Please log in.</p>;
   return (
     <div className="space-y-8 max-w-md">
-      <KeySection label="OpenAI API Key" />
+      <AiApiKeySection label="OpenAI API Key" />
       <BinanceKeySection label="Binance API Credentials" />
     </div>
   );

--- a/frontend/src/routes/ViewIndex.tsx
+++ b/frontend/src/routes/ViewIndex.tsx
@@ -4,7 +4,7 @@ import {useQuery} from '@tanstack/react-query';
 import axios from 'axios';
 import api from '../lib/axios';
 import {useUser} from '../lib/useUser';
-import KeySection from '../components/forms/KeySection';
+import AiApiKeySection from '../components/forms/AiApiKeySection';
 import BinanceKeySection from '../components/forms/BinanceKeySection';
 
 interface IndexDetails {
@@ -139,7 +139,7 @@ export default function ViewIndex() {
             </div>
             {user && !hasOpenAIKey && (
                 <div className="mt-4">
-                    <KeySection label="OpenAI API Key"/>
+                    <AiApiKeySection label="OpenAI API Key"/>
                 </div>
             )}
             {user && hasOpenAIKey && modelsQuery.data && modelsQuery.data.length > 0 && (


### PR DESCRIPTION
## Summary
- add reusable AI API key section with password-style input and link to OpenAI docs
- use new component for managing OpenAI key in settings and template view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a049c4d5b0832caeea89ee64d5da9c