### PR TITLE
feat: add reusable exchange api key component

### DIFF
--- a/frontend/src/components/forms/AiApiKeySection.tsx
+++ b/frontend/src/components/forms/AiApiKeySection.tsx
@@ -1,9 +1,13 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type CSSProperties } from 'react';
 import { useForm } from 'react-hook-form';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import axios from 'axios';
 import api from '../../lib/axios';
 import { useUser } from '../../lib/useUser';
+
+const textSecurityStyle: CSSProperties & { WebkitTextSecurity: string } = {
+  WebkitTextSecurity: 'disc',
+};
 
 export default function AiApiKeySection({ label }: { label: string }) {
   const { user } = useUser();
@@ -79,7 +83,7 @@ export default function AiApiKeySection({ label }: { label: string }) {
             placeholder="API key"
             {...form.register('key', { required: true, minLength: 10 })}
             className="border rounded px-2 py-1 w-full"
-            style={{ WebkitTextSecurity: keyValue ? 'disc' : 'none' }}
+            style={keyValue ? textSecurityStyle : undefined}
             data-lpignore="true"
             data-1p-ignore="true"
           />
@@ -132,7 +136,7 @@ export default function AiApiKeySection({ label }: { label: string }) {
             value={query.data ?? ''}
             disabled
             className="border rounded px-2 py-1 w-full"
-            style={{ WebkitTextSecurity: 'disc' }}
+            style={textSecurityStyle}
             data-lpignore="true"
             data-1p-ignore="true"
           />

--- a/frontend/src/components/forms/AiApiKeySection.tsx
+++ b/frontend/src/components/forms/AiApiKeySection.tsx
@@ -11,6 +11,7 @@ export default function AiApiKeySection({ label }: { label: string }) {
     defaultValues: { key: '' },
     mode: 'onChange',
   });
+  const keyValue = form.watch('key');
   const id = user!.id;
   const query = useQuery<string | null>({
     queryKey: ['ai-key', id],
@@ -75,9 +76,10 @@ export default function AiApiKeySection({ label }: { label: string }) {
           <input
             type="text"
             autoComplete="off"
+            placeholder="API key"
             {...form.register('key', { required: true, minLength: 10 })}
             className="border rounded px-2 py-1 w-full"
-            style={{ WebkitTextSecurity: 'disc' }}
+            style={{ WebkitTextSecurity: keyValue ? 'disc' : 'none' }}
             data-lpignore="true"
             data-1p-ignore="true"
           />

--- a/frontend/src/components/forms/ExchangeApiKeySection.tsx
+++ b/frontend/src/components/forms/ExchangeApiKeySection.tsx
@@ -16,6 +16,8 @@ export default function ExchangeApiKeySection({ exchange, label }: Props) {
     defaultValues: { key: '', secret: '' },
     mode: 'onChange',
   });
+  const keyValue = form.watch('key');
+  const secretValue = form.watch('secret');
   const id = user!.id;
   const keyPath = `/users/${id}/${exchange}-key`;
   const balancePath = `/users/${id}/${exchange}-balance`;
@@ -93,18 +95,20 @@ export default function ExchangeApiKeySection({ exchange, label }: Props) {
           <input
             type="text"
             autoComplete="off"
+            placeholder="API key"
             {...form.register('key', { required: true, minLength: 10 })}
             className="border rounded px-2 py-1 w-full"
-            style={{ WebkitTextSecurity: 'disc' }}
+            style={{ WebkitTextSecurity: keyValue ? 'disc' : 'none' }}
             data-lpignore="true"
             data-1p-ignore="true"
           />
           <input
             type="text"
             autoComplete="off"
+            placeholder="API secret"
             {...form.register('secret', { required: true, minLength: 10 })}
             className="border rounded px-2 py-1 w-full"
-            style={{ WebkitTextSecurity: 'disc' }}
+            style={{ WebkitTextSecurity: secretValue ? 'disc' : 'none' }}
             data-lpignore="true"
             data-1p-ignore="true"
           />

--- a/frontend/src/components/forms/ExchangeApiKeySection.tsx
+++ b/frontend/src/components/forms/ExchangeApiKeySection.tsx
@@ -84,23 +84,29 @@ export default function ExchangeApiKeySection({ exchange, label }: Props) {
   const buttonsDisabled = !form.formState.isValid;
 
   return (
-    <div className="space-y-2">
-      {label && <h2 className="text-lg font-bold">{label}</h2>}
+    <div className="space-y-2 w-full max-w-md">
+      {label && <h2 className="text-md font-bold">{label}</h2>}
       {query.isLoading ? (
         <p>Loading...</p>
       ) : editing ? (
         <div className="space-y-2">
           <input
             type="text"
-            placeholder="API Key"
+            autoComplete="off"
             {...form.register('key', { required: true, minLength: 10 })}
-            className="border rounded p-2 w-full"
+            className="border rounded px-2 py-1 w-full"
+            style={{ WebkitTextSecurity: 'disc' }}
+            data-lpignore="true"
+            data-1p-ignore="true"
           />
           <input
             type="text"
-            placeholder="API Secret"
+            autoComplete="off"
             {...form.register('secret', { required: true, minLength: 10 })}
-            className="border rounded p-2 w-full"
+            className="border rounded px-2 py-1 w-full"
+            style={{ WebkitTextSecurity: 'disc' }}
+            data-lpignore="true"
+            data-1p-ignore="true"
           />
           {(form.formState.errors.key || form.formState.errors.secret) && (
             <p className="text-sm text-red-600">
@@ -112,7 +118,7 @@ export default function ExchangeApiKeySection({ exchange, label }: Props) {
               type="button"
               onClick={onSubmit}
               disabled={buttonsDisabled}
-              className={`bg-blue-600 text-white px-4 py-2 rounded ${
+              className={`bg-blue-600 text-white px-2 py-1 rounded ${
                 buttonsDisabled ? 'opacity-50 cursor-not-allowed' : ''
               }`}
             >
@@ -125,7 +131,7 @@ export default function ExchangeApiKeySection({ exchange, label }: Props) {
                   setEditing(false);
                   form.reset(query.data ?? { key: '', secret: '' });
                 }}
-                className="bg-gray-300 px-4 py-2 rounded"
+                className="bg-gray-300 px-2 py-1 rounded"
               >
                 Cancel
               </button>
@@ -139,7 +145,10 @@ export default function ExchangeApiKeySection({ exchange, label }: Props) {
               type="text"
               value={query.data?.key ?? ''}
               disabled
-              className="border rounded p-2 w-full"
+              className="border rounded px-2 py-1 w-full"
+              style={{ WebkitTextSecurity: 'disc' }}
+              data-lpignore="true"
+              data-1p-ignore="true"
             />
             <button
               type="button"
@@ -147,14 +156,14 @@ export default function ExchangeApiKeySection({ exchange, label }: Props) {
                 setEditing(true);
                 form.reset({ key: '', secret: '' });
               }}
-              className="bg-blue-600 text-white px-4 py-2 rounded"
+              className="bg-blue-600 text-white px-2 py-1 rounded"
             >
               Edit
             </button>
             <button
               type="button"
               onClick={() => delMut.mutate()}
-              className="bg-red-600 text-white px-4 py-2 rounded"
+              className="bg-red-600 text-white px-2 py-1 rounded"
             >
               Delete
             </button>

--- a/frontend/src/components/forms/ExchangeApiKeySection.tsx
+++ b/frontend/src/components/forms/ExchangeApiKeySection.tsx
@@ -1,9 +1,13 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type CSSProperties } from 'react';
 import { useForm } from 'react-hook-form';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import axios from 'axios';
 import api from '../../lib/axios';
 import { useUser } from '../../lib/useUser';
+
+const textSecurityStyle: CSSProperties & { WebkitTextSecurity: string } = {
+  WebkitTextSecurity: 'disc',
+};
 
 interface Props {
   exchange: string;
@@ -98,7 +102,7 @@ export default function ExchangeApiKeySection({ exchange, label }: Props) {
             placeholder="API key"
             {...form.register('key', { required: true, minLength: 10 })}
             className="border rounded px-2 py-1 w-full"
-            style={{ WebkitTextSecurity: keyValue ? 'disc' : 'none' }}
+            style={keyValue ? textSecurityStyle : undefined}
             data-lpignore="true"
             data-1p-ignore="true"
           />
@@ -108,7 +112,7 @@ export default function ExchangeApiKeySection({ exchange, label }: Props) {
             placeholder="API secret"
             {...form.register('secret', { required: true, minLength: 10 })}
             className="border rounded px-2 py-1 w-full"
-            style={{ WebkitTextSecurity: secretValue ? 'disc' : 'none' }}
+            style={secretValue ? textSecurityStyle : undefined}
             data-lpignore="true"
             data-1p-ignore="true"
           />
@@ -150,7 +154,7 @@ export default function ExchangeApiKeySection({ exchange, label }: Props) {
               value={query.data?.key ?? ''}
               disabled
               className="border rounded px-2 py-1 w-full"
-              style={{ WebkitTextSecurity: 'disc' }}
+              style={textSecurityStyle}
               data-lpignore="true"
               data-1p-ignore="true"
             />

--- a/frontend/src/components/forms/TextInput.tsx
+++ b/frontend/src/components/forms/TextInput.tsx
@@ -1,4 +1,5 @@
-import { forwardRef, InputHTMLAttributes } from 'react';
+import { forwardRef } from 'react';
+import type { InputHTMLAttributes } from 'react';
 
 const TextInput = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(function TextInput({ className = '', ...props }, ref) {
   return <input ref={ref} className={`w-full border rounded px-2 py-1 ${className}`} {...props} />;

--- a/frontend/src/routes/Settings.tsx
+++ b/frontend/src/routes/Settings.tsx
@@ -1,6 +1,6 @@
 import { useUser } from '../lib/useUser';
 import AiApiKeySection from '../components/forms/AiApiKeySection';
-import BinanceKeySection from '../components/forms/BinanceKeySection';
+import ExchangeApiKeySection from '../components/forms/ExchangeApiKeySection';
 
 export default function Settings() {
   const { user } = useUser();
@@ -8,7 +8,7 @@ export default function Settings() {
   return (
     <div className="space-y-8 max-w-md">
       <AiApiKeySection label="OpenAI API Key" />
-      <BinanceKeySection label="Binance API Credentials" />
+      <ExchangeApiKeySection exchange="binance" label="Binance API Credentials" />
     </div>
   );
 }

--- a/frontend/src/routes/ViewIndex.tsx
+++ b/frontend/src/routes/ViewIndex.tsx
@@ -6,7 +6,7 @@ import axios from 'axios';
 import api from '../lib/axios';
 import {useUser} from '../lib/useUser';
 import AiApiKeySection from '../components/forms/AiApiKeySection';
-import BinanceKeySection from '../components/forms/BinanceKeySection';
+import ExchangeApiKeySection from '../components/forms/ExchangeApiKeySection';
 
 interface IndexDetails {
     id: string;
@@ -162,7 +162,7 @@ export default function ViewIndex() {
             )}
             {user && !hasBinanceKey && (
                 <div className="mt-4">
-                    <BinanceKeySection label="Binance API Credentials"/>
+                    <ExchangeApiKeySection exchange="binance" label="Binance API Credentials"/>
                 </div>
             )}
 


### PR DESCRIPTION
## Summary
- add ExchangeApiKeySection component to manage API keys for different exchanges
- replace BinanceKeySection usage in settings and index views

## Testing
- `npm test`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0556f7cc8832c97ab2bbf0f110877