### PR TITLE
Prevent duplicate templates and agents

### DIFF
--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -29,7 +29,8 @@ CREATE TABLE IF NOT EXISTS agent_templates(
   min_b_allocation INTEGER,
   risk TEXT,
   rebalance TEXT,
-  agent_instructions TEXT
+  agent_instructions TEXT,
+  UNIQUE(user_id, name)
 );
 
 CREATE TABLE IF NOT EXISTS agents(
@@ -38,7 +39,8 @@ CREATE TABLE IF NOT EXISTS agents(
   user_id TEXT,
   model TEXT,
   status TEXT,
-  created_at INTEGER
+  created_at INTEGER,
+  UNIQUE(template_id)
 );
 
 CREATE TABLE IF NOT EXISTS agent_exec_log(

--- a/backend/src/routes/agent-templates.ts
+++ b/backend/src/routes/agent-templates.ts
@@ -89,6 +89,13 @@ export default async function agentTemplateRoutes(app: FastifyInstance) {
     const userId = req.headers['x-user-id'] as string | undefined;
     if (!userId || body.userId !== userId)
       return reply.code(403).send({ error: 'forbidden' });
+    const dupe = db
+      .prepare('SELECT 1 FROM agent_templates WHERE user_id = ? AND name = ?')
+      .get(body.userId, body.name);
+    if (dupe)
+      return reply
+        .code(409)
+        .send({ error: 'template with this name already exists' });
     const id = randomUUID();
     const tokenA = body.tokenA.toUpperCase();
     const tokenB = body.tokenB.toUpperCase();
@@ -164,6 +171,15 @@ export default async function agentTemplateRoutes(app: FastifyInstance) {
     if (!existing) return reply.code(404).send({ error: 'not found' });
     if (!userId || existing.user_id !== userId || body.userId !== userId)
       return reply.code(403).send({ error: 'forbidden' });
+    const dupe = db
+      .prepare(
+        'SELECT 1 FROM agent_templates WHERE user_id = ? AND name = ? AND id != ?'
+      )
+      .get(userId, body.name, id);
+    if (dupe)
+      return reply
+        .code(409)
+        .send({ error: 'template with this name already exists' });
     db.prepare('UPDATE agent_templates SET name = ? WHERE id = ?').run(
       body.name,
       id
@@ -195,6 +211,15 @@ export default async function agentTemplateRoutes(app: FastifyInstance) {
     if (!existing) return reply.code(404).send({ error: 'not found' });
     if (!userId || existing.user_id !== userId || body.userId !== userId)
       return reply.code(403).send({ error: 'forbidden' });
+    const dupe = db
+      .prepare(
+        'SELECT 1 FROM agent_templates WHERE user_id = ? AND name = ? AND id != ?'
+      )
+      .get(body.userId, body.name, id);
+    if (dupe)
+      return reply
+        .code(409)
+        .send({ error: 'template with this name already exists' });
     const tokenA = body.tokenA.toUpperCase();
     const tokenB = body.tokenB.toUpperCase();
     const { targetAllocation, minTokenAAllocation, minTokenBAllocation } = normalizeAllocations(

--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -110,6 +110,13 @@ export default async function agentRoutes(app: FastifyInstance) {
       .get(body.templateId) as { user_id: string } | undefined;
     if (!template || template.user_id !== userId)
       return reply.code(403).send({ error: 'forbidden' });
+    const dupe = db
+      .prepare('SELECT 1 FROM agents WHERE template_id = ? AND user_id = ?')
+      .get(body.templateId, body.userId);
+    if (dupe)
+      return reply
+        .code(409)
+        .send({ error: 'agent already exists for this template' });
     const userRow = db
       .prepare(
         'SELECT ai_api_key_enc, binance_api_key_enc, binance_api_secret_enc FROM users WHERE id = ?'
@@ -167,6 +174,13 @@ export default async function agentRoutes(app: FastifyInstance) {
       .get(body.templateId) as { user_id: string } | undefined;
     if (!template || template.user_id !== userId)
       return reply.code(403).send({ error: 'forbidden' });
+    const dupe = db
+      .prepare('SELECT 1 FROM agents WHERE template_id = ? AND id != ?')
+      .get(body.templateId, id);
+    if (dupe)
+      return reply
+        .code(409)
+        .send({ error: 'agent already exists for this template' });
     db.prepare(
       `UPDATE agents SET template_id = ?, user_id = ?, model = ?, status = ? WHERE id = ?`
     ).run(body.templateId, body.userId, body.model, body.status, id);

--- a/frontend/src/components/AgentTemplateName.tsx
+++ b/frontend/src/components/AgentTemplateName.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Pencil } from 'lucide-react';
+import axios from 'axios';
 import { useUser } from '../lib/useUser';
 import api from '../lib/axios';
 
@@ -20,13 +21,21 @@ export default function AgentTemplateName({ templateId, name, onChange }: Props)
 
   async function save() {
     if (!user) return;
-    await api.patch(
-      `/agent-templates/${templateId}/name`,
-      { userId: user.id, name: text },
-      { headers: { 'x-user-id': user.id } }
-    );
-    setEditing(false);
-    onChange?.(text);
+    try {
+      await api.patch(
+        `/agent-templates/${templateId}/name`,
+        { userId: user.id, name: text },
+        { headers: { 'x-user-id': user.id } }
+      );
+      setEditing(false);
+      onChange?.(text);
+    } catch (err) {
+      if (axios.isAxiosError(err) && err.response?.data?.error) {
+        alert(err.response.data.error);
+      } else {
+        alert('Failed to update name');
+      }
+    }
   }
 
   if (editing) {

--- a/frontend/src/components/forms/AgentTemplateForm.tsx
+++ b/frontend/src/components/forms/AgentTemplateForm.tsx
@@ -1,4 +1,5 @@
 import {useEffect} from 'react';
+import axios from 'axios';
 import {useNavigate} from 'react-router-dom';
 import {Controller, useForm} from 'react-hook-form';
 import {z} from 'zod';
@@ -179,36 +180,44 @@ export default function AgentTemplateForm({
             values.minTokenBAllocation
         );
         const name = `${values.tokenA.toUpperCase()} ${targetAllocation} / ${values.tokenB.toUpperCase()} ${100 - targetAllocation}`;
-        if (template) {
-            await api.put(
-                `/agent-templates/${template.id}`,
-                {
-                    userId: user.id,
-                    name,
-                    ...values,
-                    tokenA: values.tokenA.toUpperCase(),
-                    tokenB: values.tokenB.toUpperCase(),
-                    agentInstructions: template.agentInstructions,
-                },
-                {headers: {'x-user-id': user.id}}
-            );
-            queryClient.invalidateQueries({queryKey: ['agent-templates']});
-            onSubmitSuccess?.();
-        } else {
-            const res = await api.post(
-                '/agent-templates',
-                {
-                    userId: user.id,
-                    name,
-                    ...values,
-                    tokenA: values.tokenA.toUpperCase(),
-                    tokenB: values.tokenB.toUpperCase(),
-                    agentInstructions: DEFAULT_AGENT_INSTRUCTIONS,
-                },
-                {headers: {'x-user-id': user.id}}
-            );
-            queryClient.invalidateQueries({queryKey: ['agent-templates']});
-            navigate(`/agent-templates/${res.data.id}`);
+        try {
+            if (template) {
+                await api.put(
+                    `/agent-templates/${template.id}`,
+                    {
+                        userId: user.id,
+                        name,
+                        ...values,
+                        tokenA: values.tokenA.toUpperCase(),
+                        tokenB: values.tokenB.toUpperCase(),
+                        agentInstructions: template.agentInstructions,
+                    },
+                    {headers: {'x-user-id': user.id}}
+                );
+                queryClient.invalidateQueries({queryKey: ['agent-templates']});
+                onSubmitSuccess?.();
+            } else {
+                const res = await api.post(
+                    '/agent-templates',
+                    {
+                        userId: user.id,
+                        name,
+                        ...values,
+                        tokenA: values.tokenA.toUpperCase(),
+                        tokenB: values.tokenB.toUpperCase(),
+                        agentInstructions: DEFAULT_AGENT_INSTRUCTIONS,
+                    },
+                    {headers: {'x-user-id': user.id}}
+                );
+                queryClient.invalidateQueries({queryKey: ['agent-templates']});
+                navigate(`/agent-templates/${res.data.id}`);
+            }
+        } catch (err) {
+            if (axios.isAxiosError(err) && err.response?.data?.error) {
+                alert(err.response.data.error);
+            } else {
+                alert('Failed to save template');
+            }
         }
     });
 

--- a/frontend/src/routes/ViewAgentTemplate.tsx
+++ b/frontend/src/routes/ViewAgentTemplate.tsx
@@ -204,6 +204,11 @@ export default function ViewAgentTemplate() {
                         } catch (err) {
                             console.error(err);
                             setIsCreating(false);
+                            if (axios.isAxiosError(err) && err.response?.data?.error) {
+                                alert(err.response.data.error);
+                            } else {
+                                alert('Failed to start agent');
+                            }
                         }
                     }}
                 >


### PR DESCRIPTION
## Summary
- enforce DB-level uniqueness for agent templates per user and agents per template
- reject duplicate template names and agent creation server-side with 409 errors
- surface backend errors to users with popup alerts when saving templates or starting agents

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1a78215a0832cb52d72766bd85ba3