### PR TITLE
feat: improve agent template display

### DIFF
--- a/frontend/src/components/AgentTemplatesTable.tsx
+++ b/frontend/src/components/AgentTemplatesTable.tsx
@@ -76,13 +76,13 @@ export default function AgentTemplatesTable({
             <tbody>
               {items.map((t) => {
                 const reviewIntervalMap: Record<string, string> = {
-                  '1h': '1 hour',
-                  '3h': '3 hours',
-                  '5h': '5 hours',
-                  '12h': '12 hours',
-                  '24h': '1 day',
-                  '3d': '3 days',
-                  '1w': '1 week',
+                  '1h': '1 Hour',
+                  '3h': '3 Hours',
+                  '5h': '5 Hours',
+                  '12h': '12 Hours',
+                  '24h': '1 Day',
+                  '3d': '3 Days',
+                  '1w': '1 Week',
                 };
                 const reviewInterval = reviewIntervalMap[t.reviewInterval] || t.reviewInterval;
                 const handleDelete = async () => {

--- a/frontend/src/components/forms/AgentTemplateForm.tsx
+++ b/frontend/src/components/forms/AgentTemplateForm.tsx
@@ -53,13 +53,13 @@ const riskOptions = [
 ];
 
 const reviewIntervalOptions = [
-    {value: '1h', label: '1 hour'},
-    {value: '3h', label: '3 hours'},
-    {value: '5h', label: '5 hours'},
-    {value: '12h', label: '12 hours'},
-    {value: '24h', label: '1 day'},
-    {value: '3d', label: '3 days'},
-    {value: '1w', label: '1 week'},
+    {value: '1h', label: '1 Hour'},
+    {value: '3h', label: '3 Hours'},
+    {value: '5h', label: '5 Hours'},
+    {value: '12h', label: '12 Hours'},
+    {value: '24h', label: '1 Day'},
+    {value: '3d', label: '3 Days'},
+    {value: '1w', label: '1 Week'},
 ];
 
 const DEFAULT_AGENT_INSTRUCTIONS =

--- a/frontend/src/routes/ViewAgent.tsx
+++ b/frontend/src/routes/ViewAgent.tsx
@@ -42,8 +42,17 @@ export default function ViewAgent() {
   if (!data) return <div className="p-4">Loading...</div>;
 
   const template = data.template;
+  const reviewIntervalMap: Record<string, string> = {
+    '1h': '1 Hour',
+    '3h': '3 Hours',
+    '5h': '5 Hours',
+    '12h': '12 Hours',
+    '24h': '1 Day',
+    '3d': '3 Days',
+    '1w': '1 Week',
+  };
   const reviewIntervalLabel =
-    template?.reviewInterval === '1h' ? '1 hour' : template?.reviewInterval;
+    reviewIntervalMap[template?.reviewInterval ?? ''] ?? template?.reviewInterval;
 
   return (
     <div className="p-4">
@@ -59,14 +68,14 @@ export default function ViewAgent() {
       </p>
       {template ? (
         <>
-          <p className="flex items-center">
-            <strong className="mr-1">Tokens:</strong>
+          <p className="flex items-center gap-1">
+            <strong>Tokens:</strong>
             <TokenDisplay token={template.tokenA} />
-            <span className="mx-1">/</span>
+            <span>/</span>
             <TokenDisplay token={template.tokenB} />
           </p>
-          <p className="flex items-center">
-            <strong className="mr-1">Risk:</strong>
+          <p className="flex items-center gap-1">
+            <strong>Risk:</strong>
             <RiskDisplay risk={template.risk} />
           </p>
           <p>

--- a/frontend/src/routes/ViewAgentTemplate.tsx
+++ b/frontend/src/routes/ViewAgentTemplate.tsx
@@ -1,6 +1,7 @@
 import {useEffect, useState} from 'react';
 import type {ReactNode} from 'react';
 import RiskDisplay from '../components/RiskDisplay';
+import TokenDisplay from '../components/TokenDisplay';
 import {useParams, useNavigate} from 'react-router-dom';
 import {useQuery} from '@tanstack/react-query';
 import axios from 'axios';
@@ -98,6 +99,17 @@ export default function ViewAgentTemplate() {
 
     if (!data) return <div className="p-4">Loading...</div>;
 
+    const reviewIntervalMap: Record<string, string> = {
+        '1h': '1 Hour',
+        '3h': '3 Hours',
+        '5h': '5 Hours',
+        '12h': '12 Hours',
+        '24h': '1 Day',
+        '3d': '3 Days',
+        '1w': '1 Week',
+    };
+    const reviewIntervalLabel = reviewIntervalMap[data.reviewInterval] ?? data.reviewInterval;
+
     function WarningSign({children}: { children: ReactNode }) {
         return (
             <div className="mt-2 p-4 text-sm text-red-600 border border-red-600 rounded bg-red-100">
@@ -110,8 +122,11 @@ export default function ViewAgentTemplate() {
         <div className="p-4">
             <h1 className="text-2xl font-bold mb-2">Agent Template</h1>
             <AgentTemplateName templateId={data.id} name={name} onChange={setName} />
-            <p>
-                <strong>Tokens:</strong> {data.tokenA.toUpperCase()} / {data.tokenB.toUpperCase()}
+            <p className="flex items-center gap-1">
+                <strong>Tokens:</strong>
+                <TokenDisplay token={data.tokenA} />
+                <span>/</span>
+                <TokenDisplay token={data.tokenB} />
             </p>
             <p>
                 <strong>Target Allocation:</strong> {data.targetAllocation} / {100 - data.targetAllocation}
@@ -126,7 +141,7 @@ export default function ViewAgentTemplate() {
                 <strong>Risk Tolerance:</strong> <RiskDisplay risk={data.risk} />
             </p>
             <p>
-                <strong>Review Interval:</strong> {data.reviewInterval}
+                <strong>Review Interval:</strong> {reviewIntervalLabel}
             </p>
             <TradingAgentInstructions
                 templateId={data.id}


### PR DESCRIPTION
## Summary
- show tokens with TokenDisplay in agent template view
- map review interval codes to human-friendly labels
- align token label with TokenDisplay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1c10ac30c832cb73e23613e84b06f