### PR TITLE
feat: add template names

### DIFF
--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS executions(
 CREATE TABLE IF NOT EXISTS agent_templates(
   id TEXT PRIMARY KEY,
   user_id TEXT,
+  name TEXT,
   token_a TEXT,
   token_b TEXT,
   target_allocation INTEGER,

--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -14,6 +14,7 @@ interface AgentRow {
   model: string;
   status: string;
   created_at: number;
+  name: string;
   token_a: string;
   token_b: string;
   target_allocation: number;
@@ -34,6 +35,7 @@ function toApi(row: AgentRow) {
     createdAt: row.created_at,
     template: {
       id: row.template_id,
+      name: row.name,
       tokenA: row.token_a,
       tokenB: row.token_b,
       targetAllocation: row.target_allocation,
@@ -48,7 +50,7 @@ function toApi(row: AgentRow) {
 
 const baseSelect =
   'SELECT a.id, a.template_id, a.user_id, a.model, a.status, a.created_at, ' +
-  't.token_a, t.token_b, t.target_allocation, t.min_a_allocation, t.min_b_allocation, ' +
+  't.name, t.token_a, t.token_b, t.target_allocation, t.min_a_allocation, t.min_b_allocation, ' +
   't.risk, t.rebalance, t.agent_instructions FROM agents a JOIN agent_templates t ON a.template_id = t.id';
 
 function getAgent(id: string) {

--- a/backend/test/agentTemplates.test.ts
+++ b/backend/test/agentTemplates.test.ts
@@ -16,6 +16,7 @@ describe('agent template routes', () => {
 
     const payload = {
       userId: 'user1',
+      name: 'BTC 60 / ETH 40',
       tokenA: 'BTC',
       tokenB: 'ETH',
       targetAllocation: 60,
@@ -60,7 +61,7 @@ describe('agent template routes', () => {
     expect(res.json()).toMatchObject({ total: 1, page: 1, pageSize: 10 });
     expect(res.json().items).toHaveLength(1);
 
-    const update = { ...payload, targetAllocation: 70, risk: 'medium' };
+    const update = { ...payload, name: 'BTC 70 / ETH 30', targetAllocation: 70, risk: 'medium' };
     res = await app.inject({
       method: 'PUT',
       url: `/api/agent-templates/${id}`,
@@ -78,6 +79,15 @@ describe('agent template routes', () => {
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ id, agentInstructions: 'new prompt' });
+
+    res = await app.inject({
+      method: 'PATCH',
+      url: `/api/agent-templates/${id}/name`,
+      headers: { 'x-user-id': 'user1' },
+      payload: { userId: 'user1', name: 'custom name' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ id, name: 'custom name' });
 
     res = await app.inject({
       method: 'DELETE',
@@ -103,6 +113,7 @@ describe('agent template routes', () => {
 
     const payload = {
       userId: 'user3',
+      name: 'BTC 60 / ETH 40',
       tokenA: 'BTC',
       tokenB: 'ETH',
       targetAllocation: 60,
@@ -161,6 +172,7 @@ describe('agent template routes', () => {
 
     const base = {
       userId: 'user5',
+      name: 'base',
       tokenA: 'BTC',
       tokenB: 'ETH',
       risk: 'low',
@@ -210,6 +222,7 @@ describe('agent template routes', () => {
 
     const payload = {
       userId: 'owner',
+      name: 'BTC 60 / ETH 40',
       tokenA: 'BTC',
       tokenB: 'ETH',
       targetAllocation: 60,
@@ -261,6 +274,7 @@ describe('agent template routes', () => {
 
     const base = {
       userId: 'user6',
+      name: 'base',
       tokenA: 'BTC',
       tokenB: 'ETH',
       targetAllocation: 60,

--- a/backend/test/agents.test.ts
+++ b/backend/test/agents.test.ts
@@ -16,8 +16,8 @@ describe('agent routes', () => {
       'INSERT INTO users (id, ai_api_key_enc, binance_api_key_enc, binance_api_secret_enc) VALUES (?, ?, ?, ?)'
     ).run('user1', 'a', 'b', 'c');
     db.prepare(
-      `INSERT INTO agent_templates (id, user_id, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, agent_instructions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run('tmpl1', 'user1', 'BTC', 'ETH', 60, 10, 20, 'low', '1h', 'prompt');
+      `INSERT INTO agent_templates (id, user_id, name, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, agent_instructions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run('tmpl1', 'user1', 'T1', 'BTC', 'ETH', 60, 10, 20, 'low', '1h', 'prompt');
 
     const payload = { templateId: 'tmpl1', userId: 'user1', model: 'gpt-5', status: 'inactive' };
 
@@ -94,11 +94,11 @@ describe('agent routes', () => {
       'INSERT INTO users (id, ai_api_key_enc, binance_api_key_enc, binance_api_secret_enc) VALUES (?, ?, ?, ?)'
     ).run('user3', 'a', 'b', 'c');
     db.prepare(
-      `INSERT INTO agent_templates (id, user_id, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, agent_instructions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run('tmpl2', 'user2', 'BTC', 'ETH', 60, 10, 20, 'low', '1h', 'prompt');
+      `INSERT INTO agent_templates (id, user_id, name, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, agent_instructions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run('tmpl2', 'user2', 'T2', 'BTC', 'ETH', 60, 10, 20, 'low', '1h', 'prompt');
     db.prepare(
-      `INSERT INTO agent_templates (id, user_id, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, agent_instructions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run('tmpl3', 'user3', 'BTC', 'ETH', 60, 10, 20, 'low', '1h', 'prompt');
+      `INSERT INTO agent_templates (id, user_id, name, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, agent_instructions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run('tmpl3', 'user3', 'T3', 'BTC', 'ETH', 60, 10, 20, 'low', '1h', 'prompt');
 
     let res = await app.inject({
       method: 'POST',

--- a/frontend/src/components/AgentTemplateName.tsx
+++ b/frontend/src/components/AgentTemplateName.tsx
@@ -1,0 +1,74 @@
+import { useState, useEffect } from 'react';
+import { Pencil } from 'lucide-react';
+import { useUser } from '../lib/useUser';
+import api from '../lib/axios';
+
+interface Props {
+  templateId: string;
+  name: string;
+  onChange?: (name: string) => void;
+}
+
+export default function AgentTemplateName({ templateId, name, onChange }: Props) {
+  const { user } = useUser();
+  const [editing, setEditing] = useState(false);
+  const [text, setText] = useState(name);
+
+  useEffect(() => {
+    setText(name);
+  }, [name]);
+
+  async function save() {
+    if (!user) return;
+    await api.patch(
+      `/agent-templates/${templateId}/name`,
+      { userId: user.id, name: text },
+      { headers: { 'x-user-id': user.id } }
+    );
+    setEditing(false);
+    onChange?.(text);
+  }
+
+  if (editing) {
+    return (
+      <div className="flex items-center gap-2 mb-4">
+        <input
+          className="border rounded p-1 flex-1"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+        />
+        <button
+          className="px-2 py-1 bg-blue-600 text-white rounded"
+          onClick={save}
+        >
+          Save
+        </button>
+        <button
+          className="px-2 py-1 border rounded"
+          onClick={() => {
+            setText(name);
+            setEditing(false);
+          }}
+        >
+          Cancel
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center mb-4">
+      <h2 className="text-xl font-bold flex-1">{name}</h2>
+      {user && (
+        <button
+          aria-label="Edit name"
+          className="text-gray-600"
+          onClick={() => setEditing(true)}
+        >
+          <Pencil className="w-4 h-4" />
+        </button>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/components/AgentTemplatesTable.tsx
+++ b/frontend/src/components/AgentTemplatesTable.tsx
@@ -8,6 +8,7 @@ import TokenDisplay from './TokenDisplay';
 
 interface AgentTemplate {
   id: string;
+  name: string;
   tokenA: string;
   tokenB: string;
   targetAllocation: number;
@@ -63,6 +64,7 @@ export default function AgentTemplatesTable({
           <table className="w-full mb-4">
             <thead>
               <tr>
+                <th className="text-left">Name</th>
                 <th className="text-left">Tokens</th>
                 <th className="text-left">Target Allocation</th>
                 <th className="text-left">Risk</th>
@@ -94,6 +96,7 @@ export default function AgentTemplatesTable({
                 };
                 return (
                   <tr key={t.id}>
+                    <td>{t.name}</td>
                     <td>
                       <span className="inline-flex items-center gap-1">
                         <TokenDisplay token={t.tokenA} />/

--- a/frontend/src/components/forms/AgentTemplateForm.tsx
+++ b/frontend/src/components/forms/AgentTemplateForm.tsx
@@ -172,11 +172,18 @@ export default function AgentTemplateForm({
 
     const onSubmit = handleSubmit(async (values) => {
         if (!user) return;
+        const {targetAllocation} = normalizeAllocations(
+            values.targetAllocation,
+            values.minTokenAAllocation,
+            values.minTokenBAllocation
+        );
+        const name = `${values.tokenA.toUpperCase()} ${targetAllocation} / ${values.tokenB.toUpperCase()} ${100 - targetAllocation}`;
         if (template) {
             await api.put(
                 `/agent-templates/${template.id}`,
                 {
                     userId: user.id,
+                    name,
                     ...values,
                     tokenA: values.tokenA.toUpperCase(),
                     tokenB: values.tokenB.toUpperCase(),
@@ -191,6 +198,7 @@ export default function AgentTemplateForm({
                 '/agent-templates',
                 {
                     userId: user.id,
+                    name,
                     ...values,
                     tokenA: values.tokenA.toUpperCase(),
                     tokenB: values.tokenB.toUpperCase(),

--- a/frontend/src/routes/AgentTemplates.tsx
+++ b/frontend/src/routes/AgentTemplates.tsx
@@ -8,6 +8,7 @@ import ErrorBoundary from '../components/ErrorBoundary';
 
 interface AgentTemplateDetails {
   id: string;
+  name: string;
   tokenA: string;
   tokenB: string;
   targetAllocation: number;

--- a/frontend/src/routes/ViewAgentTemplate.tsx
+++ b/frontend/src/routes/ViewAgentTemplate.tsx
@@ -9,10 +9,12 @@ import AiApiKeySection from '../components/forms/AiApiKeySection';
 import ExchangeApiKeySection from '../components/forms/ExchangeApiKeySection';
 import WalletBalances from '../components/WalletBalances';
 import TradingAgentInstructions from '../components/TradingAgentInstructions';
+import AgentTemplateName from '../components/AgentTemplateName';
 
 interface AgentTemplateDetails {
     id: string;
     userId: string;
+    name: string;
     tokenA: string;
     tokenB: string;
     targetAllocation: number;
@@ -75,6 +77,7 @@ export default function ViewAgentTemplate() {
     });
     const [model, setModel] = useState('');
     const [instructions, setInstructions] = useState('');
+    const [name, setName] = useState('');
     const [isCreating, setIsCreating] = useState(false);
     useEffect(() => {
         if (modelsQuery.data && modelsQuery.data.length) {
@@ -86,6 +89,11 @@ export default function ViewAgentTemplate() {
             setInstructions(data.agentInstructions);
         }
     }, [data?.agentInstructions]);
+    useEffect(() => {
+        if (data?.name) {
+            setName(data.name);
+        }
+    }, [data?.name]);
 
     if (!data) return <div className="p-4">Loading...</div>;
 
@@ -99,9 +107,11 @@ export default function ViewAgentTemplate() {
 
     return (
         <div className="p-4">
-            <h1 className="text-2xl font-bold mb-4">
-                {`${data.tokenA.toUpperCase()} ${data.targetAllocation} / ${data.tokenB.toUpperCase()} ${100 - data.targetAllocation}`}
-            </h1>
+            <h1 className="text-2xl font-bold mb-2">Agent Template</h1>
+            <AgentTemplateName templateId={data.id} name={name} onChange={setName} />
+            <p className="mt-4">
+                <strong>Tokens:</strong> {data.tokenA.toUpperCase()} / {data.tokenB.toUpperCase()}
+            </p>
             <p>
                 <strong>Target Allocation:</strong> {data.targetAllocation}/{100 - data.targetAllocation}
             </p>


### PR DESCRIPTION
## Summary
- track a human-friendly name for agent templates
- show template names in the UI and allow renaming

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a168dd01b8832c915efba366f2f671