### PR TITLE
Use status field for draft agents

### DIFF
--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -33,8 +33,7 @@ CREATE TABLE IF NOT EXISTS agents(
   min_b_allocation INTEGER,
   risk TEXT,
   review_interval TEXT,
-  agent_instructions TEXT,
-  draft INTEGER
+  agent_instructions TEXT
 );
 
 CREATE TABLE IF NOT EXISTS agent_exec_log(
@@ -51,12 +50,12 @@ CREATE INDEX IF NOT EXISTS idx_agents_draft_all_fields
     target_allocation, min_a_allocation, min_b_allocation,
     risk, review_interval, agent_instructions
   )
-  WHERE draft = 1;
+  WHERE status = 'draft';
 
 CREATE INDEX IF NOT EXISTS idx_agents_active_token_a
   ON agents(user_id, token_a)
-  WHERE status = 'active' AND draft = 0;
+  WHERE status = 'active';
 
 CREATE INDEX IF NOT EXISTS idx_agents_active_token_b
   ON agents(user_id, token_b)
-  WHERE status = 'active' AND draft = 0;
+  WHERE status = 'active';

--- a/backend/src/repos/agents.ts
+++ b/backend/src/repos/agents.ts
@@ -23,7 +23,7 @@ export function getActiveAgents(agentId?: string): ActiveAgentRow[] {
                       u.ai_api_key_enc
                  FROM agents a
                  JOIN users u ON u.id = a.user_id
-                WHERE a.status = 'active' AND a.draft = 0 ${
+                WHERE a.status = 'active' ${
                   agentId ? 'AND a.id = ?' : ''
                 }`;
   return db.prepare(sql).all(agentId ? [agentId] : []) as ActiveAgentRow[];

--- a/backend/test/agents.test.ts
+++ b/backend/test/agents.test.ts
@@ -52,7 +52,7 @@ describe('agent routes', () => {
       risk: 'low',
       reviewInterval: '1h',
       agentInstructions: 'prompt',
-      draft: false,
+      status: 'active',
     };
 
     let res = await app.inject({
@@ -63,7 +63,7 @@ describe('agent routes', () => {
     });
     expect(res.statusCode).toBe(200);
     const id = res.json().id as string;
-    expect(res.json()).toMatchObject({ id, ...payload, status: 'active' });
+    expect(res.json()).toMatchObject({ id, ...payload });
     expect(fetchMock).toHaveBeenCalledTimes(2);
 
     res = await app.inject({
@@ -72,7 +72,7 @@ describe('agent routes', () => {
       headers: { 'x-user-id': 'user1' },
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toMatchObject({ id, ...payload, status: 'active' });
+    expect(res.json()).toMatchObject({ id, ...payload });
 
     res = await app.inject({
       method: 'GET',
@@ -107,7 +107,7 @@ describe('agent routes', () => {
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ total: 1, page: 1, pageSize: 10 });
 
-    const update = { ...payload, model: 'o3', status: 'inactive', draft: true };
+    const update = { ...payload, model: 'o3', status: 'draft' };
     res = await app.inject({
       method: 'PUT',
       url: `/api/agents/${id}`,
@@ -127,7 +127,7 @@ describe('agent routes', () => {
 
     res = await app.inject({
       method: 'GET',
-      url: '/api/agents?status=inactive',
+      url: '/api/agents?status=draft',
       headers: { 'x-user-id': 'user1' },
     });
     expect(res.statusCode).toBe(200);
@@ -197,7 +197,7 @@ describe('agent routes', () => {
         risk: 'low',
         reviewInterval: '1h',
         agentInstructions: 'prompt',
-        draft: false,
+        status: 'active',
       },
     });
     const id = resCreate.json().id as string;
@@ -233,7 +233,7 @@ describe('agent routes', () => {
       risk: 'low',
       reviewInterval: '1h',
       agentInstructions: 'prompt',
-      draft: true,
+      status: 'draft',
     };
     const resCreate = await app.inject({
       method: 'POST',
@@ -260,7 +260,7 @@ describe('agent routes', () => {
       headers: { 'x-user-id': 'starter' },
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toMatchObject({ status: 'active', draft: false });
+    expect(res.json()).toMatchObject({ status: 'active' });
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(getActiveAgents().find((a) => a.id === id)).toBeDefined();
 
@@ -299,7 +299,7 @@ describe('agent routes', () => {
       method: 'POST',
       url: '/api/agents',
       headers: { 'x-user-id': 'u1' },
-      payload: { ...basePayload, draft: false },
+      payload: { ...basePayload, status: 'active' },
     });
     expect(res.statusCode).toBe(400);
 
@@ -307,7 +307,7 @@ describe('agent routes', () => {
       method: 'POST',
       url: '/api/agents',
       headers: { 'x-user-id': 'u1' },
-      payload: { ...basePayload, draft: true },
+      payload: { ...basePayload, status: 'draft' },
     });
     expect(res.statusCode).toBe(200);
     const draftId = res.json().id as string;
@@ -328,7 +328,7 @@ describe('agent routes', () => {
       method: 'POST',
       url: '/api/agents',
       headers: { 'x-user-id': 'u2' },
-      payload: { ...basePayload, userId: 'u2', name: 'Active', draft: false },
+      payload: { ...basePayload, userId: 'u2', name: 'Active', status: 'active' },
     });
     expect(res.statusCode).toBe(200);
     const activeId = res.json().id as string;
@@ -337,11 +337,9 @@ describe('agent routes', () => {
       method: 'POST',
       url: '/api/agents',
       headers: { 'x-user-id': 'u2' },
-      payload: { ...basePayload, userId: 'u2', name: 'Draft2', draft: true },
+      payload: { ...basePayload, userId: 'u2', name: 'Draft2', status: 'draft' },
     });
     const draft2Id = resDraft2.json().id as string;
-
-    db.prepare('UPDATE agents SET status = ? WHERE id = ?').run('active', draft2Id);
 
     const activeAgents = getActiveAgents();
     expect(activeAgents.find((a) => a.id === activeId)).toBeDefined();
@@ -377,7 +375,7 @@ describe('agent routes', () => {
       risk: 'low',
       reviewInterval: '1h',
       agentInstructions: 'p',
-      draft: false,
+      status: 'active',
     };
 
     const res1 = await app.inject({
@@ -429,7 +427,7 @@ describe('agent routes', () => {
       risk: 'low',
       reviewInterval: '1h',
       agentInstructions: 'p',
-      draft: true,
+      status: 'draft',
     };
 
     const res1 = await app.inject({
@@ -477,7 +475,7 @@ describe('agent routes', () => {
       risk: 'low',
       reviewInterval: '1h',
       agentInstructions: 'p',
-      draft: true,
+      status: 'draft',
     };
 
     const res1 = await app.inject({
@@ -500,7 +498,7 @@ describe('agent routes', () => {
       method: 'PUT',
       url: `/api/agents/${draft2}`,
       headers: { 'x-user-id': 'updUser' },
-      payload: { ...base, status: 'inactive' },
+      payload: { ...base },
     });
     expect(resUpd.statusCode).toBe(400);
     expect(resUpd.json().error).toContain('Draft1');

--- a/frontend/src/components/AgentStatusLabel.tsx
+++ b/frontend/src/components/AgentStatusLabel.tsx
@@ -1,11 +1,14 @@
 interface Props {
-  status: 'active' | 'inactive';
+  status: 'active' | 'inactive' | 'draft';
 }
 
 export default function AgentStatusLabel({ status }: Props) {
   const base = 'px-2 py-1 rounded text-xs font-medium';
   if (status === 'active') {
     return <span className={`${base} bg-green-100 text-green-800`}>Active</span>;
+  }
+  if (status === 'draft') {
+    return <span className={`${base} bg-yellow-100 text-yellow-800`}>Draft</span>;
   }
   return <span className={`${base} bg-gray-200 text-gray-800`}>Inactive</span>;
 }

--- a/frontend/src/routes/AgentPreview.tsx
+++ b/frontend/src/routes/AgentPreview.tsx
@@ -186,7 +186,7 @@ export default function AgentPreview() {
                                 risk: data.risk,
                                 reviewInterval: data.reviewInterval,
                                 agentInstructions: data.agentInstructions,
-                                draft: true,
+                                status: 'draft',
                             });
                             navigate(`/agents/${res.data.id}`);
                         } catch (err) {
@@ -227,7 +227,7 @@ export default function AgentPreview() {
                                 risk: data.risk,
                                 reviewInterval: data.reviewInterval,
                                 agentInstructions: data.agentInstructions,
-                                draft: false,
+                                status: 'active',
                             });
                             navigate(`/agents/${res.data.id}`);
                         } catch (err) {

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -16,7 +16,7 @@ interface Agent {
   id: string;
   userId: string;
   model: string;
-  status: 'active' | 'inactive';
+  status: 'active' | 'inactive' | 'draft';
   tokenA?: string;
   tokenB?: string;
 }


### PR DESCRIPTION
## Summary
- model agent drafts as a dedicated `draft` status instead of a separate flag
- update backend and UI to rely solely on status
- expand status label component to display draft agents

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a516065b14832c9e0568dc9eb242e1