### PR TITLE
feat(agent-view): refine token and risk displays

### DIFF
--- a/frontend/src/components/AgentTemplatesTable.tsx
+++ b/frontend/src/components/AgentTemplatesTable.tsx
@@ -5,6 +5,7 @@ import { Eye, Pencil, Trash2 } from 'lucide-react';
 import api from '../lib/axios';
 import { useUser } from '../lib/useUser';
 import TokenDisplay from './TokenDisplay';
+import RiskDisplay from './RiskDisplay';
 
 interface AgentTemplate {
   id: string;
@@ -74,9 +75,6 @@ export default function AgentTemplatesTable({
             </thead>
             <tbody>
               {items.map((t) => {
-                const risk = t.risk
-                  ? t.risk.charAt(0).toUpperCase() + t.risk.slice(1)
-                  : '';
                 const rebalanceMap: Record<string, string> = {
                   '1h': '1 hour',
                   '3h': '3 hours',
@@ -104,7 +102,9 @@ export default function AgentTemplatesTable({
                       </span>
                     </td>
                     <td>{`${t.targetAllocation}/${100 - t.targetAllocation}`}</td>
-                    <td>{risk}</td>
+                    <td>
+                      <RiskDisplay risk={t.risk} />
+                    </td>
                     <td>{rebalance}</td>
                     <td className="flex gap-2">
                       <Link

--- a/frontend/src/components/RiskDisplay.tsx
+++ b/frontend/src/components/RiskDisplay.tsx
@@ -6,14 +6,18 @@ export default function RiskDisplay({
   className?: string;
 }) {
   const key = risk.toLowerCase();
+  const gradients: Record<string, string> = {
+    low: 'linear-gradient(135deg, #4ade80, #22c55e)',
+    medium: 'linear-gradient(135deg, #fde047, #eab308)',
+    mid: 'linear-gradient(135deg, #fde047, #eab308)',
+    high: 'linear-gradient(135deg, #f87171, #ef4444)',
+  };
+
   return (
     <span className={`inline-flex items-center gap-1 ${className}`}>
       <span
         className="w-4 h-4 rounded-full"
-        style={{
-          background:
-            'linear-gradient(135deg, #22c55e, #eab308, #ef4444)',
-        }}
+        style={{ background: gradients[key] || gradients.low }}
       />
       <span className="capitalize">{key}</span>
     </span>

--- a/frontend/src/components/RiskDisplay.tsx
+++ b/frontend/src/components/RiskDisplay.tsx
@@ -1,18 +1,22 @@
-import { Shield, AlertTriangle, Flame, type LucideIcon } from 'lucide-react';
-
-const ICONS: Record<string, LucideIcon> = {
-  low: Shield,
-  medium: AlertTriangle,
-  high: Flame,
-};
-
-export default function RiskDisplay({ risk, className = '' }: { risk: string; className?: string }) {
+export default function RiskDisplay({
+  risk,
+  className = '',
+}: {
+  risk: string;
+  className?: string;
+}) {
   const key = risk.toLowerCase();
-  const Icon = ICONS[key];
   return (
     <span className={`inline-flex items-center gap-1 ${className}`}>
-      {Icon && <Icon className="w-4 h-4" />}
+      <span
+        className="w-4 h-4 rounded-full"
+        style={{
+          background:
+            'linear-gradient(135deg, #22c55e, #eab308, #ef4444)',
+        }}
+      />
       <span className="capitalize">{key}</span>
     </span>
   );
 }
+

--- a/frontend/src/components/RiskDisplay.tsx
+++ b/frontend/src/components/RiskDisplay.tsx
@@ -14,9 +14,9 @@ export default function RiskDisplay({
   };
 
   return (
-    <span className={`inline-flex items-center gap-1 ${className}`}>
+    <span className={`inline-flex items-center gap-2 ${className}`}>
       <span
-        className="w-4 h-4 rounded-full"
+        className="w-1.5 h-1.5 rounded-full"
         style={{ backgroundColor: colors[key] || colors.low }}
       />
       <span className="capitalize">{key}</span>

--- a/frontend/src/components/RiskDisplay.tsx
+++ b/frontend/src/components/RiskDisplay.tsx
@@ -6,18 +6,18 @@ export default function RiskDisplay({
   className?: string;
 }) {
   const key = risk.toLowerCase();
-  const gradients: Record<string, string> = {
-    low: 'linear-gradient(135deg, #4ade80, #22c55e)',
-    medium: 'linear-gradient(135deg, #fde047, #eab308)',
-    mid: 'linear-gradient(135deg, #fde047, #eab308)',
-    high: 'linear-gradient(135deg, #f87171, #ef4444)',
+  const colors: Record<string, string> = {
+    low: '#16a34a',
+    medium: '#d97706',
+    mid: '#d97706',
+    high: '#dc2626',
   };
 
   return (
     <span className={`inline-flex items-center gap-1 ${className}`}>
       <span
         className="w-4 h-4 rounded-full"
-        style={{ background: gradients[key] || gradients.low }}
+        style={{ backgroundColor: colors[key] || colors.low }}
       />
       <span className="capitalize">{key}</span>
     </span>

--- a/frontend/src/components/RiskDisplay.tsx
+++ b/frontend/src/components/RiskDisplay.tsx
@@ -1,0 +1,18 @@
+import { Shield, AlertTriangle, Flame, type LucideIcon } from 'lucide-react';
+
+const ICONS: Record<string, LucideIcon> = {
+  low: Shield,
+  medium: AlertTriangle,
+  high: Flame,
+};
+
+export default function RiskDisplay({ risk, className = '' }: { risk: string; className?: string }) {
+  const key = risk.toLowerCase();
+  const Icon = ICONS[key];
+  return (
+    <span className={`inline-flex items-center gap-1 ${className}`}>
+      {Icon && <Icon className="w-4 h-4" />}
+      <span className="capitalize">{key}</span>
+    </span>
+  );
+}

--- a/frontend/src/components/forms/AgentTemplateForm.tsx
+++ b/frontend/src/components/forms/AgentTemplateForm.tsx
@@ -10,6 +10,7 @@ import {normalizeAllocations} from '../../lib/allocations';
 import TokenSelect from './TokenSelect';
 import TextInput from './TextInput';
 import SelectInput from './SelectInput';
+import RiskDisplay from '../RiskDisplay';
 
 const schema = z
     .object({
@@ -45,9 +46,9 @@ const tokens = [
 ];
 
 const riskOptions = [
-    {value: 'low', label: 'Low'},
-    {value: 'medium', label: 'Medium'},
-    {value: 'high', label: 'High'},
+    {value: 'low', label: <RiskDisplay risk="low" />},
+    {value: 'medium', label: <RiskDisplay risk="medium" />},
+    {value: 'high', label: <RiskDisplay risk="high" />},
 ];
 
 const rebalanceOptions = [

--- a/frontend/src/components/forms/SelectInput.tsx
+++ b/frontend/src/components/forms/SelectInput.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 
 interface Option {
   value: string;
-  label: string;
+  label: ReactNode;
 }
 
 export default function SelectInput({
@@ -27,7 +27,7 @@ export default function SelectInput({
         onClick={() => setOpen(!open)}
         className="w-full border rounded px-2 py-1 flex items-center justify-between"
       >
-        <span className={selected ? '' : 'text-gray-500'}>
+        <span className={`${selected ? '' : 'text-gray-500'} flex items-center gap-1`}>
           {selected ? selected.label : 'Select'}
         </span>
         <span className="ml-2">▾</span>

--- a/frontend/src/routes/ViewAgent.tsx
+++ b/frontend/src/routes/ViewAgent.tsx
@@ -4,6 +4,7 @@ import api from '../lib/axios';
 import { useUser } from '../lib/useUser';
 import AgentStatusLabel from '../components/AgentStatusLabel';
 import TokenDisplay from '../components/TokenDisplay';
+import RiskDisplay from '../components/RiskDisplay';
 
 interface Agent {
   id: string;
@@ -41,6 +42,8 @@ export default function ViewAgent() {
   if (!data) return <div className="p-4">Loading...</div>;
 
   const template = data.template;
+  const rebalanceLabel =
+    template?.rebalance === '1h' ? '1 hour' : template?.rebalance;
 
   return (
     <div className="p-4">
@@ -56,16 +59,18 @@ export default function ViewAgent() {
       </p>
       {template ? (
         <>
-          <p>
-            <strong>Pair:</strong>{' '}
-            <TokenDisplay token={template.tokenA} />/
+          <p className="flex items-center">
+            <strong className="mr-1">Tokens:</strong>
+            <TokenDisplay token={template.tokenA} />
+            <span className="mx-1">/</span>
             <TokenDisplay token={template.tokenB} />
           </p>
-          <p>
-            <strong>Risk:</strong> {template.risk}
+          <p className="flex items-center">
+            <strong className="mr-1">Risk:</strong>
+            <RiskDisplay risk={template.risk} />
           </p>
           <p>
-            <strong>Rebalance:</strong> {template.rebalance}
+            <strong>Rebalance:</strong> {rebalanceLabel}
           </p>
           <p>
             <strong>Target Allocation:</strong> {template.targetAllocation}/

--- a/frontend/src/routes/ViewAgentTemplate.tsx
+++ b/frontend/src/routes/ViewAgentTemplate.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useState} from 'react';
 import type {ReactNode} from 'react';
+import RiskDisplay from '../components/RiskDisplay';
 import {useParams, useNavigate} from 'react-router-dom';
 import {useQuery} from '@tanstack/react-query';
 import axios from 'axios';
@@ -121,8 +122,8 @@ export default function ViewAgentTemplate() {
             <p>
                 <strong>Minimum {data.tokenB.toUpperCase()} Allocation:</strong> {data.minTokenBAllocation}%
             </p>
-            <p>
-                <strong>Risk Tolerance:</strong> {data.risk}
+            <p className="flex items-center gap-1">
+                <strong>Risk Tolerance:</strong> <RiskDisplay risk={data.risk} />
             </p>
             <p>
                 <strong>Rebalance Frequency:</strong> {data.rebalance}


### PR DESCRIPTION
## Summary
- rename Pair label to Tokens and align with token displays
- show risk with new RiskDisplay component and icon
- format rebalance interval to display "1 hour"

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a16c245628832c853413cf2691786b