### PR TITLE
Show agent token balance in USD

### DIFF
--- a/frontend/src/components/AgentBalance.tsx
+++ b/frontend/src/components/AgentBalance.tsx
@@ -1,0 +1,54 @@
+import axios from 'axios';
+import { useQueries, useQuery } from '@tanstack/react-query';
+import api from '../lib/axios';
+import { useUser } from '../lib/useUser';
+
+interface Props {
+  tokenA: string;
+  tokenB: string;
+}
+
+export default function AgentBalance({ tokenA, tokenB }: Props) {
+  const { user } = useUser();
+  const { data: binanceKey } = useQuery<string | null>({
+    queryKey: ['binance-key', user?.id],
+    enabled: !!user,
+    queryFn: async () => {
+      try {
+        const res = await api.get(`/users/${user!.id}/binance-key`);
+        return res.data.key as string;
+      } catch (err) {
+        if (axios.isAxiosError(err) && err.response?.status === 404) return null;
+        throw err;
+      }
+    },
+  });
+
+  const balanceQueries = useQueries({
+    queries: [tokenA, tokenB].map((token) => ({
+      queryKey: ['binance-balance-usd', user?.id, token.toUpperCase()],
+      enabled: !!user && !!binanceKey,
+      queryFn: async () => {
+        const res = await api.get(
+          `/users/${user!.id}/binance-balance/${token.toUpperCase()}`,
+          { headers: { 'x-user-id': user!.id } }
+        );
+        const bal = res.data as { free: number; locked: number };
+        const amount = (bal.free ?? 0) + (bal.locked ?? 0);
+        if (!amount) return 0;
+        if (token.toUpperCase() === 'USDT') return amount;
+        const priceRes = await fetch(
+          `https://api.binance.com/api/v3/ticker/price?symbol=${token.toUpperCase()}USDT`
+        );
+        if (!priceRes.ok) return 0;
+        const priceData = (await priceRes.json()) as { price: string };
+        return amount * Number(priceData.price);
+      },
+    })),
+  });
+
+  if (!user || !binanceKey) return <span>-</span>;
+  const isLoading = balanceQueries.some((q) => q.isLoading);
+  const total = balanceQueries.reduce((sum, q) => sum + (q.data ?? 0), 0);
+  return <span>{isLoading ? 'Loading...' : `$${total.toFixed(2)}`}</span>;
+}

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -65,7 +65,7 @@ export default function Dashboard() {
           <table className="w-full mb-4">
             <thead>
               <tr>
-                <th className="text-left">Pair</th>
+                <th className="text-left">Tokens</th>
                 <th className="text-left">Balance (USD)</th>
                 <th className="text-left">Model</th>
                 <th className="text-left">Status</th>

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -6,6 +6,7 @@ import api from '../lib/axios';
 import { useUser } from '../lib/useUser';
 import AgentStatusLabel from '../components/AgentStatusLabel';
 import TokenDisplay from '../components/TokenDisplay';
+import AgentBalance from '../components/AgentBalance';
 
 interface Agent {
   id: string;
@@ -13,7 +14,6 @@ interface Agent {
   userId: string;
   model: string;
   status: 'active' | 'inactive';
-  createdAt: number;
   template?: {
     tokenA: string;
     tokenB: string;
@@ -65,8 +65,8 @@ export default function Dashboard() {
           <table className="w-full mb-4">
             <thead>
               <tr>
-                <th className="text-left">Created</th>
                 <th className="text-left">Pair</th>
+                <th className="text-left">Balance (USD)</th>
                 <th className="text-left">Model</th>
                 <th className="text-left">Status</th>
                 <th></th>
@@ -75,13 +75,22 @@ export default function Dashboard() {
             <tbody>
               {items.map((agent) => (
                 <tr key={agent.id}>
-                  <td>{new Date(agent.createdAt).toLocaleString()}</td>
                   <td>
                     {agent.template ? (
                       <span className="inline-flex items-center gap-1">
                         <TokenDisplay token={agent.template.tokenA} /> /
                         <TokenDisplay token={agent.template.tokenB} />
                       </span>
+                    ) : (
+                      '-'
+                    )}
+                  </td>
+                  <td>
+                    {agent.template ? (
+                      <AgentBalance
+                        tokenA={agent.template.tokenA}
+                        tokenB={agent.template.tokenB}
+                      />
                     ) : (
                       '-'
                     )}


### PR DESCRIPTION
## Summary
- Replace created timestamp in My Agents table with USD balance for agent token pair
- Add `AgentBalance` component to fetch user balances and convert to USD

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a09e496a78832c826aad4b227add6c