### PR TITLE
Join agents with templates and add detailed agent views

### DIFF
--- a/backend/test/agents.test.ts
+++ b/backend/test/agents.test.ts
@@ -29,6 +29,7 @@ describe('agent routes', () => {
     });
     expect(res.statusCode).toBe(200);
     const id = res.json().id as string;
+    expect(res.json().template).toMatchObject({ tokenA: 'BTC', tokenB: 'ETH' });
 
     res = await app.inject({
       method: 'GET',
@@ -36,7 +37,7 @@ describe('agent routes', () => {
       headers: { 'x-user-id': 'user1' },
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toMatchObject({ id, ...payload });
+    expect(res.json()).toMatchObject({ id, ...payload, template: { tokenA: 'BTC', tokenB: 'ETH' } });
 
     res = await app.inject({
       method: 'GET',
@@ -45,6 +46,7 @@ describe('agent routes', () => {
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toHaveLength(1);
+    expect(res.json()[0].template).toMatchObject({ tokenA: 'BTC', tokenB: 'ETH' });
 
     res = await app.inject({
       method: 'GET',
@@ -54,6 +56,7 @@ describe('agent routes', () => {
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ total: 1, page: 1, pageSize: 10 });
     expect(res.json().items).toHaveLength(1);
+    expect(res.json().items[0].template).toMatchObject({ tokenA: 'BTC', tokenB: 'ETH' });
 
     const update = { templateId: 'tmpl1', userId: 'user1', model: 'o3', status: 'active' };
     res = await app.inject({
@@ -63,7 +66,7 @@ describe('agent routes', () => {
       payload: update,
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toMatchObject({ id, ...update });
+    expect(res.json()).toMatchObject({ id, ...update, template: { tokenA: 'BTC', tokenB: 'ETH' } });
 
     res = await app.inject({
       method: 'DELETE',

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import Dashboard from './routes/Dashboard';
 import AgentTemplates from './routes/AgentTemplates';
 import Keys from './routes/Keys';
 import ViewAgentTemplate from './routes/ViewAgentTemplate';
+import ViewAgent from './routes/ViewAgent';
 
 export default function App() {
   return (
@@ -13,6 +14,7 @@ export default function App() {
         <Route path="/agent-templates" element={<AgentTemplates />} />
         <Route path="/keys" element={<Keys />} />
         <Route path="/agent-templates/:id" element={<ViewAgentTemplate />} />
+        <Route path="/agents/:id" element={<ViewAgent />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Route>
     </Routes>

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
 import api from '../lib/axios';
 import { useUser } from '../lib/useUser';
 import AgentStatusLabel from '../components/AgentStatusLabel';
@@ -8,8 +9,14 @@ interface Agent {
   id: string;
   templateId: string;
   userId: string;
+  model: string;
   status: 'active' | 'inactive';
   createdAt: number;
+  template: {
+    tokenA: string;
+    tokenB: string;
+    risk: string;
+  };
 }
 
 export default function Dashboard() {
@@ -57,7 +64,8 @@ export default function Dashboard() {
             <thead>
               <tr>
                 <th className="text-left">Agent ID</th>
-                <th className="text-left">Template</th>
+                <th className="text-left">Pair</th>
+                <th className="text-left">Model</th>
                 <th className="text-left">Status</th>
                 <th className="text-left">Created</th>
               </tr>
@@ -65,8 +73,15 @@ export default function Dashboard() {
             <tbody>
               {items.map((agent) => (
                 <tr key={agent.id}>
-                  <td>{agent.id}</td>
-                  <td>{agent.templateId}</td>
+                  <td>
+                    <Link className="text-blue-600 underline" to={`/agents/${agent.id}`}>
+                      {agent.id}
+                    </Link>
+                  </td>
+                  <td>
+                    {agent.template.tokenA}/{agent.template.tokenB}
+                  </td>
+                  <td>{agent.model}</td>
                   <td>
                     <AgentStatusLabel status={agent.status} />
                   </td>

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
+import { Eye } from 'lucide-react';
 import api from '../lib/axios';
 import { useUser } from '../lib/useUser';
 import AgentStatusLabel from '../components/AgentStatusLabel';
@@ -68,6 +69,7 @@ export default function Dashboard() {
                 <th className="text-left">Pair</th>
                 <th className="text-left">Model</th>
                 <th className="text-left">Status</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -75,20 +77,27 @@ export default function Dashboard() {
                 <tr key={agent.id}>
                   <td>{new Date(agent.createdAt).toLocaleString()}</td>
                   <td>
-                    <Link className="text-blue-600 underline" to={`/agents/${agent.id}`}>
-                      {agent.template ? (
-                        <>
-                          <TokenDisplay token={agent.template.tokenA} />/
-                          <TokenDisplay token={agent.template.tokenB} />
-                        </>
-                      ) : (
-                        '-'
-                      )}
-                    </Link>
+                    {agent.template ? (
+                      <span className="inline-flex items-center gap-1">
+                        <TokenDisplay token={agent.template.tokenA} /> /
+                        <TokenDisplay token={agent.template.tokenB} />
+                      </span>
+                    ) : (
+                      '-'
+                    )}
                   </td>
                   <td>{agent.model}</td>
                   <td>
                     <AgentStatusLabel status={agent.status} />
+                  </td>
+                  <td>
+                    <Link
+                      className="text-blue-600 underline inline-flex"
+                      to={`/agents/${agent.id}`}
+                      aria-label="View agent"
+                    >
+                      <Eye className="w-4 h-4" />
+                    </Link>
                   </td>
                 </tr>
               ))}

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import api from '../lib/axios';
 import { useUser } from '../lib/useUser';
 import AgentStatusLabel from '../components/AgentStatusLabel';
+import TokenDisplay from '../components/TokenDisplay';
 
 interface Agent {
   id: string;
@@ -63,31 +64,32 @@ export default function Dashboard() {
           <table className="w-full mb-4">
             <thead>
               <tr>
-                <th className="text-left">Agent ID</th>
+                <th className="text-left">Created</th>
                 <th className="text-left">Pair</th>
                 <th className="text-left">Model</th>
                 <th className="text-left">Status</th>
-                <th className="text-left">Created</th>
               </tr>
             </thead>
             <tbody>
               {items.map((agent) => (
                 <tr key={agent.id}>
+                  <td>{new Date(agent.createdAt).toLocaleString()}</td>
                   <td>
                     <Link className="text-blue-600 underline" to={`/agents/${agent.id}`}>
-                      {agent.id}
+                      {agent.template ? (
+                        <>
+                          <TokenDisplay token={agent.template.tokenA} />/
+                          <TokenDisplay token={agent.template.tokenB} />
+                        </>
+                      ) : (
+                        '-'
+                      )}
                     </Link>
-                  </td>
-                  <td>
-                    {agent.template
-                      ? `${agent.template.tokenA}/${agent.template.tokenB}`
-                      : '-'}
                   </td>
                   <td>{agent.model}</td>
                   <td>
                     <AgentStatusLabel status={agent.status} />
                   </td>
-                  <td>{new Date(agent.createdAt).toLocaleString()}</td>
                 </tr>
               ))}
             </tbody>

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -12,7 +12,7 @@ interface Agent {
   model: string;
   status: 'active' | 'inactive';
   createdAt: number;
-  template: {
+  template?: {
     tokenA: string;
     tokenB: string;
     risk: string;
@@ -79,7 +79,9 @@ export default function Dashboard() {
                     </Link>
                   </td>
                   <td>
-                    {agent.template.tokenA}/{agent.template.tokenB}
+                    {agent.template
+                      ? `${agent.template.tokenA}/${agent.template.tokenB}`
+                      : '-'}
                   </td>
                   <td>{agent.model}</td>
                   <td>

--- a/frontend/src/routes/ViewAgent.tsx
+++ b/frontend/src/routes/ViewAgent.tsx
@@ -11,7 +11,7 @@ interface Agent {
   model: string;
   status: 'active' | 'inactive';
   createdAt: number;
-  template: {
+  template?: {
     tokenA: string;
     tokenB: string;
     targetAllocation: number;
@@ -39,42 +39,48 @@ export default function ViewAgent() {
 
   if (!data) return <div className="p-4">Loading...</div>;
 
+  const template = data.template;
+
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">Agent {data.id}</h1>
-      <p>
-        <strong>Pair:</strong> {data.template.tokenA}/{data.template.tokenB}
-      </p>
-      <p>
-        <strong>Model:</strong> {data.model}
-      </p>
-      <p>
-        <strong>Status:</strong> <AgentStatusLabel status={data.status} />
-      </p>
-      <p>
-        <strong>Created:</strong> {new Date(data.createdAt).toLocaleString()}
-      </p>
-      <p>
-        <strong>Risk:</strong> {data.template.risk}
-      </p>
-      <p>
-        <strong>Rebalance:</strong> {data.template.rebalance}
-      </p>
-      <p>
-        <strong>Target Allocation:</strong> {data.template.targetAllocation}/
-        {100 - data.template.targetAllocation}
-      </p>
-      <p>
-        <strong>Minimum {data.template.tokenA} Allocation:</strong>{' '}
-        {data.template.minTokenAAllocation}%
-      </p>
-      <p>
-        <strong>Minimum {data.template.tokenB} Allocation:</strong>{' '}
-        {data.template.minTokenBAllocation}%
-      </p>
-      <p>
-        <strong>Instructions:</strong> {data.template.agentInstructions}
-      </p>
+      {template ? (
+        <>
+          <p>
+            <strong>Pair:</strong> {template.tokenA}/{template.tokenB}
+          </p>
+          <p>
+            <strong>Model:</strong> {data.model}
+          </p>
+          <p>
+            <strong>Status:</strong> <AgentStatusLabel status={data.status} />
+          </p>
+          <p>
+            <strong>Created:</strong> {new Date(data.createdAt).toLocaleString()}
+          </p>
+          <p>
+            <strong>Risk:</strong> {template.risk}
+          </p>
+          <p>
+            <strong>Rebalance:</strong> {template.rebalance}
+          </p>
+          <p>
+            <strong>Target Allocation:</strong> {template.targetAllocation}/
+            {100 - template.targetAllocation}
+          </p>
+          <p>
+            <strong>Minimum {template.tokenA} Allocation:</strong> {template.minTokenAAllocation}%
+          </p>
+          <p>
+            <strong>Minimum {template.tokenB} Allocation:</strong> {template.minTokenBAllocation}%
+          </p>
+          <p>
+            <strong>Instructions:</strong> {template.agentInstructions}
+          </p>
+        </>
+      ) : (
+        <p>No template information available.</p>
+      )}
     </div>
   );
 }

--- a/frontend/src/routes/ViewAgent.tsx
+++ b/frontend/src/routes/ViewAgent.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import api from '../lib/axios';
 import { useUser } from '../lib/useUser';
 import AgentStatusLabel from '../components/AgentStatusLabel';
+import TokenDisplay from '../components/TokenDisplay';
 
 interface Agent {
   id: string;
@@ -43,20 +44,25 @@ export default function ViewAgent() {
 
   return (
     <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Agent {data.id}</h1>
+      <h1 className="text-2xl font-bold mb-4">Agent</h1>
+      <p>
+        <strong>Agent ID:</strong> {data.id}
+      </p>
+      <p>
+        <strong>Model:</strong> {data.model}
+      </p>
+      <p>
+        <strong>Status:</strong> <AgentStatusLabel status={data.status} />
+      </p>
+      <p>
+        <strong>Created:</strong> {new Date(data.createdAt).toLocaleString()}
+      </p>
       {template ? (
         <>
           <p>
-            <strong>Pair:</strong> {template.tokenA}/{template.tokenB}
-          </p>
-          <p>
-            <strong>Model:</strong> {data.model}
-          </p>
-          <p>
-            <strong>Status:</strong> <AgentStatusLabel status={data.status} />
-          </p>
-          <p>
-            <strong>Created:</strong> {new Date(data.createdAt).toLocaleString()}
+            <strong>Pair:</strong>{' '}
+            <TokenDisplay token={template.tokenA} />/
+            <TokenDisplay token={template.tokenB} />
           </p>
           <p>
             <strong>Risk:</strong> {template.risk}

--- a/frontend/src/routes/ViewAgent.tsx
+++ b/frontend/src/routes/ViewAgent.tsx
@@ -1,0 +1,81 @@
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import api from '../lib/axios';
+import { useUser } from '../lib/useUser';
+import AgentStatusLabel from '../components/AgentStatusLabel';
+
+interface Agent {
+  id: string;
+  templateId: string;
+  userId: string;
+  model: string;
+  status: 'active' | 'inactive';
+  createdAt: number;
+  template: {
+    tokenA: string;
+    tokenB: string;
+    targetAllocation: number;
+    minTokenAAllocation: number;
+    minTokenBAllocation: number;
+    risk: string;
+    rebalance: string;
+    agentInstructions: string;
+  };
+}
+
+export default function ViewAgent() {
+  const { id } = useParams();
+  const { user } = useUser();
+  const { data } = useQuery({
+    queryKey: ['agent', id, user?.id],
+    queryFn: async () => {
+      const res = await api.get(`/agents/${id}`, {
+        headers: { 'x-user-id': user!.id },
+      });
+      return res.data as Agent;
+    },
+    enabled: !!id && !!user,
+  });
+
+  if (!data) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Agent {data.id}</h1>
+      <p>
+        <strong>Pair:</strong> {data.template.tokenA}/{data.template.tokenB}
+      </p>
+      <p>
+        <strong>Model:</strong> {data.model}
+      </p>
+      <p>
+        <strong>Status:</strong> <AgentStatusLabel status={data.status} />
+      </p>
+      <p>
+        <strong>Created:</strong> {new Date(data.createdAt).toLocaleString()}
+      </p>
+      <p>
+        <strong>Risk:</strong> {data.template.risk}
+      </p>
+      <p>
+        <strong>Rebalance:</strong> {data.template.rebalance}
+      </p>
+      <p>
+        <strong>Target Allocation:</strong> {data.template.targetAllocation}/
+        {100 - data.template.targetAllocation}
+      </p>
+      <p>
+        <strong>Minimum {data.template.tokenA} Allocation:</strong>{' '}
+        {data.template.minTokenAAllocation}%
+      </p>
+      <p>
+        <strong>Minimum {data.template.tokenB} Allocation:</strong>{' '}
+        {data.template.minTokenBAllocation}%
+      </p>
+      <p>
+        <strong>Instructions:</strong> {data.template.agentInstructions}
+      </p>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Expand agents API to join templates, returning token pair and template details
- Display token pairs and models in My Agents table
- Add single agent view for detailed agent and template information

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a08902aa30832c86f89e016b4188af