### PR TITLE
Rename rebalance frequency to review interval

### DIFF
--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -28,7 +28,7 @@ CREATE TABLE IF NOT EXISTS agent_templates(
   min_a_allocation INTEGER,
   min_b_allocation INTEGER,
   risk TEXT,
-  rebalance TEXT,
+  review_interval TEXT,
   agent_instructions TEXT
 );
 

--- a/backend/src/routes/agent-templates.ts
+++ b/backend/src/routes/agent-templates.ts
@@ -13,7 +13,7 @@ interface AgentTemplateRow {
   min_a_allocation: number;
   min_b_allocation: number;
   risk: string;
-  rebalance: string;
+  review_interval: string;
   agent_instructions: string;
 }
 
@@ -28,7 +28,7 @@ function toApi(row: AgentTemplateRow) {
     minTokenAAllocation: row.min_a_allocation,
     minTokenBAllocation: row.min_b_allocation,
     risk: row.risk,
-    rebalance: row.rebalance,
+    reviewInterval: row.review_interval,
     agentInstructions: row.agent_instructions,
   };
 }
@@ -83,7 +83,7 @@ export default async function agentTemplateRoutes(app: FastifyInstance) {
       minTokenAAllocation: number;
       minTokenBAllocation: number;
       risk: string;
-      rebalance: string;
+      reviewInterval: string;
       agentInstructions: string;
     };
     const userId = req.headers['x-user-id'] as string | undefined;
@@ -98,7 +98,7 @@ export default async function agentTemplateRoutes(app: FastifyInstance) {
       body.minTokenBAllocation
     );
     db.prepare(
-      `INSERT INTO agent_templates (id, user_id, name, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, agent_instructions)
+      `INSERT INTO agent_templates (id, user_id, name, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       id,
@@ -110,7 +110,7 @@ export default async function agentTemplateRoutes(app: FastifyInstance) {
       minTokenAAllocation,
       minTokenBAllocation,
       body.risk,
-      body.rebalance,
+      body.reviewInterval,
       body.agentInstructions
     );
     return {
@@ -186,7 +186,7 @@ export default async function agentTemplateRoutes(app: FastifyInstance) {
       minTokenAAllocation: number;
       minTokenBAllocation: number;
       risk: string;
-      rebalance: string;
+      reviewInterval: string;
       agentInstructions: string;
     };
     const existing = db
@@ -203,7 +203,7 @@ export default async function agentTemplateRoutes(app: FastifyInstance) {
       body.minTokenBAllocation
     );
     db.prepare(
-      `UPDATE agent_templates SET user_id = ?, name = ?, token_a = ?, token_b = ?, target_allocation = ?, min_a_allocation = ?, min_b_allocation = ?, risk = ?, rebalance = ?, agent_instructions = ? WHERE id = ?`
+      `UPDATE agent_templates SET user_id = ?, name = ?, token_a = ?, token_b = ?, target_allocation = ?, min_a_allocation = ?, min_b_allocation = ?, risk = ?, review_interval = ?, agent_instructions = ? WHERE id = ?`
     ).run(
       body.userId,
       body.name,
@@ -213,7 +213,7 @@ export default async function agentTemplateRoutes(app: FastifyInstance) {
       minTokenAAllocation,
       minTokenBAllocation,
       body.risk,
-      body.rebalance,
+      body.reviewInterval,
       body.agentInstructions,
       id
     );

--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -21,7 +21,7 @@ interface AgentRow {
   min_a_allocation: number;
   min_b_allocation: number;
   risk: string;
-  rebalance: string;
+  review_interval: string;
   agent_instructions: string;
 }
 
@@ -42,7 +42,7 @@ function toApi(row: AgentRow) {
       minTokenAAllocation: row.min_a_allocation,
       minTokenBAllocation: row.min_b_allocation,
       risk: row.risk,
-      rebalance: row.rebalance,
+      reviewInterval: row.review_interval,
       agentInstructions: row.agent_instructions,
     },
   };
@@ -51,7 +51,7 @@ function toApi(row: AgentRow) {
 const baseSelect =
   'SELECT a.id, a.template_id, a.user_id, a.model, a.status, a.created_at, ' +
   't.name, t.token_a, t.token_b, t.target_allocation, t.min_a_allocation, t.min_b_allocation, ' +
-  't.risk, t.rebalance, t.agent_instructions FROM agents a JOIN agent_templates t ON a.template_id = t.id';
+  't.risk, t.review_interval, t.agent_instructions FROM agents a JOIN agent_templates t ON a.template_id = t.id';
 
 function getAgent(id: string) {
   return db

--- a/backend/test/agentTemplates.test.ts
+++ b/backend/test/agentTemplates.test.ts
@@ -23,7 +23,7 @@ describe('agent template routes', () => {
       minTokenAAllocation: 10,
       minTokenBAllocation: 20,
       risk: 'low',
-      rebalance: '1h',
+      reviewInterval: '1h',
       agentInstructions: 'prompt',
     };
 
@@ -120,7 +120,7 @@ describe('agent template routes', () => {
       minTokenAAllocation: 10,
       minTokenBAllocation: 20,
       risk: 'low',
-      rebalance: '1h',
+      reviewInterval: '1h',
       agentInstructions: 'prompt',
     };
 
@@ -176,7 +176,7 @@ describe('agent template routes', () => {
       tokenA: 'BTC',
       tokenB: 'ETH',
       risk: 'low',
-      rebalance: '1h',
+      reviewInterval: '1h',
       agentInstructions: 'prompt',
     };
 
@@ -229,7 +229,7 @@ describe('agent template routes', () => {
       minTokenAAllocation: 10,
       minTokenBAllocation: 20,
       risk: 'low',
-      rebalance: '1h',
+      reviewInterval: '1h',
       agentInstructions: 'prompt',
     };
 
@@ -281,7 +281,7 @@ describe('agent template routes', () => {
       minTokenAAllocation: 10,
       minTokenBAllocation: 20,
       risk: 'low',
-      rebalance: '1h',
+      reviewInterval: '1h',
       agentInstructions: 'prompt',
     };
 

--- a/backend/test/agents.test.ts
+++ b/backend/test/agents.test.ts
@@ -16,7 +16,7 @@ describe('agent routes', () => {
       'INSERT INTO users (id, ai_api_key_enc, binance_api_key_enc, binance_api_secret_enc) VALUES (?, ?, ?, ?)'
     ).run('user1', 'a', 'b', 'c');
     db.prepare(
-      `INSERT INTO agent_templates (id, user_id, name, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, agent_instructions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO agent_templates (id, user_id, name, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run('tmpl1', 'user1', 'T1', 'BTC', 'ETH', 60, 10, 20, 'low', '1h', 'prompt');
 
     const payload = { templateId: 'tmpl1', userId: 'user1', model: 'gpt-5', status: 'inactive' };
@@ -94,10 +94,10 @@ describe('agent routes', () => {
       'INSERT INTO users (id, ai_api_key_enc, binance_api_key_enc, binance_api_secret_enc) VALUES (?, ?, ?, ?)'
     ).run('user3', 'a', 'b', 'c');
     db.prepare(
-      `INSERT INTO agent_templates (id, user_id, name, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, agent_instructions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO agent_templates (id, user_id, name, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run('tmpl2', 'user2', 'T2', 'BTC', 'ETH', 60, 10, 20, 'low', '1h', 'prompt');
     db.prepare(
-      `INSERT INTO agent_templates (id, user_id, name, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, rebalance, agent_instructions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO agent_templates (id, user_id, name, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run('tmpl3', 'user3', 'T3', 'BTC', 'ETH', 60, 10, 20, 'low', '1h', 'prompt');
 
     let res = await app.inject({

--- a/frontend/src/components/AgentTemplatesTable.tsx
+++ b/frontend/src/components/AgentTemplatesTable.tsx
@@ -14,7 +14,7 @@ interface AgentTemplate {
   tokenB: string;
   targetAllocation: number;
   risk: string;
-  rebalance: string;
+  reviewInterval: string;
 }
 
 export default function AgentTemplatesTable({
@@ -69,13 +69,13 @@ export default function AgentTemplatesTable({
                 <th className="text-left">Tokens</th>
                 <th className="text-left">Target Allocation</th>
                 <th className="text-left">Risk</th>
-                <th className="text-left">Rebalance</th>
+                <th className="text-left">Review Interval</th>
                 <th></th>
               </tr>
             </thead>
             <tbody>
               {items.map((t) => {
-                const rebalanceMap: Record<string, string> = {
+                const reviewIntervalMap: Record<string, string> = {
                   '1h': '1 hour',
                   '3h': '3 hours',
                   '5h': '5 hours',
@@ -84,7 +84,7 @@ export default function AgentTemplatesTable({
                   '3d': '3 days',
                   '1w': '1 week',
                 };
-                const rebalance = rebalanceMap[t.rebalance] || t.rebalance;
+                const reviewInterval = reviewIntervalMap[t.reviewInterval] || t.reviewInterval;
                 const handleDelete = async () => {
                   if (!user) return;
                   await api.delete(`/agent-templates/${t.id}`, {
@@ -105,7 +105,7 @@ export default function AgentTemplatesTable({
                     <td>
                       <RiskDisplay risk={t.risk} />
                     </td>
-                    <td>{rebalance}</td>
+                    <td>{reviewInterval}</td>
                     <td className="flex gap-2">
                       <Link
                         to={`/agent-templates/${t.id}`}

--- a/frontend/src/components/forms/AgentTemplateForm.tsx
+++ b/frontend/src/components/forms/AgentTemplateForm.tsx
@@ -11,6 +11,7 @@ import TokenSelect from './TokenSelect';
 import TextInput from './TextInput';
 import SelectInput from './SelectInput';
 import RiskDisplay from '../RiskDisplay';
+import {Info} from 'lucide-react';
 
 const schema = z
     .object({
@@ -29,7 +30,7 @@ const schema = z
             .min(0, 'Must be at least 0')
             .max(100, 'Must be 100 or less'),
         risk: z.enum(['low', 'medium', 'high']),
-        rebalance: z.enum(['1h', '3h', '5h', '12h', '24h', '3d', '1w']),
+        reviewInterval: z.enum(['1h', '3h', '5h', '12h', '24h', '3d', '1w']),
     })
     .refine((data) => data.tokenA !== data.tokenB, {
         message: 'Tokens must be different',
@@ -51,7 +52,7 @@ const riskOptions = [
     {value: 'high', label: <RiskDisplay risk="high" />},
 ];
 
-const rebalanceOptions = [
+const reviewIntervalOptions = [
     {value: '1h', label: '1 hour'},
     {value: '3h', label: '3 hours'},
     {value: '5h', label: '5 hours'},
@@ -71,7 +72,7 @@ const defaultValues: FormValues = {
     minTokenAAllocation: 0,
     minTokenBAllocation: 30,
     risk: 'low',
-    rebalance: '1h',
+    reviewInterval: '1h',
 };
 
 export default function AgentTemplateForm({
@@ -89,7 +90,7 @@ export default function AgentTemplateForm({
         minTokenAAllocation: number;
         minTokenBAllocation: number;
         risk: string;
-        rebalance: string;
+        reviewInterval: string;
         agentInstructions: string;
     };
     onSubmitSuccess?: () => void;
@@ -119,7 +120,7 @@ export default function AgentTemplateForm({
                 minTokenAAllocation: template.minTokenAAllocation,
                 minTokenBAllocation: template.minTokenBAllocation,
                 risk: template.risk as any,
-                rebalance: template.rebalance as any,
+                reviewInterval: template.reviewInterval as any,
             });
         } else {
             reset(defaultValues);
@@ -358,18 +359,21 @@ export default function AgentTemplateForm({
                         />
                     </div>
                     <div>
-                        <label className="block text-sm font-medium mb-1" htmlFor="rebalance">
-                            Rebalance Frequency
+                        <label className="block text-sm font-medium mb-1" htmlFor="reviewInterval">
+                            <span className="inline-flex items-center">
+                                Review Interval
+                                <Info className="w-4 h-4 ml-1 text-gray-500" title="How often the agent will review the portfolio; it may not rebalance every time." />
+                            </span>
                         </label>
                         <Controller
-                            name="rebalance"
+                            name="reviewInterval"
                             control={control}
                             render={({field}) => (
                                 <SelectInput
-                                    id="rebalance"
+                                    id="reviewInterval"
                                     value={field.value}
                                     onChange={field.onChange}
-                                    options={rebalanceOptions}
+                                    options={reviewIntervalOptions}
                                 />
                             )}
                         />

--- a/frontend/src/routes/AgentTemplates.tsx
+++ b/frontend/src/routes/AgentTemplates.tsx
@@ -15,7 +15,7 @@ interface AgentTemplateDetails {
   minTokenAAllocation: number;
   minTokenBAllocation: number;
   risk: string;
-  rebalance: string;
+  reviewInterval: string;
   agentInstructions: string;
 }
 

--- a/frontend/src/routes/ViewAgent.tsx
+++ b/frontend/src/routes/ViewAgent.tsx
@@ -20,7 +20,7 @@ interface Agent {
     minTokenAAllocation: number;
     minTokenBAllocation: number;
     risk: string;
-    rebalance: string;
+    reviewInterval: string;
     agentInstructions: string;
   };
 }
@@ -42,8 +42,8 @@ export default function ViewAgent() {
   if (!data) return <div className="p-4">Loading...</div>;
 
   const template = data.template;
-  const rebalanceLabel =
-    template?.rebalance === '1h' ? '1 hour' : template?.rebalance;
+  const reviewIntervalLabel =
+    template?.reviewInterval === '1h' ? '1 hour' : template?.reviewInterval;
 
   return (
     <div className="p-4">
@@ -70,7 +70,7 @@ export default function ViewAgent() {
             <RiskDisplay risk={template.risk} />
           </p>
           <p>
-            <strong>Rebalance:</strong> {rebalanceLabel}
+            <strong>Review Interval:</strong> {reviewIntervalLabel}
           </p>
           <p>
             <strong>Target Allocation:</strong> {template.targetAllocation} / {100 - template.targetAllocation}

--- a/frontend/src/routes/ViewAgentTemplate.tsx
+++ b/frontend/src/routes/ViewAgentTemplate.tsx
@@ -22,7 +22,7 @@ interface AgentTemplateDetails {
     minTokenAAllocation: number;
     minTokenBAllocation: number;
     risk: string;
-    rebalance: string;
+    reviewInterval: string;
     agentInstructions: string;
 }
 
@@ -126,7 +126,7 @@ export default function ViewAgentTemplate() {
                 <strong>Risk Tolerance:</strong> <RiskDisplay risk={data.risk} />
             </p>
             <p>
-                <strong>Rebalance Frequency:</strong> {data.rebalance}
+                <strong>Review Interval:</strong> {data.reviewInterval}
             </p>
             <TradingAgentInstructions
                 templateId={data.id}


### PR DESCRIPTION
## Summary
- rename `rebalance` fields to `reviewInterval`/`review_interval`
- show review interval on agent template table and views
- add info tip explaining review interval in agent template form

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1ad13c800832c9573f5cca77f3773