### PR TITLE
Rename Settings to Keys and add sidebar icons

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 import AppShell from './components/layout/AppShell';
 import Dashboard from './routes/Dashboard';
 import AgentTemplates from './routes/AgentTemplates';
-import Settings from './routes/Settings';
+import Keys from './routes/Keys';
 import ViewAgentTemplate from './routes/ViewAgentTemplate';
 
 export default function App() {
@@ -11,7 +11,7 @@ export default function App() {
       <Route element={<AppShell />}>
         <Route path="/" element={<Dashboard />} />
         <Route path="/agent-templates" element={<AgentTemplates />} />
-        <Route path="/settings" element={<Settings />} />
+        <Route path="/keys" element={<Keys />} />
         <Route path="/agent-templates/:id" element={<ViewAgentTemplate />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Route>

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -2,6 +2,7 @@ import { Link, Outlet } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import axios from '../../lib/axios';
 import GoogleLoginButton from '../GoogleLoginButton';
+import { Bot, FileText, Key } from 'lucide-react';
 
 function ApiStatus() {
   const { isSuccess } = useQuery({
@@ -24,14 +25,17 @@ export default function AppShell() {
       </header>
       <div className="flex flex-1">
         <nav className="w-48 bg-gray-100 p-4">
-          <Link to="/" className="block mb-2 text-gray-700 hover:text-gray-900">
+          <Link to="/" className="flex items-center gap-2 mb-2 text-gray-700 hover:text-gray-900">
+            <Bot className="w-4 h-4" />
             Agents
           </Link>
-          <Link to="/agent-templates" className="block mb-2 text-gray-700 hover:text-gray-900">
+          <Link to="/agent-templates" className="flex items-center gap-2 mb-2 text-gray-700 hover:text-gray-900">
+            <FileText className="w-4 h-4" />
             Agent Templates
           </Link>
-          <Link to="/settings" className="block mb-2 text-gray-700 hover:text-gray-900">
-            Settings
+          <Link to="/keys" className="flex items-center gap-2 mb-2 text-gray-700 hover:text-gray-900">
+            <Key className="w-4 h-4" />
+            Keys
           </Link>
         </nav>
         <main className="flex-1 p-3 bg-white">

--- a/frontend/src/routes/Keys.tsx
+++ b/frontend/src/routes/Keys.tsx
@@ -2,7 +2,7 @@ import { useUser } from '../lib/useUser';
 import AiApiKeySection from '../components/forms/AiApiKeySection';
 import ExchangeApiKeySection from '../components/forms/ExchangeApiKeySection';
 
-export default function Settings() {
+export default function Keys() {
   const { user } = useUser();
   if (!user) return <p>Please log in.</p>;
   return (


### PR DESCRIPTION
## Summary
- rename Settings page and route to Keys
- show lucide-react icons alongside sidebar menu labels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0878a4f20832ca484153fbe9eff3f