### PR TITLE
Refactor agent preview into editable components

### DIFF
--- a/frontend/src/components/AgentInstructions.tsx
+++ b/frontend/src/components/AgentInstructions.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import { Pencil } from 'lucide-react';
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+  maxLength?: number;
+}
+
+export default function AgentInstructions({ value, onChange, maxLength = 1000 }: Props) {
+  const [editing, setEditing] = useState(false);
+  const [local, setLocal] = useState(value);
+  useEffect(() => setLocal(value), [value]);
+  return (
+    <div className="mt-4">
+      <div className="flex items-center gap-1 mb-2">
+        <h2 className="text-xl font-bold flex-1">Trading Agent Instructions</h2>
+        <Pencil
+          className="w-4 h-4 text-gray-500 cursor-pointer"
+          onClick={() => setEditing(true)}
+        />
+      </div>
+      {editing ? (
+        <>
+          <textarea
+            value={local}
+            onChange={(e) => setLocal(e.target.value)}
+            onBlur={() => {
+              setEditing(false);
+              onChange(local);
+            }}
+            maxLength={maxLength}
+            rows={6}
+            className="w-full border rounded p-2"
+          />
+          <div className="text-right text-sm text-gray-500 mt-1">
+            {local.length} / {maxLength}
+          </div>
+        </>
+      ) : (
+        <pre className="whitespace-pre-wrap">{value}</pre>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/components/AgentName.tsx
+++ b/frontend/src/components/AgentName.tsx
@@ -1,0 +1,17 @@
+import EditableText from './EditableText';
+
+interface Props {
+  name: string;
+  onChange: (value: string) => void;
+}
+
+export default function AgentName({ name, onChange }: Props) {
+  return (
+    <EditableText
+      value={name}
+      onChange={onChange}
+      className="text-xl font-bold mb-2"
+    />
+  );
+}
+

--- a/frontend/src/components/AgentStrategy.tsx
+++ b/frontend/src/components/AgentStrategy.tsx
@@ -1,0 +1,91 @@
+import RiskDisplay from './RiskDisplay';
+import TokenDisplay from './TokenDisplay';
+import EditableText from './EditableText';
+
+interface StrategyData {
+  tokenA: string;
+  tokenB: string;
+  targetAllocation: number;
+  minTokenAAllocation: number;
+  minTokenBAllocation: number;
+  risk: string;
+  reviewInterval: string;
+}
+
+interface Props {
+  data: StrategyData;
+  onChange: <K extends keyof StrategyData>(key: K, value: StrategyData[K]) => void;
+}
+
+const reviewIntervalMap: Record<string, string> = {
+  '1h': '1 Hour',
+  '3h': '3 Hours',
+  '5h': '5 Hours',
+  '12h': '12 Hours',
+  '24h': '1 Day',
+  '3d': '3 Days',
+  '1w': '1 Week',
+};
+
+export default function AgentStrategy({ data, onChange }: Props) {
+  return (
+    <div className="space-y-2">
+      <p className="flex items-center gap-1">
+        <strong>Tokens:</strong>
+        <EditableText
+          value={data.tokenA}
+          onChange={(v) => onChange('tokenA', v.toUpperCase())}
+          renderDisplay={(v) => <TokenDisplay token={v} />}
+        />
+        <span>/</span>
+        <EditableText
+          value={data.tokenB}
+          onChange={(v) => onChange('tokenB', v.toUpperCase())}
+          renderDisplay={(v) => <TokenDisplay token={v} />}
+        />
+      </p>
+      <p>
+        <strong>Target Allocation:</strong>{' '}
+        <EditableText
+          value={String(data.targetAllocation)}
+          onChange={(v) => onChange('targetAllocation', Number(v))}
+        />
+        {' / '}
+        {100 - data.targetAllocation}
+      </p>
+      <p>
+        <strong>Minimum {data.tokenA.toUpperCase()} Allocation:</strong>{' '}
+        <EditableText
+          value={String(data.minTokenAAllocation)}
+          onChange={(v) => onChange('minTokenAAllocation', Number(v))}
+        />
+        %
+      </p>
+      <p>
+        <strong>Minimum {data.tokenB.toUpperCase()} Allocation:</strong>{' '}
+        <EditableText
+          value={String(data.minTokenBAllocation)}
+          onChange={(v) => onChange('minTokenBAllocation', Number(v))}
+        />
+        %
+      </p>
+      <p className="flex items-center gap-1">
+        <strong>Risk Tolerance:</strong>{' '}
+        <EditableText
+          value={data.risk}
+          onChange={(v) => onChange('risk', v)}
+          renderDisplay={(v) => <RiskDisplay risk={v as any} />}
+        />
+      </p>
+      <p>
+        <strong>Review Interval:</strong>{' '}
+        <EditableText
+          value={data.reviewInterval}
+          onChange={(v) => onChange('reviewInterval', v)}
+          renderDisplay={(v) => reviewIntervalMap[v] ?? v}
+        />
+      </p>
+    </div>
+  );
+}
+

--- a/frontend/src/components/EditableText.tsx
+++ b/frontend/src/components/EditableText.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { Pencil } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+  renderDisplay?: (value: string) => ReactNode;
+  className?: string;
+  textClassName?: string;
+}
+
+export default function EditableText({
+  value,
+  onChange,
+  renderDisplay,
+  className = '',
+  textClassName = '',
+}: Props) {
+  const [editing, setEditing] = useState(false);
+  const [local, setLocal] = useState(value);
+  useEffect(() => setLocal(value), [value]);
+  return (
+    <span className={`inline-flex items-center gap-1 ${className}`}>
+      {editing ? (
+        <input
+          value={local}
+          onChange={(e) => setLocal(e.target.value)}
+          onBlur={() => {
+            setEditing(false);
+            onChange(local);
+          }}
+          className={`px-1 border-b border-gray-300 bg-transparent focus:outline-none ${textClassName}`}
+        />
+      ) : (
+        <span className={`px-1 ${textClassName}`}>
+          {renderDisplay ? renderDisplay(value) : value}
+        </span>
+      )}
+      <Pencil
+        className="w-4 h-4 text-gray-500 cursor-pointer"
+        onClick={() => setEditing(true)}
+      />
+    </span>
+  );
+}
+


### PR DESCRIPTION
## Summary
- modularize agent preview into AgentName, AgentStrategy, and AgentInstructions components
- allow editing of strategy fields and instructions with draft saving
- show instruction character count and handle local updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a520aa80a0832cb443a1d05ddce023