### PR TITLE
feat: add key security banner

### DIFF
--- a/frontend/src/routes/Keys.tsx
+++ b/frontend/src/routes/Keys.tsx
@@ -7,6 +7,10 @@ export default function Keys() {
   if (!user) return <p>Please log in.</p>;
   return (
     <div className="space-y-8 max-w-md">
+      <div className="p-3 bg-blue-100 border border-blue-200 text-sm text-blue-900 rounded">
+        Your API keys are encrypted using AES-256 and stored only on our server. They are
+        decrypted solely when needed to call providers and are never shared.
+      </div>
       <AiApiKeySection label="OpenAI API Key" />
       <ExchangeApiKeySection exchange="binance" label="Binance API Credentials" />
     </div>


### PR DESCRIPTION
## Summary
- inform users about key storage security on the keys page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a17462f418832cbf4aa2065ef0018d