### PR TITLE
Ensure consistent button heights

### DIFF
--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -14,15 +14,17 @@ export default function Button({
   children,
   ...props
 }: Props) {
-  const base = 'px-3 py-1.5 rounded text-sm flex items-center justify-center';
+  const base =
+    'px-3 py-1.5 rounded text-sm flex items-center justify-center border';
   const variants: Record<string, string> = {
     primary:
-      'bg-blue-600 text-white hover:bg-blue-700 disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed',
+      'bg-blue-600 text-white hover:bg-blue-700 disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed border-transparent',
     secondary:
-      'border border-gray-300 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed',
+      'border-gray-300 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed',
     danger:
-      'bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed',
-    link: 'text-blue-500 hover:underline disabled:opacity-50 disabled:cursor-not-allowed bg-transparent',
+      'bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed border-transparent',
+    link:
+      'text-blue-500 hover:underline disabled:opacity-50 disabled:cursor-not-allowed bg-transparent border-none',
   };
   return (
     <button


### PR DESCRIPTION
## Summary
- add a transparent border to primary/danger buttons and include border in base button style
- prevent secondary button border from increasing height

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1cb1a4f30832cb1251d90d31f5bd0