### PR TITLE
feat: add agent status labels and rename navigation

### DIFF
--- a/frontend/src/components/AgentStatusLabel.tsx
+++ b/frontend/src/components/AgentStatusLabel.tsx
@@ -1,0 +1,11 @@
+interface Props {
+  status: 'active' | 'inactive';
+}
+
+export default function AgentStatusLabel({ status }: Props) {
+  const base = 'px-2 py-1 rounded text-xs font-medium';
+  if (status === 'active') {
+    return <span className={`${base} bg-green-100 text-green-800`}>Active</span>;
+  }
+  return <span className={`${base} bg-gray-200 text-gray-800`}>Inactive</span>;
+}

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -25,7 +25,7 @@ export default function AppShell() {
       <div className="flex flex-1">
         <nav className="w-48 bg-gray-100 p-4">
           <Link to="/" className="block mb-2 text-gray-700 hover:text-gray-900">
-            Dashboard
+            Agents
           </Link>
           <Link to="/create-index" className="block mb-2 text-gray-700 hover:text-gray-900">
             Create Index

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -2,12 +2,13 @@ import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import api from '../lib/axios';
 import { useUser } from '../lib/useUser';
+import AgentStatusLabel from '../components/AgentStatusLabel';
 
 interface IndexAgent {
   id: string;
   templateId: string;
   userId: string;
-  status: string;
+  status: 'active' | 'inactive';
   createdAt: number;
 }
 
@@ -35,7 +36,7 @@ export default function Dashboard() {
   if (!user) {
     return (
       <div className="p-4">
-        <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+        <h1 className="text-2xl font-bold mb-4">My Agents</h1>
         <p>Please log in to view your agents.</p>
       </div>
     );
@@ -66,7 +67,9 @@ export default function Dashboard() {
                 <tr key={agent.id}>
                   <td>{agent.id}</td>
                   <td>{agent.templateId}</td>
-                  <td>{agent.status}</td>
+                  <td>
+                    <AgentStatusLabel status={agent.status} />
+                  </td>
                   <td>{new Date(agent.createdAt).toLocaleString()}</td>
                 </tr>
               ))}


### PR DESCRIPTION
## Summary
- add `AgentStatusLabel` component for inactive/active styling
- use new status labels on My Agents dashboard
- rename Dashboard menu item to Agents

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a080f68854832ca91d40327e42c346