### PR TITLE
Add Google Authenticator 2FA support

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "fastify": "^4.24.3",
         "google-auth-library": "^10.2.1",
         "node-cron": "^3.0.2",
+        "otplib": "^12.0.1",
         "pino": "^8.15.0",
         "zod": "^3.22.4"
       },
@@ -510,6 +511,53 @@
       "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@otplib/core": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==",
+      "license": "MIT"
+    },
+    "node_modules/@otplib/plugin-crypto": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
+      "integrity": "sha512-qPuhN3QrT7ZZLcLCyKOSNhuijUi9G5guMRVrxq63r9YNOxxQjPm59gVxLM+7xGnHnM6cimY57tuKsjK7y9LM1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1"
+      }
+    },
+    "node_modules/@otplib/plugin-thirty-two": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-thirty-two/-/plugin-thirty-two-12.0.1.tgz",
+      "integrity": "sha512-MtT+uqRso909UkbrrYpJ6XFjj9D+x2Py7KjTO9JDPhL0bJUYVu5kFP4TFZW4NFAywrAtFRxOVY261u0qwb93gA==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "thirty-two": "^1.0.2"
+      }
+    },
+    "node_modules/@otplib/preset-default": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
+      "integrity": "sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/plugin-crypto": "^12.0.1",
+        "@otplib/plugin-thirty-two": "^12.0.1"
+      }
+    },
+    "node_modules/@otplib/preset-v11": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-v11/-/preset-v11-12.0.1.tgz",
+      "integrity": "sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/plugin-crypto": "^12.0.1",
+        "@otplib/plugin-thirty-two": "^12.0.1"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.46.2",
@@ -2080,6 +2128,17 @@
         "wrappy": "1"
       }
     },
+    "node_modules/otplib": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
+      "integrity": "sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/preset-default": "^12.0.1",
+        "@otplib/preset-v11": "^12.0.1"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -2595,6 +2654,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/thirty-two": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/thirty-two/-/thirty-two-1.0.2.tgz",
+      "integrity": "sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==",
+      "engines": {
+        "node": ">=0.2.6"
       }
     },
     "node_modules/thread-stream": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,8 @@
     "google-auth-library": "^10.2.1",
     "node-cron": "^3.0.2",
     "pino": "^8.15.0",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "otplib": "^12.0.1"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -5,7 +5,9 @@ CREATE TABLE IF NOT EXISTS users(
   session_key_expires_at INTEGER,
   ai_api_key_enc TEXT,
   binance_api_key_enc TEXT,
-  binance_api_secret_enc TEXT
+  binance_api_secret_enc TEXT,
+  totp_secret TEXT,
+  is_totp_enabled INTEGER DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS executions(

--- a/backend/src/routes/login.ts
+++ b/backend/src/routes/login.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { OAuth2Client } from 'google-auth-library';
 import { z } from 'zod';
+import { authenticator } from 'otplib';
 import { db } from '../db/index.js';
 import { env } from '../util/env.js';
 
@@ -8,7 +9,9 @@ const client = new OAuth2Client();
 
 export default async function loginRoutes(app: FastifyInstance) {
   app.post('/login', async (req, reply) => {
-    const body = z.object({ token: z.string() }).parse(req.body);
+    const body = z
+      .object({ token: z.string(), otp: z.string().optional() })
+      .parse(req.body);
     const ticket = await client.verifyIdToken({
       idToken: body.token,
       audience: env.GOOGLE_CLIENT_ID,
@@ -16,9 +19,19 @@ export default async function loginRoutes(app: FastifyInstance) {
     const payload = ticket.getPayload();
     if (!payload?.sub) return reply.code(400).send({ error: 'invalid token' });
     const id = payload.sub;
-    const row = db.prepare('SELECT id FROM users WHERE id = ?').get(id) as { id: string } | undefined;
+    const row = db
+      .prepare('SELECT totp_secret, is_totp_enabled FROM users WHERE id = ?')
+      .get(id) as { totp_secret?: string; is_totp_enabled?: number } | undefined;
     if (!row) {
       db.prepare('INSERT INTO users (id, is_auto_enabled) VALUES (?, 0)').run(id);
+    } else if (row.is_totp_enabled && row.totp_secret) {
+      if (!body.otp)
+        return reply.code(401).send({ error: 'otp required' });
+      const valid = authenticator.verify({
+        token: body.otp,
+        secret: row.totp_secret,
+      });
+      if (!valid) return reply.code(401).send({ error: 'invalid otp' });
     }
     return { id, email: payload.email };
   });

--- a/backend/src/routes/twofa.ts
+++ b/backend/src/routes/twofa.ts
@@ -1,0 +1,49 @@
+import type { FastifyInstance } from 'fastify';
+import { authenticator } from 'otplib';
+import { db } from '../db/index.js';
+
+export default async function twofaRoutes(app: FastifyInstance) {
+  app.get('/2fa/status', async (req, reply) => {
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (!userId) return reply.code(403).send({ error: 'forbidden' });
+    const row = db
+      .prepare('SELECT is_totp_enabled FROM users WHERE id = ?')
+      .get(userId) as { is_totp_enabled?: number } | undefined;
+    return { enabled: !!row?.is_totp_enabled };
+  });
+
+  app.get('/2fa/setup', async (req, reply) => {
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (!userId) return reply.code(403).send({ error: 'forbidden' });
+    const secret = authenticator.generateSecret();
+    const otpauthUrl = authenticator.keyuri(userId, 'PromptSwap', secret);
+    return { secret, otpauthUrl };
+  });
+
+  app.post('/2fa/enable', async (req, reply) => {
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (!userId) return reply.code(403).send({ error: 'forbidden' });
+    const body = req.body as { token: string; secret: string };
+    const valid = authenticator.verify({ token: body.token, secret: body.secret });
+    if (!valid) return reply.code(400).send({ error: 'invalid token' });
+    db.prepare('UPDATE users SET totp_secret = ?, is_totp_enabled = 1 WHERE id = ?').run(
+      body.secret,
+      userId,
+    );
+    return { enabled: true };
+  });
+
+  app.post('/2fa/disable', async (req, reply) => {
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (!userId) return reply.code(403).send({ error: 'forbidden' });
+    const body = req.body as { token: string };
+    const row = db
+      .prepare('SELECT totp_secret FROM users WHERE id = ?')
+      .get(userId) as { totp_secret?: string } | undefined;
+    if (!row?.totp_secret) return reply.code(400).send({ error: 'not enabled' });
+    const valid = authenticator.verify({ token: body.token, secret: row.totp_secret });
+    if (!valid) return reply.code(400).send({ error: 'invalid token' });
+    db.prepare('UPDATE users SET totp_secret = NULL, is_totp_enabled = 0 WHERE id = ?').run(userId);
+    return { enabled: false };
+  });
+}

--- a/backend/test/login.test.ts
+++ b/backend/test/login.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterAll } from 'vitest';
 
 process.env.DATABASE_URL = ':memory:';
 process.env.KEY_PASSWORD = 'test-pass';
@@ -6,6 +6,7 @@ process.env.GOOGLE_CLIENT_ID = 'test-client';
 
 const { db, migrate } = await import('../src/db/index.js');
 const { OAuth2Client } = await import('google-auth-library');
+const { authenticator } = await import('otplib');
 const { default: buildServer } = await import('../src/server.js');
 
 describe('login route', () => {
@@ -27,6 +28,37 @@ describe('login route', () => {
       .get('user123') as { id: string } | undefined;
     expect(row).toBeTruthy();
     await app.close();
+  });
+
+  it('requires otp when 2fa enabled', async () => {
+    migrate();
+    const app = await buildServer();
+    vi.spyOn(OAuth2Client.prototype, 'verifyIdToken').mockResolvedValue({
+      getPayload: () => ({ sub: 'user2', email: 'user2@example.com' }),
+    } as any);
+    const secret = authenticator.generateSecret();
+    db.prepare(
+      'INSERT INTO users (id, is_auto_enabled, totp_secret, is_totp_enabled) VALUES (?, 0, ?, 1)'
+    ).run('user2', secret);
+
+    const res1 = await app.inject({
+      method: 'POST',
+      url: '/api/login',
+      payload: { token: 't1' },
+    });
+    expect(res1.statusCode).toBe(401);
+
+    const otp = authenticator.generate(secret);
+    const res2 = await app.inject({
+      method: 'POST',
+      url: '/api/login',
+      payload: { token: 't1', otp },
+    });
+    expect(res2.statusCode).toBe(200);
+    await app.close();
+  });
+
+  afterAll(() => {
     db.close();
   });
 });

--- a/backend/test/twofa.test.ts
+++ b/backend/test/twofa.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+
+process.env.DATABASE_URL = ':memory:';
+process.env.KEY_PASSWORD = 'test-pass';
+process.env.GOOGLE_CLIENT_ID = 'test-client';
+
+const { db, migrate } = await import('../src/db/index.js');
+const { default: buildServer } = await import('../src/server.js');
+const { authenticator } = await import('otplib');
+
+describe('2fa routes', () => {
+  it('enables and disables 2fa', async () => {
+    migrate();
+    db.prepare('INSERT INTO users (id, is_auto_enabled) VALUES (?,0)').run('user1');
+    const app = await buildServer();
+
+    const setupRes = await app.inject({
+      method: 'GET',
+      url: '/api/2fa/setup',
+      headers: { 'x-user-id': 'user1' },
+    });
+    expect(setupRes.statusCode).toBe(200);
+    const { secret } = setupRes.json() as { secret: string };
+
+    const token = authenticator.generate(secret);
+    const enableRes = await app.inject({
+      method: 'POST',
+      url: '/api/2fa/enable',
+      headers: { 'x-user-id': 'user1' },
+      payload: { token, secret },
+    });
+    expect(enableRes.statusCode).toBe(200);
+
+    const statusRes = await app.inject({
+      method: 'GET',
+      url: '/api/2fa/status',
+      headers: { 'x-user-id': 'user1' },
+    });
+    expect(statusRes.json()).toEqual({ enabled: true });
+
+    const disableRes = await app.inject({
+      method: 'POST',
+      url: '/api/2fa/disable',
+      headers: { 'x-user-id': 'user1' },
+      payload: { token: authenticator.generate(secret) },
+    });
+    expect(disableRes.statusCode).toBe(200);
+
+    const statusRes2 = await app.inject({
+      method: 'GET',
+      url: '/api/2fa/status',
+      headers: { 'x-user-id': 'user1' },
+    });
+    expect(statusRes2.json()).toEqual({ enabled: false });
+
+    await app.close();
+    db.close();
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-hook-form": "^7.62.0",
+        "react-qr-code": "^2.0.13",
         "react-router-dom": "^7.8.0",
         "zod": "^4.0.17"
       },
@@ -3191,7 +3192,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -3329,6 +3329,18 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -3502,7 +3514,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3855,6 +3866,17 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -3870,6 +3892,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/qr.js": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -3927,6 +3955,25 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-qr-code": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.18.tgz",
+      "integrity": "sha512-v1Jqz7urLMhkO6jkgJuBYhnqvXagzceg3qJUWayuCK/c6LTIonpWbwxR1f1APGd4xrW/QcQEovNrAojbUz65Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1",
+        "qr.js": "0.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.62.0",
     "react-router-dom": "^7.8.0",
-    "zod": "^4.0.17"
+    "zod": "^4.0.17",
+    "react-qr-code": "^2.0.13"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import AgentTemplates from './routes/AgentTemplates';
 import Keys from './routes/Keys';
 import ViewAgentTemplate from './routes/ViewAgentTemplate';
 import ViewAgent from './routes/ViewAgent';
+import Settings from './routes/Settings';
 
 export default function App() {
   return (
@@ -13,6 +14,7 @@ export default function App() {
         <Route path="/" element={<Dashboard />} />
         <Route path="/agent-templates" element={<AgentTemplates />} />
         <Route path="/keys" element={<Keys />} />
+        <Route path="/settings" element={<Settings />} />
         <Route path="/agent-templates/:id" element={<ViewAgentTemplate />} />
         <Route path="/agents/:id" element={<ViewAgent />} />
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/components/GoogleLoginButton.tsx
+++ b/frontend/src/components/GoogleLoginButton.tsx
@@ -36,9 +36,20 @@ export default function GoogleLoginButton() {
     google.accounts.id.initialize({
       client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID,
       callback: async (resp: CredentialResponse) => {
-        const res = await api.post('/login', { token: resp.credential });
-        setUser(res.data);
-        if (btnRef.current) btnRef.current.innerHTML = '';
+        try {
+          const res = await api.post('/login', { token: resp.credential });
+          setUser(res.data);
+          if (btnRef.current) btnRef.current.innerHTML = '';
+        } catch (err: any) {
+          if (err.response?.data?.error === 'otp required') {
+            const otp = window.prompt('Enter 2FA code');
+            if (otp) {
+              const res2 = await api.post('/login', { token: resp.credential, otp });
+              setUser(res2.data);
+              if (btnRef.current) btnRef.current.innerHTML = '';
+            }
+          }
+        }
       },
     });
     google.accounts.id.renderButton(btnRef.current, {

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -2,7 +2,7 @@ import { Link, Outlet } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import axios from '../../lib/axios';
 import GoogleLoginButton from '../GoogleLoginButton';
-import { Bot, FileText, Key } from 'lucide-react';
+import { Bot, FileText, Key, Settings as SettingsIcon } from 'lucide-react';
 
 function ApiStatus() {
   const { isSuccess } = useQuery({
@@ -36,6 +36,10 @@ export default function AppShell() {
           <Link to="/keys" className="flex items-center gap-2 mb-2 text-gray-700 hover:text-gray-900">
             <Key className="w-4 h-4" />
             Keys
+          </Link>
+          <Link to="/settings" className="flex items-center gap-2 mb-2 text-gray-700 hover:text-gray-900">
+            <SettingsIcon className="w-4 h-4" />
+            Settings
           </Link>
         </nav>
         <main className="flex-1 p-3 bg-white">

--- a/frontend/src/routes/Settings.tsx
+++ b/frontend/src/routes/Settings.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState, FormEvent } from 'react';
+import QRCode from 'react-qr-code';
+import api from '../lib/axios';
+import { useUser } from '../lib/useUser';
+
+export default function Settings() {
+  const { user } = useUser();
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  const [setup, setSetup] = useState<{ secret: string; otpauthUrl: string } | null>(null);
+  const [code, setCode] = useState('');
+
+  useEffect(() => {
+    if (!user) return;
+    api
+      .get('/2fa/status', { headers: { 'x-user-id': user.id } })
+      .then((res) => setEnabled(res.data.enabled));
+  }, [user]);
+
+  if (!user) return <p>Please log in.</p>;
+  if (enabled === null) return <p>Loading...</p>;
+
+  const startSetup = async () => {
+    const res = await api.get('/2fa/setup', { headers: { 'x-user-id': user.id } });
+    setSetup(res.data);
+  };
+
+  const enable = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!setup) return;
+    await api.post(
+      '/2fa/enable',
+      { token: code, secret: setup.secret },
+      { headers: { 'x-user-id': user.id } },
+    );
+    setEnabled(true);
+    setSetup(null);
+    setCode('');
+  };
+
+  const disable = async (e: FormEvent) => {
+    e.preventDefault();
+    await api.post(
+      '/2fa/disable',
+      { token: code },
+      { headers: { 'x-user-id': user.id } },
+    );
+    setEnabled(false);
+    setCode('');
+  };
+
+  return (
+    <div className="space-y-4 max-w-md">
+      <h2 className="text-xl font-bold">Settings</h2>
+      {enabled ? (
+        <form onSubmit={disable} className="space-y-2">
+          <p>Two-factor authentication is enabled.</p>
+          <input
+            className="border p-1 w-40"
+            placeholder="Code"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+          />
+          <button type="submit" className="px-2 py-1 bg-blue-500 text-white rounded">
+            Disable
+          </button>
+        </form>
+      ) : setup ? (
+        <form onSubmit={enable} className="space-y-2">
+          <p>Scan this QR code with Google Authenticator and enter the code.</p>
+          <QRCode value={setup.otpauthUrl} />
+          <input
+            className="border p-1 w-40"
+            placeholder="Code"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+          />
+          <button type="submit" className="px-2 py-1 bg-blue-500 text-white rounded">
+            Enable
+          </button>
+        </form>
+      ) : (
+        <button
+          onClick={startSetup}
+          className="px-2 py-1 bg-blue-500 text-white rounded"
+        >
+          Setup 2FA
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add TOTP columns to users and backend routes for enabling, disabling and checking 2FA
- require one-time codes on login when 2FA is enabled
- add Settings page and navigation item for configuring 2FA, with QR code setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a18395fbc0832c954a51a0d6fe62e6