### PR TITLE
feat: add reusable button component

### DIFF
--- a/frontend/src/components/AgentTemplateName.tsx
+++ b/frontend/src/components/AgentTemplateName.tsx
@@ -2,6 +2,7 @@ import {useState, useEffect} from 'react';
 import {Pencil} from 'lucide-react';
 import {useUser} from '../lib/useUser';
 import api from '../lib/axios';
+import Button from './ui/Button';
 
 interface Props {
   templateId: string;
@@ -42,21 +43,18 @@ export default function AgentTemplateName({templateId, name, onChange}: Props) {
             maxLength={MAX_NAME_LENGTH}
             onChange={(e) => setText(e.target.value)}
           />
-          <button
-            className="px-2 py-1 bg-blue-600 text-white rounded mr-2"
-            onClick={save}
-          >
+          <Button className="mr-2" onClick={save}>
             Save
-          </button>
-          <button
-            className="px-2 py-1 border rounded"
+          </Button>
+          <Button
+            variant="secondary"
             onClick={() => {
               setText(name);
               setEditing(false);
             }}
           >
             Cancel
-          </button>
+          </Button>
         </>
       ) : (
         <>

--- a/frontend/src/components/AgentTemplatesTable.tsx
+++ b/frontend/src/components/AgentTemplatesTable.tsx
@@ -6,6 +6,7 @@ import api from '../lib/axios';
 import { useUser } from '../lib/useUser';
 import TokenDisplay from './TokenDisplay';
 import RiskDisplay from './RiskDisplay';
+import Button from './ui/Button';
 
 interface AgentTemplate {
   id: string;
@@ -138,23 +139,25 @@ export default function AgentTemplatesTable({
           </table>
           {totalPages > 1 && (
             <div className="flex gap-2 items-center">
-              <button
-                className="px-2 py-1 border"
+              <Button
+                type="button"
+                variant="secondary"
                 disabled={page <= 1}
                 onClick={() => setPage((p) => p - 1)}
               >
                 Prev
-              </button>
+              </Button>
               <span>
                 {page} / {totalPages}
               </span>
-              <button
-                className="px-2 py-1 border"
+              <Button
+                type="button"
+                variant="secondary"
                 disabled={page >= totalPages}
                 onClick={() => setPage((p) => p + 1)}
               >
                 Next
-              </button>
+              </Button>
             </div>
           )}
         </>

--- a/frontend/src/components/GoogleLoginButton.tsx
+++ b/frontend/src/components/GoogleLoginButton.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { LogOut } from 'lucide-react';
 import api from '../lib/axios';
 import { useUser } from '../lib/useUser';
+import Button from './ui/Button';
 
 type CredentialResponse = { credential: string };
 
@@ -63,16 +64,18 @@ export default function GoogleLoginButton() {
     return (
       <div className="h-5 flex items-center text-sm gap-2">
         <span>{user.email}</span>
-        <button
+        <Button
+          type="button"
+          variant="link"
+          className="text-xs flex items-center gap-1"
           onClick={() => {
             const google = window.google;
             google?.accounts.id.disableAutoSelect?.();
             setUser(null);
           }}
-          className="text-xs text-blue-500 hover:underline flex items-center gap-1"
         >
           <LogOut className="w-4 h-4" />
-        </button>
+        </Button>
       </div>
     );
   return <div ref={btnRef} className="h-5 capitalize" />;

--- a/frontend/src/components/TradingAgentInstructions.tsx
+++ b/frontend/src/components/TradingAgentInstructions.tsx
@@ -2,6 +2,7 @@ import {useState, useEffect} from 'react';
 import {Pencil} from 'lucide-react';
 import {useUser} from '../lib/useUser';
 import api from '../lib/axios';
+import Button from './ui/Button';
 
 interface Props {
   templateId: string;
@@ -57,21 +58,16 @@ export default function TradingAgentInstructions({templateId, instructions, onCh
             {text.length}/{MAX_LENGTH}
           </div>
           <div className="mt-2 flex gap-2">
-            <button
-              className="px-4 py-2 bg-blue-600 text-white rounded"
-              onClick={save}
-            >
-              Save
-            </button>
-            <button
-              className="px-4 py-2 border rounded"
+            <Button onClick={save}>Save</Button>
+            <Button
+              variant="secondary"
               onClick={() => {
                 setText(instructions);
                 setEditing(false);
               }}
             >
               Cancel
-            </button>
+            </Button>
           </div>
         </div>
       ) : (

--- a/frontend/src/components/forms/AgentTemplateForm.tsx
+++ b/frontend/src/components/forms/AgentTemplateForm.tsx
@@ -14,6 +14,7 @@ import RiskDisplay from '../RiskDisplay';
 import {Info} from 'lucide-react';
 import axios from 'axios';
 import { useToast } from '../Toast';
+import Button from '../ui/Button';
 
 const schema = z
     .object({
@@ -403,37 +404,32 @@ export default function AgentTemplateForm({
                 )}
                 {template ? (
                     <div className="flex gap-2">
-                        <button
+                        <Button
                             type="submit"
-                            className={`flex-1 py-2 rounded border border-transparent ${
-                                user && !isSubmitting
-                                    ? 'bg-blue-600 text-white'
-                                    : 'bg-gray-300 text-gray-500 cursor-not-allowed'
-                            }`}
-                            disabled={!user || isSubmitting}
+                            className="flex-1"
+                            disabled={!user}
+                            loading={isSubmitting}
                         >
                             Update
-                        </button>
-                        <button
+                        </Button>
+                        <Button
                             type="button"
-                            className="flex-1 py-2 rounded border border-gray-300"
+                            variant="secondary"
+                            className="flex-1"
                             onClick={onCancel}
                         >
                             Cancel
-                        </button>
+                        </Button>
                     </div>
                 ) : (
-                    <button
+                    <Button
                         type="submit"
-                        className={`w-full py-2 rounded border border-transparent ${
-                            user && !isSubmitting
-                                ? 'bg-blue-600 text-white'
-                                : 'bg-gray-300 text-gray-500 cursor-not-allowed'
-                        }`}
-                        disabled={!user || isSubmitting}
+                        className="w-full"
+                        disabled={!user}
+                        loading={isSubmitting}
                     >
                         Save Template
-                    </button>
+                    </Button>
                 )}
             </form>
         </>

--- a/frontend/src/components/forms/AiApiKeySection.tsx
+++ b/frontend/src/components/forms/AiApiKeySection.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation } from '@tanstack/react-query';
 import axios from 'axios';
 import api from '../../lib/axios';
 import { useUser } from '../../lib/useUser';
+import Button from '../ui/Button';
 
 const textSecurityStyle: CSSProperties & { WebkitTextSecurity: string } = {
   WebkitTextSecurity: 'disc',
@@ -105,30 +106,26 @@ export default function AiApiKeySection({ label }: { label: string }) {
             </p>
           )}
           <div className="flex gap-2">
-            <button
+            <Button
               type="button"
               onClick={onSubmit}
               disabled={saveDisabled}
-              className={`bg-blue-600 text-white px-2 py-1 rounded ${
-                saveDisabled ? 'opacity-50 cursor-not-allowed' : ''
-              }`}
+              loading={saveMut.isPending}
             >
               {query.data ? 'Update' : 'Save'}
-            </button>
+            </Button>
             {query.data && (
-              <button
+              <Button
                 type="button"
+                variant="secondary"
                 onClick={() => {
                   setEditing(false);
                   form.setValue('key', query.data ?? '');
                 }}
                 disabled={saveMut.isPending}
-                className={`bg-gray-300 px-2 py-1 rounded ${
-                  saveMut.isPending ? 'opacity-50 cursor-not-allowed' : ''
-                }`}
               >
                 Cancel
-              </button>
+              </Button>
             )}
           </div>
         </div>
@@ -143,29 +140,24 @@ export default function AiApiKeySection({ label }: { label: string }) {
             data-lpignore="true"
             data-1p-ignore="true"
           />
-          <button
+          <Button
             type="button"
             onClick={() => {
               setEditing(true);
               form.setValue('key', '');
             }}
             disabled={delMut.isPending}
-            className={`bg-blue-600 text-white px-2 py-1 rounded ${
-              delMut.isPending ? 'opacity-50 cursor-not-allowed' : ''
-            }`}
           >
             Edit
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
+            variant="danger"
             onClick={() => delMut.mutate()}
             disabled={delMut.isPending}
-            className={`bg-red-600 text-white px-2 py-1 rounded ${
-              delMut.isPending ? 'opacity-50 cursor-not-allowed' : ''
-            }`}
           >
             Delete
-          </button>
+          </Button>
         </div>
       )}
     </div>

--- a/frontend/src/components/forms/ExchangeApiKeySection.tsx
+++ b/frontend/src/components/forms/ExchangeApiKeySection.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation } from '@tanstack/react-query';
 import axios from 'axios';
 import api from '../../lib/axios';
 import { useUser } from '../../lib/useUser';
+import Button from '../ui/Button';
 
 const textSecurityStyle: CSSProperties & { WebkitTextSecurity: string } = {
   WebkitTextSecurity: 'disc',
@@ -138,30 +139,26 @@ export default function ExchangeApiKeySection({ exchange, label }: Props) {
             </p>
           )}
           <div className="flex gap-2">
-            <button
+            <Button
               type="button"
               onClick={onSubmit}
               disabled={saveDisabled}
-              className={`bg-blue-600 text-white px-2 py-1 rounded ${
-                saveDisabled ? 'opacity-50 cursor-not-allowed' : ''
-              }`}
+              loading={saveMut.isPending}
             >
               {query.data ? 'Update' : 'Save'}
-            </button>
+            </Button>
             {query.data && (
-              <button
+              <Button
                 type="button"
+                variant="secondary"
                 onClick={() => {
                   setEditing(false);
                   form.reset(query.data ?? { key: '', secret: '' });
                 }}
                 disabled={saveMut.isPending}
-                className={`bg-gray-300 px-2 py-1 rounded ${
-                  saveMut.isPending ? 'opacity-50 cursor-not-allowed' : ''
-                }`}
               >
                 Cancel
-              </button>
+              </Button>
             )}
           </div>
         </div>
@@ -177,29 +174,24 @@ export default function ExchangeApiKeySection({ exchange, label }: Props) {
               data-lpignore="true"
               data-1p-ignore="true"
             />
-            <button
+            <Button
               type="button"
               onClick={() => {
                 setEditing(true);
                 form.reset({ key: '', secret: '' });
               }}
               disabled={delMut.isPending}
-              className={`bg-blue-600 text-white px-2 py-1 rounded ${
-                delMut.isPending ? 'opacity-50 cursor-not-allowed' : ''
-              }`}
             >
               Edit
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
+              variant="danger"
               onClick={() => delMut.mutate()}
               disabled={delMut.isPending}
-              className={`bg-red-600 text-white px-2 py-1 rounded ${
-                delMut.isPending ? 'opacity-50 cursor-not-allowed' : ''
-              }`}
             >
               Delete
-            </button>
+            </Button>
           </div>
           {balanceQuery.isLoading ? (
             <p>Loading balance...</p>

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,36 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary' | 'danger' | 'link';
+  loading?: boolean;
+  children: ReactNode;
+}
+
+export default function Button({
+  variant = 'primary',
+  loading = false,
+  disabled,
+  className = '',
+  children,
+  ...props
+}: Props) {
+  const base = 'px-3 py-1.5 rounded text-sm flex items-center justify-center';
+  const variants: Record<string, string> = {
+    primary:
+      'bg-blue-600 text-white hover:bg-blue-700 disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed',
+    secondary:
+      'border border-gray-300 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed',
+    danger:
+      'bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed',
+    link: 'text-blue-500 hover:underline disabled:opacity-50 disabled:cursor-not-allowed bg-transparent',
+  };
+  return (
+    <button
+      {...props}
+      disabled={disabled || loading}
+      className={`${base} ${variants[variant]} ${className}`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -7,6 +7,7 @@ import { useUser } from '../lib/useUser';
 import AgentStatusLabel from '../components/AgentStatusLabel';
 import TokenDisplay from '../components/TokenDisplay';
 import AgentBalance from '../components/AgentBalance';
+import Button from '../components/ui/Button';
 
 interface Agent {
   id: string;
@@ -114,23 +115,25 @@ export default function Dashboard() {
           </table>
           {totalPages > 0 && (
             <div className="flex gap-2 items-center">
-              <button
-                className="px-2 py-1 border"
+              <Button
+                type="button"
+                variant="secondary"
                 disabled={page <= 1}
                 onClick={() => setPage((p) => p - 1)}
               >
                 Prev
-              </button>
+              </Button>
               <span>
                 {page} / {totalPages}
               </span>
-              <button
-                className="px-2 py-1 border"
+              <Button
+                type="button"
+                variant="secondary"
                 disabled={page >= totalPages}
                 onClick={() => setPage((p) => p + 1)}
               >
                 Next
-              </button>
+              </Button>
             </div>
           )}
         </>

--- a/frontend/src/routes/Settings.tsx
+++ b/frontend/src/routes/Settings.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, FormEvent } from 'react';
 import QRCode from 'react-qr-code';
 import api from '../lib/axios';
 import { useUser } from '../lib/useUser';
+import Button from '../components/ui/Button';
 
 export default function Settings() {
   const { user } = useUser();
@@ -60,9 +61,7 @@ export default function Settings() {
             value={code}
             onChange={(e) => setCode(e.target.value)}
           />
-          <button type="submit" className="px-2 py-1 bg-blue-500 text-white rounded">
-            Disable
-          </button>
+          <Button type="submit">Disable</Button>
         </form>
       ) : setup ? (
         <form onSubmit={enable} className="space-y-2">
@@ -74,17 +73,10 @@ export default function Settings() {
             value={code}
             onChange={(e) => setCode(e.target.value)}
           />
-          <button type="submit" className="px-2 py-1 bg-blue-500 text-white rounded">
-            Enable
-          </button>
+          <Button type="submit">Enable</Button>
         </form>
       ) : (
-        <button
-          onClick={startSetup}
-          className="px-2 py-1 bg-blue-500 text-white rounded"
-        >
-          Setup 2FA
-        </button>
+        <Button onClick={startSetup}>Setup 2FA</Button>
       )}
     </div>
   );

--- a/frontend/src/routes/ViewAgentTemplate.tsx
+++ b/frontend/src/routes/ViewAgentTemplate.tsx
@@ -13,6 +13,7 @@ import WalletBalances from '../components/WalletBalances';
 import TradingAgentInstructions from '../components/TradingAgentInstructions';
 import AgentTemplateName from '../components/AgentTemplateName';
 import { useToast } from '../components/Toast';
+import Button from '../components/ui/Button';
 
 interface AgentTemplateDetails {
     id: string;
@@ -191,12 +192,8 @@ export default function ViewAgentTemplate() {
                 {!user && (
                     <p className="text-sm text-gray-600 mb-2 mt-4">Log in to continue</p>
                 )}
-                <button
-                    className={`mt-4 px-4 py-2 rounded ${
-                        !isCreating && user && hasOpenAIKey && hasBinanceKey && modelsQuery.data?.length
-                            ? 'bg-blue-600 text-white'
-                            : 'bg-gray-300 text-gray-500 cursor-not-allowed'
-                    }`}
+                <Button
+                    className="mt-4"
                     disabled={
                         isCreating ||
                         !user ||
@@ -204,6 +201,7 @@ export default function ViewAgentTemplate() {
                         !hasBinanceKey ||
                         !modelsQuery.data?.length
                     }
+                    loading={isCreating}
                     onClick={async () => {
                         if (!user) return;
                         setIsCreating(true);
@@ -229,7 +227,7 @@ export default function ViewAgentTemplate() {
                     }}
                 >
                     Start Agent
-                </button>
+                </Button>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- add reusable Button component with primary, secondary, danger and link styles
- update forms, settings and tables to use new Button component and support loading state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1c86a3c6c832cb1a6f531e5ab710e