### PR TITLE
Align template editing fields and add length limits

### DIFF
--- a/frontend/src/components/AgentTemplateName.tsx
+++ b/frontend/src/components/AgentTemplateName.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'react';
-import { Pencil } from 'lucide-react';
-import { useUser } from '../lib/useUser';
+import {useState, useEffect} from 'react';
+import {Pencil} from 'lucide-react';
+import {useUser} from '../lib/useUser';
 import api from '../lib/axios';
 
 interface Props {
@@ -9,8 +9,10 @@ interface Props {
   onChange?: (name: string) => void;
 }
 
-export default function AgentTemplateName({ templateId, name, onChange }: Props) {
-  const { user } = useUser();
+const MAX_NAME_LENGTH = 50;
+
+export default function AgentTemplateName({templateId, name, onChange}: Props) {
+  const {user} = useUser();
   const [editing, setEditing] = useState(false);
   const [text, setText] = useState(name);
 
@@ -22,53 +24,55 @@ export default function AgentTemplateName({ templateId, name, onChange }: Props)
     if (!user) return;
     await api.patch(
       `/agent-templates/${templateId}/name`,
-      { userId: user.id, name: text },
-      { headers: { 'x-user-id': user.id } }
+      {userId: user.id, name: text},
+      {headers: {'x-user-id': user.id}}
     );
     setEditing(false);
     onChange?.(text);
   }
 
-  if (editing) {
-    return (
-      <div className="flex items-center gap-2 mb-4">
-        <input
-          className="border rounded p-1 flex-1"
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-        />
-        <button
-          className="px-2 py-1 bg-blue-600 text-white rounded"
-          onClick={save}
-        >
-          Save
-        </button>
-        <button
-          className="px-2 py-1 border rounded"
-          onClick={() => {
-            setText(name);
-            setEditing(false);
-          }}
-        >
-          Cancel
-        </button>
-      </div>
-    );
-  }
-
   return (
-    <div className="flex items-center mb-4">
-      <h2 className="text-xl font-bold flex-1">{name}</h2>
-      {user && (
-        <button
-          aria-label="Edit name"
-          className="text-gray-600"
-          onClick={() => setEditing(true)}
-        >
-          <Pencil className="w-4 h-4" />
-        </button>
+    <p className="flex items-center mt-4">
+      <strong className="mr-2">Name:</strong>
+      {editing ? (
+        <>
+          <input
+            className="border rounded p-1 flex-1 mr-2"
+            value={text}
+            maxLength={MAX_NAME_LENGTH}
+            onChange={(e) => setText(e.target.value)}
+          />
+          <button
+            className="px-2 py-1 bg-blue-600 text-white rounded mr-2"
+            onClick={save}
+          >
+            Save
+          </button>
+          <button
+            className="px-2 py-1 border rounded"
+            onClick={() => {
+              setText(name);
+              setEditing(false);
+            }}
+          >
+            Cancel
+          </button>
+        </>
+      ) : (
+        <>
+          <span>{name}</span>
+          {user && (
+            <button
+              aria-label="Edit name"
+              className="text-gray-600 ml-1"
+              onClick={() => setEditing(true)}
+            >
+              <Pencil className="w-4 h-4" />
+            </button>
+          )}
+        </>
       )}
-    </div>
+    </p>
   );
 }
 

--- a/frontend/src/components/AgentTemplateName.tsx
+++ b/frontend/src/components/AgentTemplateName.tsx
@@ -37,7 +37,7 @@ export default function AgentTemplateName({templateId, name, onChange}: Props) {
       {editing ? (
         <>
           <input
-            className="border rounded p-1 mr-2 w-full max-w-[50ch]"
+            className="border rounded p-1 mr-2 w-full max-w-[33ch]"
             value={text}
             maxLength={MAX_NAME_LENGTH}
             onChange={(e) => setText(e.target.value)}

--- a/frontend/src/components/AgentTemplateName.tsx
+++ b/frontend/src/components/AgentTemplateName.tsx
@@ -37,7 +37,7 @@ export default function AgentTemplateName({templateId, name, onChange}: Props) {
       {editing ? (
         <>
           <input
-            className="border rounded p-1 flex-1 mr-2"
+            className="border rounded p-1 mr-2 w-full max-w-[50ch]"
             value={text}
             maxLength={MAX_NAME_LENGTH}
             onChange={(e) => setText(e.target.value)}
@@ -64,7 +64,7 @@ export default function AgentTemplateName({templateId, name, onChange}: Props) {
           {user && (
             <button
               aria-label="Edit name"
-              className="text-gray-600 ml-1"
+              className="text-gray-600 ml-2"
               onClick={() => setEditing(true)}
             >
               <Pencil className="w-4 h-4" />

--- a/frontend/src/components/TradingAgentInstructions.tsx
+++ b/frontend/src/components/TradingAgentInstructions.tsx
@@ -13,6 +13,7 @@ export default function TradingAgentInstructions({templateId, instructions, onCh
   const {user} = useUser();
   const [editing, setEditing] = useState(false);
   const [text, setText] = useState(instructions);
+  const MAX_LENGTH = 2000;
 
   useEffect(() => {
     setText(instructions);
@@ -49,8 +50,12 @@ export default function TradingAgentInstructions({templateId, instructions, onCh
             className="w-full border rounded p-2"
             rows={4}
             value={text}
+            maxLength={MAX_LENGTH}
             onChange={(e) => setText(e.target.value)}
           />
+          <div className="text-sm text-gray-600 text-right mt-1">
+            {text.length}/{MAX_LENGTH}
+          </div>
           <div className="mt-2 flex gap-2">
             <button
               className="px-4 py-2 bg-blue-600 text-white rounded"

--- a/frontend/src/routes/ViewAgentTemplate.tsx
+++ b/frontend/src/routes/ViewAgentTemplate.tsx
@@ -110,7 +110,7 @@ export default function ViewAgentTemplate() {
         <div className="p-4">
             <h1 className="text-2xl font-bold mb-2">Agent Template</h1>
             <AgentTemplateName templateId={data.id} name={name} onChange={setName} />
-            <p className="mt-4">
+            <p>
                 <strong>Tokens:</strong> {data.tokenA.toUpperCase()} / {data.tokenB.toUpperCase()}
             </p>
             <p>


### PR DESCRIPTION
## Summary
- Limit agent template name to 50 characters and align its edit icon inline with other fields
- Constrain instructions prompt to 2000 characters with live character counter
- Remove extra spacing around token list to match updated name field styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1a361e7d4832cb20b35523d48db88