### PR TITLE
Ensure dashboard agent list uses auth header

### DIFF
--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -20,6 +20,7 @@ export default function Dashboard() {
     queryFn: async () => {
       const res = await api.get('/index-agents/paginated', {
         params: { page, pageSize: 10, userId: user!.id },
+        headers: { 'x-user-id': user!.id },
       });
       return res.data as {
         items: IndexAgent[];


### PR DESCRIPTION
## Summary
- send `x-user-id` header when fetching paginated index agents on dashboard

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a071cafa08832c92b6ecd92173a13a