### PR TITLE
Ensure consistent button heights and streamline form fields

### DIFF
--- a/frontend/src/components/forms/AgentTemplateForm.tsx
+++ b/frontend/src/components/forms/AgentTemplateForm.tsx
@@ -10,8 +10,8 @@ import {normalizeAllocations} from '../../lib/allocations';
 import TokenSelect from './TokenSelect';
 import TextInput from './TextInput';
 import SelectInput from './SelectInput';
+import FormField from './FormField';
 import RiskDisplay from '../RiskDisplay';
-import {Info} from 'lucide-react';
 import axios from 'axios';
 import { useToast } from '../Toast';
 import Button from '../ui/Button';
@@ -233,10 +233,7 @@ export default function AgentTemplateForm({
             >
                 <h2 className="text-xl font-bold">{template ? 'Edit Agent Template' : 'Create Agent Template'}</h2>
                 <div className="grid grid-cols-2 gap-4">
-                    <div>
-                        <label className="block text-sm font-medium mb-1" htmlFor="tokenA">
-                            Token A
-                        </label>
+                    <FormField label="Token A" htmlFor="tokenA">
                         <Controller
                             name="tokenA"
                             control={control}
@@ -251,11 +248,8 @@ export default function AgentTemplateForm({
                                 />
                             )}
                         />
-                    </div>
-                    <div>
-                        <label className="block text-sm font-medium mb-1" htmlFor="tokenB">
-                            Token B
-                        </label>
+                    </FormField>
+                    <FormField label="Token B" htmlFor="tokenB">
                         <Controller
                             name="tokenB"
                             control={control}
@@ -270,12 +264,9 @@ export default function AgentTemplateForm({
                                 />
                             )}
                         />
-                    </div>
+                    </FormField>
                 </div>
-                <div>
-                    <label className="block text-sm font-medium mb-1" htmlFor="targetAllocation">
-                        Target Allocation
-                    </label>
+                <FormField label="Target Allocation" htmlFor="targetAllocation">
                     <div className="flex items-center gap-2">
           <span className="w-24 text-right">
             {targetAllocation}% {tokenA.toUpperCase()}
@@ -293,15 +284,12 @@ export default function AgentTemplateForm({
             {100 - targetAllocation}% {tokenB.toUpperCase()}
           </span>
                     </div>
-                </div>
+                </FormField>
                 <div className="grid grid-cols-2 gap-4">
-                    <div>
-                        <label
-                            className="block text-sm font-medium mb-1"
-                            htmlFor="minTokenAAllocation"
-                        >
-                            Min {tokenA.toUpperCase()} allocation
-                        </label>
+                    <FormField
+                        label={`Min ${tokenA.toUpperCase()} allocation`}
+                        htmlFor="minTokenAAllocation"
+                    >
                         <Controller
                             name="minTokenAAllocation"
                             control={control}
@@ -322,14 +310,11 @@ export default function AgentTemplateForm({
                                 />
                             )}
                         />
-                    </div>
-                    <div>
-                        <label
-                            className="block text-sm font-medium mb-1"
-                            htmlFor="minTokenBAllocation"
-                        >
-                            Min {tokenB.toUpperCase()} allocation
-                        </label>
+                    </FormField>
+                    <FormField
+                        label={`Min ${tokenB.toUpperCase()} allocation`}
+                        htmlFor="minTokenBAllocation"
+                    >
                         <Controller
                             name="minTokenBAllocation"
                             control={control}
@@ -350,13 +335,10 @@ export default function AgentTemplateForm({
                                 />
                             )}
                         />
-                    </div>
+                    </FormField>
                 </div>
                 <div className="grid grid-cols-2 gap-4">
-                    <div>
-                        <label className="block text-sm font-medium mb-1" htmlFor="risk">
-                            Risk Tolerance
-                        </label>
+                    <FormField label="Risk Tolerance" htmlFor="risk">
                         <Controller
                             name="risk"
                             control={control}
@@ -369,22 +351,12 @@ export default function AgentTemplateForm({
                                 />
                             )}
                         />
-                    </div>
-                    <div>
-                        <label className="block text-sm font-medium mb-1" htmlFor="reviewInterval">
-                            <span className="inline-flex items-center">
-                                Review Interval
-                                <span
-                                    className="relative ml-1 cursor-pointer group"
-                                    tabIndex={0}
-                                >
-                                    <Info className="w-4 h-4 text-gray-500" />
-                                    <span className="absolute z-10 hidden w-48 -translate-x-1/2 left-1/2 -translate-y-full mb-1 rounded bg-gray-800 p-2 text-xs text-white group-hover:block group-focus:block">
-                                        How often the agent will review the portfolio; it may not rebalance every time.
-                                    </span>
-                                </span>
-                            </span>
-                        </label>
+                    </FormField>
+                    <FormField
+                        label="Review Interval"
+                        htmlFor="reviewInterval"
+                        tooltip="How often the agent will review the portfolio; it may not rebalance every time."
+                    >
                         <Controller
                             name="reviewInterval"
                             control={control}
@@ -397,7 +369,7 @@ export default function AgentTemplateForm({
                                 />
                             )}
                         />
-                    </div>
+                    </FormField>
                 </div>
                 {!user && (
                     <p className="text-sm text-gray-600 mb-2">Log in to continue</p>

--- a/frontend/src/components/forms/FormField.tsx
+++ b/frontend/src/components/forms/FormField.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from 'react';
+import InfoTooltip from '../ui/InfoTooltip';
+
+interface Props {
+  label?: ReactNode;
+  htmlFor?: string;
+  tooltip?: ReactNode;
+  className?: string;
+  children: ReactNode;
+}
+
+export default function FormField({
+  label,
+  htmlFor,
+  tooltip,
+  className = '',
+  children,
+}: Props) {
+  return (
+    <div className={className}>
+      {label && (
+        <label className="block text-sm font-medium mb-1" htmlFor={htmlFor}>
+          <span className="inline-flex items-center">
+            {label}
+            {tooltip && <InfoTooltip>{tooltip}</InfoTooltip>}
+          </span>
+        </label>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -14,15 +14,17 @@ export default function Button({
   children,
   ...props
 }: Props) {
-  const base = 'px-3 py-1.5 rounded text-sm flex items-center justify-center';
+  const base =
+    'px-3 py-1.5 rounded text-sm flex items-center justify-center border';
   const variants: Record<string, string> = {
     primary:
-      'bg-blue-600 text-white hover:bg-blue-700 disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed',
+      'bg-blue-600 text-white hover:bg-blue-700 disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed border-transparent',
     secondary:
-      'border border-gray-300 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed',
+      'border-gray-300 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed',
     danger:
-      'bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed',
-    link: 'text-blue-500 hover:underline disabled:opacity-50 disabled:cursor-not-allowed bg-transparent',
+      'bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed border-transparent',
+    link:
+      'text-blue-500 hover:underline disabled:opacity-50 disabled:cursor-not-allowed bg-transparent border-none',
   };
   return (
     <button

--- a/frontend/src/components/ui/InfoTooltip.tsx
+++ b/frontend/src/components/ui/InfoTooltip.tsx
@@ -1,0 +1,13 @@
+import { Info } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+export default function InfoTooltip({ children }: { children: ReactNode }) {
+  return (
+    <span className="relative ml-1 cursor-pointer group" tabIndex={0}>
+      <Info className="w-4 h-4 text-gray-500" />
+      <span className="absolute z-10 hidden w-48 -translate-x-1/2 left-1/2 -translate-y-full mb-1 rounded bg-gray-800 p-2 text-xs text-white group-hover:block group-focus:block">
+        {children}
+      </span>
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- add a transparent border to primary/danger buttons and include border in base button style
- prevent secondary button border from increasing height
- introduce InfoTooltip and generic FormField for labeled fields with optional tooltips
- refactor AgentTemplateForm to use FormField, reducing repeated markup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1cb1a4f30832cb1251d90d31f5bd0