### PR TITLE
Disable API key actions during pending requests

### DIFF
--- a/frontend/src/components/forms/AiApiKeySection.tsx
+++ b/frontend/src/components/forms/AiApiKeySection.tsx
@@ -68,7 +68,7 @@ export default function AiApiKeySection({ label }: { label: string }) {
   });
 
   const onSubmit = form.handleSubmit((data) => saveMut.mutate(data.key));
-  const buttonsDisabled = !form.formState.isValid;
+  const saveDisabled = !form.formState.isValid || saveMut.isPending;
 
   return (
     <div className="space-y-2 w-full max-w-md">
@@ -108,9 +108,9 @@ export default function AiApiKeySection({ label }: { label: string }) {
             <button
               type="button"
               onClick={onSubmit}
-              disabled={buttonsDisabled}
+              disabled={saveDisabled}
               className={`bg-blue-600 text-white px-2 py-1 rounded ${
-                buttonsDisabled ? 'opacity-50 cursor-not-allowed' : ''
+                saveDisabled ? 'opacity-50 cursor-not-allowed' : ''
               }`}
             >
               {query.data ? 'Update' : 'Save'}
@@ -122,7 +122,10 @@ export default function AiApiKeySection({ label }: { label: string }) {
                   setEditing(false);
                   form.setValue('key', query.data ?? '');
                 }}
-                className="bg-gray-300 px-2 py-1 rounded"
+                disabled={saveMut.isPending}
+                className={`bg-gray-300 px-2 py-1 rounded ${
+                  saveMut.isPending ? 'opacity-50 cursor-not-allowed' : ''
+                }`}
               >
                 Cancel
               </button>
@@ -146,14 +149,20 @@ export default function AiApiKeySection({ label }: { label: string }) {
               setEditing(true);
               form.setValue('key', '');
             }}
-            className="bg-blue-600 text-white px-2 py-1 rounded"
+            disabled={delMut.isPending}
+            className={`bg-blue-600 text-white px-2 py-1 rounded ${
+              delMut.isPending ? 'opacity-50 cursor-not-allowed' : ''
+            }`}
           >
             Edit
           </button>
           <button
             type="button"
             onClick={() => delMut.mutate()}
-            className="bg-red-600 text-white px-2 py-1 rounded"
+            disabled={delMut.isPending}
+            className={`bg-red-600 text-white px-2 py-1 rounded ${
+              delMut.isPending ? 'opacity-50 cursor-not-allowed' : ''
+            }`}
           >
             Delete
           </button>

--- a/frontend/src/components/forms/ExchangeApiKeySection.tsx
+++ b/frontend/src/components/forms/ExchangeApiKeySection.tsx
@@ -91,7 +91,7 @@ export default function ExchangeApiKeySection({ exchange, label }: Props) {
   });
 
   const onSubmit = form.handleSubmit((data) => saveMut.mutate(data));
-  const buttonsDisabled = !form.formState.isValid;
+  const saveDisabled = !form.formState.isValid || saveMut.isPending;
 
   return (
     <div className="space-y-2 w-full max-w-md">
@@ -141,9 +141,9 @@ export default function ExchangeApiKeySection({ exchange, label }: Props) {
             <button
               type="button"
               onClick={onSubmit}
-              disabled={buttonsDisabled}
+              disabled={saveDisabled}
               className={`bg-blue-600 text-white px-2 py-1 rounded ${
-                buttonsDisabled ? 'opacity-50 cursor-not-allowed' : ''
+                saveDisabled ? 'opacity-50 cursor-not-allowed' : ''
               }`}
             >
               {query.data ? 'Update' : 'Save'}
@@ -155,7 +155,10 @@ export default function ExchangeApiKeySection({ exchange, label }: Props) {
                   setEditing(false);
                   form.reset(query.data ?? { key: '', secret: '' });
                 }}
-                className="bg-gray-300 px-2 py-1 rounded"
+                disabled={saveMut.isPending}
+                className={`bg-gray-300 px-2 py-1 rounded ${
+                  saveMut.isPending ? 'opacity-50 cursor-not-allowed' : ''
+                }`}
               >
                 Cancel
               </button>
@@ -180,14 +183,20 @@ export default function ExchangeApiKeySection({ exchange, label }: Props) {
                 setEditing(true);
                 form.reset({ key: '', secret: '' });
               }}
-              className="bg-blue-600 text-white px-2 py-1 rounded"
+              disabled={delMut.isPending}
+              className={`bg-blue-600 text-white px-2 py-1 rounded ${
+                delMut.isPending ? 'opacity-50 cursor-not-allowed' : ''
+              }`}
             >
               Edit
             </button>
             <button
               type="button"
               onClick={() => delMut.mutate()}
-              className="bg-red-600 text-white px-2 py-1 rounded"
+              disabled={delMut.isPending}
+              className={`bg-red-600 text-white px-2 py-1 rounded ${
+                delMut.isPending ? 'opacity-50 cursor-not-allowed' : ''
+              }`}
             >
               Delete
             </button>


### PR DESCRIPTION
## Summary
- Prevent AI API key buttons from sending multiple requests by disabling them while mutations run
- Block exchange API key actions during save or delete requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a062d71ffc832c85f8939e14ba18f8