### PR TITLE
feat: enhance draft workflow and agent management

### DIFF
--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,24 +1,30 @@
 import { createContext, useContext, useState, ReactNode } from 'react';
 
 interface ToastContext {
-  show: (message: string) => void;
+  show: (message: string, variant?: 'error' | 'success') => void;
 }
 const Context = createContext<ToastContext>({ show: () => {} });
 
 export function ToastProvider({ children }: { children: ReactNode }) {
-  const [message, setMessage] = useState<string | null>(null);
+  const [toast, setToast] = useState<
+    { message: string; variant: 'error' | 'success' } | null
+  >(null);
 
-  const show = (msg: string) => {
-    setMessage(msg);
-    setTimeout(() => setMessage(null), 3000);
+  const show = (msg: string, variant: 'error' | 'success' = 'error') => {
+    setToast({ message: msg, variant });
+    setTimeout(() => setToast(null), 3000);
   };
 
   return (
     <Context.Provider value={{ show }}>
       {children}
-      {message && (
-        <div className="fixed top-4 left-1/2 -translate-x-1/2 bg-red-600 text-white px-4 py-2 rounded shadow">
-          {message}
+      {toast && (
+        <div
+          className={`fixed top-4 left-1/2 -translate-x-1/2 text-white px-4 py-2 rounded shadow ${
+            toast.variant === 'error' ? 'bg-red-600' : 'bg-green-600'
+          }`}
+        >
+          {toast.message}
         </div>
       )}
     </Context.Provider>

--- a/frontend/src/routes/AgentPreview.tsx
+++ b/frontend/src/routes/AgentPreview.tsx
@@ -211,9 +211,8 @@ export default function AgentPreview({ draft }: Props) {
                     agentInstructions: agentData.agentInstructions,
                     status: 'draft',
                   });
-                  navigate(`/agents/${draft!.id}`);
                 } else {
-                  const res = await api.post('/agents', {
+                  await api.post('/agents', {
                     userId: user.id,
                     model,
                     name: agentData.name,
@@ -227,8 +226,10 @@ export default function AgentPreview({ draft }: Props) {
                     agentInstructions: agentData.agentInstructions,
                     status: 'draft',
                   });
-                  navigate(`/agents/${res.data.id}`);
                 }
+                setIsSavingDraft(false);
+                toast.show('Draft saved successfully', 'success');
+                navigate('/');
               } catch (err) {
                 setIsSavingDraft(false);
                 if (axios.isAxiosError(err) && err.response?.data?.error) {
@@ -239,7 +240,7 @@ export default function AgentPreview({ draft }: Props) {
               }
             }}
           >
-            Save Draft
+            {isDraft ? 'Update Draft' : 'Save Draft'}
           </Button>
           <Button
             disabled={

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -1,7 +1,8 @@
 import { useState, useCallback } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
-import { Eye } from 'lucide-react';
+import { Eye, Trash } from 'lucide-react';
+import axios from 'axios';
 import api from '../lib/axios';
 import { useUser } from '../lib/useUser';
 import AgentStatusLabel from '../components/AgentStatusLabel';
@@ -11,6 +12,7 @@ import Button from '../components/ui/Button';
 import CreateAgentForm from '../components/forms/CreateAgentForm';
 import PriceChart from '../components/forms/PriceChart';
 import ErrorBoundary from '../components/ErrorBoundary';
+import { useToast } from '../components/Toast';
 
 interface Agent {
   id: string;
@@ -26,6 +28,8 @@ export default function Dashboard() {
   const [page, setPage] = useState(1);
   const [tokens, setTokens] = useState({ tokenA: 'USDT', tokenB: 'SOL' });
   const [onlyActive, setOnlyActive] = useState(false);
+  const queryClient = useQueryClient();
+  const toast = useToast();
 
   const handleTokensChange = useCallback((a: string, b: string) => {
     setTokens((prev) =>
@@ -56,6 +60,20 @@ export default function Dashboard() {
 
   const totalPages = data ? Math.ceil(data.total / data.pageSize) : 0;
   const items = data?.items ?? [];
+
+  const handleDelete = async (id: string) => {
+    try {
+      await api.delete(`/agents/${id}`);
+      queryClient.invalidateQueries({ queryKey: ['agents'] });
+      toast.show('Agent deleted', 'success');
+    } catch (err) {
+      if (axios.isAxiosError(err) && err.response?.data?.error) {
+        toast.show(err.response.data.error);
+      } else {
+        toast.show('Failed to delete agent');
+      }
+    }
+  };
 
   return (
     <div className="flex flex-col gap-3 w-full">
@@ -124,13 +142,22 @@ export default function Dashboard() {
                         <AgentStatusLabel status={agent.status} />
                       </td>
                       <td>
-                        <Link
-                          className="text-blue-600 underline inline-flex"
-                          to={`/agents/${agent.id}`}
-                          aria-label="View agent"
-                        >
-                          <Eye className="w-4 h-4" />
-                        </Link>
+                        <div className="flex items-center gap-2">
+                          <Link
+                            className="text-blue-600 underline inline-flex"
+                            to={`/agents/${agent.id}`}
+                            aria-label="View agent"
+                          >
+                            <Eye className="w-4 h-4" />
+                          </Link>
+                          <button
+                            className="text-red-600"
+                            onClick={() => handleDelete(agent.id)}
+                            aria-label="Delete agent"
+                          >
+                            <Trash className="w-4 h-4" />
+                          </button>
+                        </div>
                       </td>
                     </tr>
                   ))}

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -62,6 +62,10 @@ export default function Dashboard() {
   const items = data?.items ?? [];
 
   const handleDelete = async (id: string) => {
+    const confirmed = window.confirm('Delete this agent?');
+    if (!confirmed) {
+      return;
+    }
     try {
       await api.delete(`/agents/${id}`);
       queryClient.invalidateQueries({ queryKey: ['agents'] });


### PR DESCRIPTION
## Summary
- add success toast variant for green notifications
- redirect to agents list after saving draft and update button labels
- allow deleting agents from dashboard

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a67b045c38832c87c333596dd28216