### PR TITLE
feat: allow saving agent drafts

### DIFF
--- a/backend/src/repos/agents.ts
+++ b/backend/src/repos/agents.ts
@@ -23,6 +23,8 @@ export function getActiveAgents(agentId?: string): ActiveAgentRow[] {
                       u.ai_api_key_enc
                  FROM agents a
                  JOIN users u ON u.id = a.user_id
-                WHERE a.status = 'active' ${agentId ? 'AND a.id = ?' : ''}`;
+                WHERE a.status = 'active' AND a.draft = 0 ${
+                  agentId ? 'AND a.id = ?' : ''
+                }`;
   return db.prepare(sql).all(agentId ? [agentId] : []) as ActiveAgentRow[];
 }

--- a/frontend/src/routes/AgentPreview.tsx
+++ b/frontend/src/routes/AgentPreview.tsx
@@ -70,6 +70,7 @@ export default function AgentPreview() {
     });
     const [model, setModel] = useState('');
     const [isCreating, setIsCreating] = useState(false);
+    const [isSavingDraft, setIsSavingDraft] = useState(false);
     useEffect(() => {
         if (modelsQuery.data && modelsQuery.data.length) {
             setModel(modelsQuery.data[0]);
@@ -165,6 +166,41 @@ export default function AgentPreview() {
                 {!user && (
                     <p className="text-sm text-gray-600 mb-2 mt-4">Log in to continue</p>
                 )}
+                <Button
+                    className="mt-4 mr-2"
+                    disabled={isSavingDraft || !user}
+                    loading={isSavingDraft}
+                    onClick={async () => {
+                        if (!user) return;
+                        setIsSavingDraft(true);
+                        try {
+                            const res = await api.post('/agents', {
+                                userId: user.id,
+                                model,
+                                name: data.name,
+                                tokenA: data.tokenA,
+                                tokenB: data.tokenB,
+                                targetAllocation: data.targetAllocation,
+                                minTokenAAllocation: data.minTokenAAllocation,
+                                minTokenBAllocation: data.minTokenBAllocation,
+                                risk: data.risk,
+                                reviewInterval: data.reviewInterval,
+                                agentInstructions: data.agentInstructions,
+                                draft: true,
+                            });
+                            navigate(`/agents/${res.data.id}`);
+                        } catch (err) {
+                            setIsSavingDraft(false);
+                            if (axios.isAxiosError(err) && err.response?.data?.error) {
+                                toast.show(err.response.data.error);
+                            } else {
+                                toast.show('Failed to save draft');
+                            }
+                        }
+                    }}
+                >
+                    Save Draft
+                </Button>
                 <Button
                     className="mt-4"
                     disabled={


### PR DESCRIPTION
## Summary
- add Save Draft action on agent preview
- relax API key checks for draft agents and force drafts inactive
- prevent scheduler from running draft agents
- test draft validation and scheduler filtering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3ee320910832c8f46939dcfb50146