### PR TITLE
feat: store agent instructions as json

### DIFF
--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -2,6 +2,11 @@ import type { FastifyInstance } from 'fastify';
 import { randomUUID } from 'node:crypto';
 import { db } from '../db/index.js';
 
+interface AgentInstructions {
+  webSearchStrategy: string;
+  goal: string;
+}
+
 export enum AgentStatus {
   Active = 'active',
   Inactive = 'inactive',
@@ -43,7 +48,7 @@ function toApi(row: AgentRow) {
       minTokenBAllocation: row.min_b_allocation,
       risk: row.risk,
       rebalance: row.rebalance,
-      agentInstructions: row.agent_instructions,
+      agentInstructions: JSON.parse(row.agent_instructions) as AgentInstructions,
     },
   };
 }

--- a/backend/test/agentTemplates.test.ts
+++ b/backend/test/agentTemplates.test.ts
@@ -24,7 +24,7 @@ describe('agent template routes', () => {
       minTokenBAllocation: 20,
       risk: 'low',
       rebalance: '1h',
-      agentInstructions: 'prompt',
+      agentInstructions: { webSearchStrategy: 'search', goal: 'prompt' },
     };
 
     let res = await app.inject({
@@ -75,10 +75,16 @@ describe('agent template routes', () => {
       method: 'PATCH',
       url: `/api/agent-templates/${id}/instructions`,
       headers: { 'x-user-id': 'user1' },
-      payload: { userId: 'user1', agentInstructions: 'new prompt' },
+      payload: {
+        userId: 'user1',
+        agentInstructions: { webSearchStrategy: 'search', goal: 'new prompt' },
+      },
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toMatchObject({ id, agentInstructions: 'new prompt' });
+    expect(res.json()).toMatchObject({
+      id,
+      agentInstructions: { webSearchStrategy: 'search', goal: 'new prompt' },
+    });
 
     res = await app.inject({
       method: 'PATCH',
@@ -121,7 +127,7 @@ describe('agent template routes', () => {
       minTokenBAllocation: 20,
       risk: 'low',
       rebalance: '1h',
-      agentInstructions: 'prompt',
+      agentInstructions: { webSearchStrategy: 'search', goal: 'prompt' },
     };
 
     let res = await app.inject({
@@ -177,7 +183,7 @@ describe('agent template routes', () => {
       tokenB: 'ETH',
       risk: 'low',
       rebalance: '1h',
-      agentInstructions: 'prompt',
+      agentInstructions: { webSearchStrategy: 'search', goal: 'prompt' },
     };
 
     let res = await app.inject({
@@ -230,7 +236,7 @@ describe('agent template routes', () => {
       minTokenBAllocation: 20,
       risk: 'low',
       rebalance: '1h',
-      agentInstructions: 'prompt',
+      agentInstructions: { webSearchStrategy: 'search', goal: 'prompt' },
     };
 
     const create = await app.inject({
@@ -245,7 +251,10 @@ describe('agent template routes', () => {
       method: 'PATCH',
       url: `/api/agent-templates/${id}/instructions`,
       headers: { 'x-user-id': 'intruder' },
-      payload: { userId: 'intruder', agentInstructions: 'hack' },
+      payload: {
+        userId: 'intruder',
+        agentInstructions: { webSearchStrategy: 'hack', goal: 'hack' },
+      },
     });
     expect(res.statusCode).toBe(403);
 
@@ -253,7 +262,10 @@ describe('agent template routes', () => {
       method: 'PATCH',
       url: `/api/agent-templates/${id}/instructions`,
       headers: { 'x-user-id': 'owner' },
-      payload: { userId: 'intruder', agentInstructions: 'hack' },
+      payload: {
+        userId: 'intruder',
+        agentInstructions: { webSearchStrategy: 'hack', goal: 'hack' },
+      },
     });
     expect(res.statusCode).toBe(403);
 
@@ -261,7 +273,10 @@ describe('agent template routes', () => {
       method: 'PATCH',
       url: '/api/agent-templates/missing/instructions',
       headers: { 'x-user-id': 'owner' },
-      payload: { userId: 'owner', agentInstructions: 'prompt2' },
+      payload: {
+        userId: 'owner',
+        agentInstructions: { webSearchStrategy: 'search', goal: 'prompt2' },
+      },
     });
     expect(res.statusCode).toBe(404);
 
@@ -282,7 +297,7 @@ describe('agent template routes', () => {
       minTokenBAllocation: 20,
       risk: 'low',
       rebalance: '1h',
-      agentInstructions: 'prompt',
+      agentInstructions: { webSearchStrategy: 'search', goal: 'prompt' },
     };
 
     let res = await app.inject({

--- a/backend/test/agents.test.ts
+++ b/backend/test/agents.test.ts
@@ -17,7 +17,19 @@ describe('agent routes', () => {
     ).run('user1', 'a', 'b', 'c');
     db.prepare(
       `INSERT INTO agent_templates (id, user_id, name, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, agent_instructions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run('tmpl1', 'user1', 'T1', 'BTC', 'ETH', 60, 10, 20, 'low', '1h', 'prompt');
+    ).run(
+      'tmpl1',
+      'user1',
+      'T1',
+      'BTC',
+      'ETH',
+      60,
+      10,
+      20,
+      'low',
+      '1h',
+      JSON.stringify({ webSearchStrategy: 'search', goal: 'prompt' })
+    );
 
     const payload = { templateId: 'tmpl1', userId: 'user1', model: 'gpt-5', status: 'inactive' };
 
@@ -95,10 +107,34 @@ describe('agent routes', () => {
     ).run('user3', 'a', 'b', 'c');
     db.prepare(
       `INSERT INTO agent_templates (id, user_id, name, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, agent_instructions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run('tmpl2', 'user2', 'T2', 'BTC', 'ETH', 60, 10, 20, 'low', '1h', 'prompt');
+    ).run(
+      'tmpl2',
+      'user2',
+      'T2',
+      'BTC',
+      'ETH',
+      60,
+      10,
+      20,
+      'low',
+      '1h',
+      JSON.stringify({ webSearchStrategy: 'search', goal: 'prompt' })
+    );
     db.prepare(
       `INSERT INTO agent_templates (id, user_id, name, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, agent_instructions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run('tmpl3', 'user3', 'T3', 'BTC', 'ETH', 60, 10, 20, 'low', '1h', 'prompt');
+    ).run(
+      'tmpl3',
+      'user3',
+      'T3',
+      'BTC',
+      'ETH',
+      60,
+      10,
+      20,
+      'low',
+      '1h',
+      JSON.stringify({ webSearchStrategy: 'search', goal: 'prompt' })
+    );
 
     let res = await app.inject({
       method: 'POST',

--- a/frontend/src/components/TradingAgentInstructions.tsx
+++ b/frontend/src/components/TradingAgentInstructions.tsx
@@ -1,32 +1,41 @@
-import {useState, useEffect} from 'react';
-import {Pencil} from 'lucide-react';
-import {useUser} from '../lib/useUser';
+import { useState, useEffect } from 'react';
+import { Pencil } from 'lucide-react';
+import { useUser } from '../lib/useUser';
 import api from '../lib/axios';
+
+interface AgentInstructions {
+  webSearchStrategy: string;
+  goal: string;
+}
 
 interface Props {
   templateId: string;
-  instructions: string;
-  onChange?: (text: string) => void;
+  instructions: AgentInstructions;
+  onChange?: (value: AgentInstructions) => void;
 }
 
-export default function TradingAgentInstructions({templateId, instructions, onChange}: Props) {
-  const {user} = useUser();
+export default function TradingAgentInstructions({
+  templateId,
+  instructions,
+  onChange,
+}: Props) {
+  const { user } = useUser();
   const [editing, setEditing] = useState(false);
-  const [text, setText] = useState(instructions);
+  const [local, setLocal] = useState<AgentInstructions>(instructions);
 
   useEffect(() => {
-    setText(instructions);
+    setLocal(instructions);
   }, [instructions]);
 
   async function save() {
     if (!user) return;
     await api.patch(
       `/agent-templates/${templateId}/instructions`,
-      {userId: user.id, agentInstructions: text},
-      {headers: {'x-user-id': user.id}}
+      { userId: user.id, agentInstructions: local },
+      { headers: { 'x-user-id': user.id } }
     );
     setEditing(false);
-    onChange?.(text);
+    onChange?.(local);
   }
 
   return (
@@ -44,13 +53,33 @@ export default function TradingAgentInstructions({templateId, instructions, onCh
         )}
       </div>
       {editing ? (
-        <div>
-          <textarea
-            className="w-full border rounded p-2"
-            rows={4}
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-          />
+        <div className="space-y-2">
+          <div>
+            <label className="block text-sm font-medium mb-1" htmlFor="webSearchStrategy">
+              Web Search Strategy
+            </label>
+            <textarea
+              id="webSearchStrategy"
+              className="w-full border rounded p-2"
+              rows={2}
+              value={local.webSearchStrategy}
+              onChange={(e) =>
+                setLocal({ ...local, webSearchStrategy: e.target.value })
+              }
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1" htmlFor="goal">
+              Goal
+            </label>
+            <textarea
+              id="goal"
+              className="w-full border rounded p-2"
+              rows={4}
+              value={local.goal}
+              onChange={(e) => setLocal({ ...local, goal: e.target.value })}
+            />
+          </div>
           <div className="mt-2 flex gap-2">
             <button
               className="px-4 py-2 bg-blue-600 text-white rounded"
@@ -61,7 +90,7 @@ export default function TradingAgentInstructions({templateId, instructions, onCh
             <button
               className="px-4 py-2 border rounded"
               onClick={() => {
-                setText(instructions);
+                setLocal(instructions);
                 setEditing(false);
               }}
             >
@@ -70,7 +99,14 @@ export default function TradingAgentInstructions({templateId, instructions, onCh
           </div>
         </div>
       ) : (
-        <pre className="whitespace-pre-wrap">{instructions}</pre>
+        <div className="space-y-2">
+          <p>
+            <strong>Web Search Strategy:</strong> {instructions.webSearchStrategy}
+          </p>
+          <p>
+            <strong>Goal:</strong> {instructions.goal}
+          </p>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/forms/AgentTemplateForm.tsx
+++ b/frontend/src/components/forms/AgentTemplateForm.tsx
@@ -12,6 +12,11 @@ import TextInput from './TextInput';
 import SelectInput from './SelectInput';
 import RiskDisplay from '../RiskDisplay';
 
+interface AgentInstructions {
+    webSearchStrategy: string;
+    goal: string;
+}
+
 const schema = z
     .object({
         tokenA: z.string().min(1, 'Token A is required'),
@@ -61,8 +66,10 @@ const rebalanceOptions = [
     {value: '1w', label: '1 week'},
 ];
 
-const DEFAULT_AGENT_INSTRUCTIONS =
-    'Manage this index based on the configured parameters, actively monitoring real-time market data and relevant news to dynamically adjust positions, aiming to capture local highs for exits and local lows for entries to maximize performance within the defined allocation strategy.';
+const DEFAULT_AGENT_INSTRUCTIONS: AgentInstructions = {
+    webSearchStrategy: 'use search tool with keywords CoinTelegraph Solana Latest',
+    goal: 'Manage this index based on the configured parameters, actively monitoring real-time market data and relevant news to dynamically adjust positions, aiming to capture local highs for exits and local lows for entries to maximize performance within the defined allocation strategy.',
+};
 
 const defaultValues: FormValues = {
     tokenA: 'USDT',
@@ -90,7 +97,7 @@ export default function AgentTemplateForm({
         minTokenBAllocation: number;
         risk: string;
         rebalance: string;
-        agentInstructions: string;
+        agentInstructions: AgentInstructions;
     };
     onSubmitSuccess?: () => void;
     onCancel?: () => void;

--- a/frontend/src/routes/AgentTemplates.tsx
+++ b/frontend/src/routes/AgentTemplates.tsx
@@ -6,6 +6,11 @@ import PriceChart from '../components/forms/PriceChart';
 import AgentTemplatesTable from '../components/AgentTemplatesTable';
 import ErrorBoundary from '../components/ErrorBoundary';
 
+interface AgentInstructions {
+  webSearchStrategy: string;
+  goal: string;
+}
+
 interface AgentTemplateDetails {
   id: string;
   name: string;
@@ -16,7 +21,7 @@ interface AgentTemplateDetails {
   minTokenBAllocation: number;
   risk: string;
   rebalance: string;
-  agentInstructions: string;
+  agentInstructions: AgentInstructions;
 }
 
 export default function AgentTemplates() {

--- a/frontend/src/routes/ViewAgent.tsx
+++ b/frontend/src/routes/ViewAgent.tsx
@@ -6,6 +6,11 @@ import AgentStatusLabel from '../components/AgentStatusLabel';
 import TokenDisplay from '../components/TokenDisplay';
 import RiskDisplay from '../components/RiskDisplay';
 
+interface AgentInstructions {
+  webSearchStrategy: string;
+  goal: string;
+}
+
 interface Agent {
   id: string;
   templateId: string;
@@ -21,7 +26,7 @@ interface Agent {
     minTokenBAllocation: number;
     risk: string;
     rebalance: string;
-    agentInstructions: string;
+    agentInstructions: AgentInstructions;
   };
 }
 
@@ -82,7 +87,10 @@ export default function ViewAgent() {
             <strong>Minimum {template.tokenB} Allocation:</strong> {template.minTokenBAllocation}%
           </p>
           <p>
-            <strong>Instructions:</strong> {template.agentInstructions}
+            <strong>Web Search Strategy:</strong> {template.agentInstructions.webSearchStrategy}
+          </p>
+          <p>
+            <strong>Goal:</strong> {template.agentInstructions.goal}
           </p>
         </>
       ) : (

--- a/frontend/src/routes/ViewAgentTemplate.tsx
+++ b/frontend/src/routes/ViewAgentTemplate.tsx
@@ -12,6 +12,11 @@ import WalletBalances from '../components/WalletBalances';
 import TradingAgentInstructions from '../components/TradingAgentInstructions';
 import AgentTemplateName from '../components/AgentTemplateName';
 
+interface AgentInstructions {
+    webSearchStrategy: string;
+    goal: string;
+}
+
 interface AgentTemplateDetails {
     id: string;
     userId: string;
@@ -23,7 +28,7 @@ interface AgentTemplateDetails {
     minTokenBAllocation: number;
     risk: string;
     rebalance: string;
-    agentInstructions: string;
+    agentInstructions: AgentInstructions;
 }
 
 export default function ViewAgentTemplate() {
@@ -77,7 +82,7 @@ export default function ViewAgentTemplate() {
         },
     });
     const [model, setModel] = useState('');
-    const [instructions, setInstructions] = useState('');
+    const [instructions, setInstructions] = useState<AgentInstructions>({webSearchStrategy: '', goal: ''});
     const [name, setName] = useState('');
     const [isCreating, setIsCreating] = useState(false);
     useEffect(() => {


### PR DESCRIPTION
## Summary
- represent agent instructions as structured JSON for templates and agents
- add UI for editing web search strategy and goal fields
- default template instructions now include web search guidance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a198b9bc84832caee18733bb98af46