### PR TITLE
feat: add client-side agent preview

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 import AppShell from './components/layout/AppShell';
 import Dashboard from './routes/Dashboard';
 import Keys from './routes/Keys';
-import ViewAgentTemplate from './routes/ViewAgentTemplate';
+import AgentPreview from './routes/AgentPreview';
 import ViewAgent from './routes/ViewAgent';
 import Settings from './routes/Settings';
 
@@ -13,7 +13,7 @@ export default function App() {
         <Route path="/" element={<Dashboard />} />
         <Route path="/keys" element={<Keys />} />
         <Route path="/settings" element={<Settings />} />
-        <Route path="/agent-templates/:id" element={<ViewAgentTemplate />} />
+        <Route path="/agent-preview" element={<AgentPreview />} />
         <Route path="/agents/:id" element={<ViewAgent />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Route>

--- a/frontend/src/components/AgentTemplatesTable.tsx
+++ b/frontend/src/components/AgentTemplatesTable.tsx
@@ -106,7 +106,8 @@ export default function AgentTemplatesTable({
                     <td>{reviewInterval}</td>
                     <td className="flex gap-2">
                       <Link
-                        to={`/agent-templates/${t.id}`}
+                        to="/agent-preview"
+                        state={t}
                         className="text-blue-600 underline inline-flex"
                         aria-label="View template"
                       >

--- a/frontend/src/components/forms/CreateAgentForm.tsx
+++ b/frontend/src/components/forms/CreateAgentForm.tsx
@@ -13,7 +13,7 @@ import SelectInput from './SelectInput';
 import FormField from './FormField';
 import RiskDisplay from '../RiskDisplay';
 import axios from 'axios';
-import { useToast } from '../Toast';
+import {useToast} from '../Toast';
 import Button from '../ui/Button';
 
 const schema = z
@@ -78,7 +78,7 @@ const defaultValues: FormValues = {
     reviewInterval: '1h',
 };
 
-export default function AgentTemplateForm({
+export default function CreateAgentForm({
                                       onTokensChange,
                                       template,
                                       onSubmitSuccess,
@@ -197,16 +197,18 @@ export default function AgentTemplateForm({
                 queryClient.invalidateQueries({queryKey: ['agent-templates']});
                 onSubmitSuccess?.();
             } else {
-                const res = await api.post('/agent-templates', {
-                    userId: user.id,
+                const previewData = {
                     name,
-                    ...values,
                     tokenA: values.tokenA.toUpperCase(),
                     tokenB: values.tokenB.toUpperCase(),
+                    targetAllocation,
+                    minTokenAAllocation: values.minTokenAAllocation,
+                    minTokenBAllocation: values.minTokenBAllocation,
+                    risk: values.risk,
+                    reviewInterval: values.reviewInterval,
                     agentInstructions: DEFAULT_AGENT_INSTRUCTIONS,
-                });
-                queryClient.invalidateQueries({queryKey: ['agent-templates']});
-                navigate(`/agent-templates/${res.data.id}`);
+                };
+                navigate('/agent-preview', {state: previewData});
             }
         } catch (err) {
             if (axios.isAxiosError(err) && err.response?.data?.error) {
@@ -223,7 +225,7 @@ export default function AgentTemplateForm({
                 onSubmit={onSubmit}
                 className="bg-white shadow-md border border-gray-200 rounded p-6 space-y-4 w-full max-w-[30rem]"
             >
-                <h2 className="text-xl font-bold">{template ? 'Edit Agent Template' : 'Create Agent Template'}</h2>
+                <h2 className="text-xl font-bold">{template ? 'Edit Agent' : 'Create Agent'}</h2>
                 <div className="grid grid-cols-2 gap-4">
                     <FormField label="Token A" htmlFor="tokenA">
                         <Controller
@@ -392,7 +394,7 @@ export default function AgentTemplateForm({
                         disabled={!user}
                         loading={isSubmitting}
                     >
-                        Save Template
+                        Preview
                     </Button>
                 )}
             </form>

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -8,7 +8,7 @@ import AgentStatusLabel from '../components/AgentStatusLabel';
 import TokenDisplay from '../components/TokenDisplay';
 import AgentBalance from '../components/AgentBalance';
 import Button from '../components/ui/Button';
-import AgentTemplateForm from '../components/forms/AgentTemplateForm';
+import CreateAgentForm from '../components/forms/CreateAgentForm';
 import PriceChart from '../components/forms/PriceChart';
 import ErrorBoundary from '../components/ErrorBoundary';
 
@@ -61,7 +61,7 @@ export default function Dashboard() {
         <ErrorBoundary>
           <PriceChart tokenA={tokens.tokenA} tokenB={tokens.tokenB} />
         </ErrorBoundary>
-        <AgentTemplateForm onTokensChange={handleTokensChange} />
+        <CreateAgentForm onTokensChange={handleTokensChange} />
       </div>
       <ErrorBoundary>
         <div className="bg-white shadow-md border border-gray-200 rounded p-6 w-full">

--- a/frontend/src/routes/ViewAgent.tsx
+++ b/frontend/src/routes/ViewAgent.tsx
@@ -60,7 +60,8 @@ export default function ViewAgent() {
           <p>
             <strong>Template:</strong>{' '}
             <Link
-              to={`/agent-templates/${template.id}`}
+              to="/agent-preview"
+              state={template}
               className="text-blue-600 underline"
             >
               {template.name}


### PR DESCRIPTION
## Summary
- rename form and UI to "Create Agent" with Preview button
- render agent preview on the client without calling template API
- route dashboard links and views to the new Agent Preview page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3bc3ca06c832c9e651c2510ddd7da