### PR TITLE
feat: editable agent instructions

### DIFF
--- a/backend/test/indexTemplates.test.ts
+++ b/backend/test/indexTemplates.test.ts
@@ -71,6 +71,15 @@ describe('index template routes', () => {
     expect(res.json()).toMatchObject({ id, ...update });
 
     res = await app.inject({
+      method: 'PATCH',
+      url: `/api/index-templates/${id}/instructions`,
+      headers: { 'x-user-id': 'user1' },
+      payload: { userId: 'user1', agentInstructions: 'new prompt' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ id, agentInstructions: 'new prompt' });
+
+    res = await app.inject({
       method: 'DELETE',
       url: `/api/index-templates/${id}`,
       headers: { 'x-user-id': 'user1' },

--- a/frontend/src/components/TradingAgentInstructions.tsx
+++ b/frontend/src/components/TradingAgentInstructions.tsx
@@ -1,0 +1,78 @@
+import {useState, useEffect} from 'react';
+import {Pencil} from 'lucide-react';
+import {useUser} from '../lib/useUser';
+import api from '../lib/axios';
+
+interface Props {
+  templateId: string;
+  instructions: string;
+  onChange?: (text: string) => void;
+}
+
+export default function TradingAgentInstructions({templateId, instructions, onChange}: Props) {
+  const {user} = useUser();
+  const [editing, setEditing] = useState(false);
+  const [text, setText] = useState(instructions);
+
+  useEffect(() => {
+    setText(instructions);
+  }, [instructions]);
+
+  async function save() {
+    if (!user) return;
+    await api.patch(
+      `/index-templates/${templateId}/instructions`,
+      {userId: user.id, agentInstructions: text},
+      {headers: {'x-user-id': user.id}}
+    );
+    setEditing(false);
+    onChange?.(text);
+  }
+
+  return (
+    <div className="mt-4">
+      <div className="flex items-center mb-2">
+        <h2 className="text-xl font-bold flex-1">Trading Agent Instructions</h2>
+        {user && (
+          <button
+            aria-label="Edit"
+            className="text-gray-600"
+            onClick={() => setEditing((e) => !e)}
+          >
+            <Pencil className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+      {editing ? (
+        <div>
+          <textarea
+            className="w-full border rounded p-2"
+            rows={4}
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+          />
+          <div className="mt-2 flex gap-2">
+            <button
+              className="px-4 py-2 bg-blue-600 text-white rounded"
+              onClick={save}
+            >
+              Save
+            </button>
+            <button
+              className="px-4 py-2 border rounded"
+              onClick={() => {
+                setText(instructions);
+                setEditing(false);
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <pre className="whitespace-pre-wrap">{instructions}</pre>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/routes/ViewIndex.tsx
+++ b/frontend/src/routes/ViewIndex.tsx
@@ -7,6 +7,7 @@ import api from '../lib/axios';
 import {useUser} from '../lib/useUser';
 import AiApiKeySection from '../components/forms/AiApiKeySection';
 import ExchangeApiKeySection from '../components/forms/ExchangeApiKeySection';
+import TradingAgentInstructions from '../components/TradingAgentInstructions';
 
 interface IndexDetails {
     id: string;
@@ -71,11 +72,17 @@ export default function ViewIndex() {
         },
     });
     const [model, setModel] = useState('');
+    const [instructions, setInstructions] = useState('');
     useEffect(() => {
         if (modelsQuery.data && modelsQuery.data.length) {
             setModel(modelsQuery.data[0]);
         }
     }, [modelsQuery.data]);
+    useEffect(() => {
+        if (data?.agentInstructions) {
+            setInstructions(data.agentInstructions);
+        }
+    }, [data?.agentInstructions]);
 
     const balanceA = useQuery({
         queryKey: ['binance-balance', user?.id, data?.tokenA?.toUpperCase()],
@@ -137,10 +144,11 @@ export default function ViewIndex() {
             <p>
                 <strong>Rebalance Frequency:</strong> {data.rebalance}
             </p>
-            <div className="mt-4">
-                <h2 className="text-xl font-bold mb-2">Trading Agent Instructions</h2>
-                <pre className="whitespace-pre-wrap">{data.agentInstructions}</pre>
-            </div>
+            <TradingAgentInstructions
+                templateId={data.id}
+                instructions={instructions}
+                onChange={setInstructions}
+            />
             {user && !hasOpenAIKey && (
                 <div className="mt-4">
                     <AiApiKeySection label="OpenAI API Key"/>


### PR DESCRIPTION
## Summary
- allow editing trading agent instructions from template view
- add PATCH endpoint for updating instructions
- cover instruction updates with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a067259af8832c9b3bb9b6b762b489