### PR TITLE
Add agent update modal and refresh active agent scheduling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,4 +13,5 @@ Backend code lives in `/backend`; the React app lives in `/frontend`.
 - Do not write DB migrations during early development - edit schema.sql directly (unless this rule is removed).
 - Always cover backend code, especially API endpoints, with sufficient amount of tests.
 - Reuse existing frontend form components (e.g., SelectInput, TokenSelect) for consistent UI and validation.
+- New backend API endpoints should use the `RATE_LIMITS` presets for rate limiting.
 

--- a/backend/src/routes/models.ts
+++ b/backend/src/routes/models.ts
@@ -37,7 +37,10 @@ export default async function modelsRoutes(app: FastifyInstance) {
       const json = await res.json();
       const models = (json.data as { id: string }[])
         .map((m) => m.id)
-        .filter((id: string) => /^(gpt-5|o3|search)/.test(id));
+        .filter(
+          (id: string) =>
+            id.startsWith('gpt-5') || id.startsWith('o3') || id.includes('search'),
+        );
       return { models };
       } catch {
         return reply

--- a/backend/src/routes/models.ts
+++ b/backend/src/routes/models.ts
@@ -37,7 +37,7 @@ export default async function modelsRoutes(app: FastifyInstance) {
       const json = await res.json();
       const models = (json.data as { id: string }[])
         .map((m) => m.id)
-        .filter((id: string) => /^(gpt-5|o3|gpt-4\.1|gpt-4o)/.test(id));
+        .filter((id: string) => /^(gpt-5|o3|search)/.test(id));
       return { models };
       } catch {
         return reply

--- a/backend/test/models.test.ts
+++ b/backend/test/models.test.ts
@@ -27,7 +27,7 @@ describe('model routes', () => {
       ok: true,
       json: async () => ({
         data: [
-          { id: 'gpt-4.1-mini' },
+          { id: 'search' },
           { id: 'gpt-3.5' },
           { id: 'o3-mini' },
           { id: 'gpt-5' },
@@ -41,7 +41,7 @@ describe('model routes', () => {
       headers: { 'x-user-id': 'user1' },
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ models: ['gpt-4.1-mini', 'o3-mini', 'gpt-5'] });
+    expect(res.json()).toEqual({ models: ['search', 'o3-mini', 'gpt-5'] });
 
     await app.close();
     (globalThis as any).fetch = originalFetch;

--- a/backend/test/models.test.ts
+++ b/backend/test/models.test.ts
@@ -27,7 +27,7 @@ describe('model routes', () => {
       ok: true,
       json: async () => ({
         data: [
-          { id: 'search' },
+          { id: 'foo-search' },
           { id: 'gpt-3.5' },
           { id: 'o3-mini' },
           { id: 'gpt-5' },
@@ -41,7 +41,7 @@ describe('model routes', () => {
       headers: { 'x-user-id': 'user1' },
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ models: ['search', 'o3-mini', 'gpt-5'] });
+    expect(res.json()).toEqual({ models: ['foo-search', 'o3-mini', 'gpt-5'] });
 
     await app.close();
     (globalThis as any).fetch = originalFetch;

--- a/frontend/src/components/AgentInstructions.tsx
+++ b/frontend/src/components/AgentInstructions.tsx
@@ -14,7 +14,7 @@ export default function AgentInstructions({ value, onChange, maxLength = 1000 }:
   return (
     <div className="mt-4">
       <div className="flex items-center gap-1 mb-2">
-        <h2 className="text-xl font-bold flex-1">Trading Agent Instructions</h2>
+        <h2 className="text-xl font-bold flex-1">Trading Instructions</h2>
         <Pencil
           className="w-4 h-4 text-gray-500 cursor-pointer"
           onMouseDown={(e) => e.preventDefault()}

--- a/frontend/src/components/StrategyForm.tsx
+++ b/frontend/src/components/StrategyForm.tsx
@@ -17,6 +17,7 @@ interface StrategyData {
 interface Props {
   data: StrategyData;
   onChange: <K extends keyof StrategyData>(key: K, value: StrategyData[K]) => void;
+  disabled?: boolean;
 }
 
 const tokens = [
@@ -42,7 +43,7 @@ const reviewIntervalOptions = [
   { value: '1w', label: '1 Week' },
 ];
 
-export default function StrategyForm({ data, onChange }: Props) {
+export default function StrategyForm({ data, onChange, disabled = false }: Props) {
   const {
     tokenA,
     tokenB,
@@ -62,6 +63,7 @@ export default function StrategyForm({ data, onChange }: Props) {
             value={tokenA}
             onChange={(v) => onChange('tokenA', v)}
             options={tokens.filter((t) => t.value === tokenA || t.value !== tokenB)}
+            disabled={disabled}
           />
         </FormField>
         <FormField label="Token B" htmlFor="tokenB">
@@ -70,6 +72,7 @@ export default function StrategyForm({ data, onChange }: Props) {
             value={tokenB}
             onChange={(v) => onChange('tokenB', v)}
             options={tokens.filter((t) => t.value === tokenB || t.value !== tokenA)}
+            disabled={disabled}
           />
         </FormField>
       </div>
@@ -86,6 +89,7 @@ export default function StrategyForm({ data, onChange }: Props) {
             value={targetAllocation}
             onChange={(e) => onChange('targetAllocation', Number(e.target.value))}
             className="flex-1"
+            disabled={disabled}
           />
           <span className="w-24">
             {100 - targetAllocation}% {tokenB.toUpperCase()}
@@ -101,6 +105,7 @@ export default function StrategyForm({ data, onChange }: Props) {
             max={100}
             value={minTokenAAllocation}
             onChange={(e) => onChange('minTokenAAllocation', Number(e.target.value))}
+            disabled={disabled}
           />
         </FormField>
         <FormField label={`Min ${tokenB.toUpperCase()} allocation`} htmlFor="minTokenBAllocation">
@@ -111,6 +116,7 @@ export default function StrategyForm({ data, onChange }: Props) {
             max={100}
             value={minTokenBAllocation}
             onChange={(e) => onChange('minTokenBAllocation', Number(e.target.value))}
+            disabled={disabled}
           />
         </FormField>
       </div>
@@ -121,6 +127,7 @@ export default function StrategyForm({ data, onChange }: Props) {
             value={risk}
             onChange={(v) => onChange('risk', v)}
             options={riskOptions}
+            disabled={disabled}
           />
         </FormField>
         <FormField
@@ -133,6 +140,7 @@ export default function StrategyForm({ data, onChange }: Props) {
             value={reviewInterval}
             onChange={(v) => onChange('reviewInterval', v)}
             options={reviewIntervalOptions}
+            disabled={disabled}
           />
         </FormField>
       </div>

--- a/frontend/src/components/forms/SelectInput.tsx
+++ b/frontend/src/components/forms/SelectInput.tsx
@@ -11,12 +11,14 @@ export default function SelectInput({
   options,
   id,
   className = '',
+  disabled = false,
 }: {
   value: string;
   onChange: (v: string) => void;
   options: Option[];
   id: string;
   className?: string;
+  disabled?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const selected = options.find((o) => o.value === value);
@@ -26,7 +28,8 @@ export default function SelectInput({
       <button
         type="button"
         id={id}
-        onClick={() => setOpen(!open)}
+        disabled={disabled}
+        onClick={() => !disabled && setOpen(!open)}
         className={`w-full border rounded px-2 py-1 flex items-center justify-between ${className}`}
       >
         <span className={`${selected ? '' : 'text-gray-500'} flex items-center gap-1`}>
@@ -34,7 +37,7 @@ export default function SelectInput({
         </span>
         <span className="ml-2">▾</span>
       </button>
-      {open && (
+      {open && !disabled && (
         <ul className="absolute z-10 w-full bg-white border rounded mt-1 max-h-40 overflow-auto">
           {options.map((opt) => (
             <li key={opt.value}>

--- a/frontend/src/components/forms/TokenSelect.tsx
+++ b/frontend/src/components/forms/TokenSelect.tsx
@@ -10,11 +10,13 @@ export default function TokenSelect({
   onChange,
   options,
   id,
+  disabled = false,
 }: {
   value: string;
   onChange: (v: string) => void;
   options: Option[];
   id: string;
+  disabled?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const selected = options.find((o) => o.value === value);
@@ -24,7 +26,8 @@ export default function TokenSelect({
       <button
         type="button"
         id={id}
-        onClick={() => setOpen(!open)}
+        disabled={disabled}
+        onClick={() => !disabled && setOpen(!open)}
         className="w-full border rounded px-2 py-1 flex items-center justify-between"
       >
         {selected ? (
@@ -34,7 +37,7 @@ export default function TokenSelect({
         )}
         <span className="ml-2">▾</span>
       </button>
-      {open && (
+      {open && !disabled && (
         <ul className="absolute z-10 w-full bg-white border rounded mt-1 max-h-40 overflow-auto">
           {options.map((opt) => (
             <li key={opt.value}>

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export default function Modal({ open, onClose, children }: Props) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="bg-white p-4 rounded shadow max-w-lg w-full relative">
+        {children}
+        <button
+          type="button"
+          className="absolute top-2 right-2 text-gray-600"
+          onClick={onClose}
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/routes/ViewAgent.tsx
+++ b/frontend/src/routes/ViewAgent.tsx
@@ -76,23 +76,18 @@ export default function ViewAgent() {
     },
   });
 
-  if (!data) return <div className="p-4">Loading...</div>;
-  if (data.status === 'draft') return <AgentPreview draft={data} />;
-
-  const isActive = data.status === 'active';
-
   const [showStrategy, setShowStrategy] = useState(false);
   const [showPrompt, setShowPrompt] = useState(false);
   const [showUpdate, setShowUpdate] = useState(false);
   const [updateData, setUpdateData] = useState({
-    tokenA: data.tokenA,
-    tokenB: data.tokenB,
-    targetAllocation: data.targetAllocation,
-    minTokenAAllocation: data.minTokenAAllocation,
-    minTokenBAllocation: data.minTokenBAllocation,
-    risk: data.risk,
-    reviewInterval: data.reviewInterval,
-    agentInstructions: data.agentInstructions,
+    tokenA: '',
+    tokenB: '',
+    targetAllocation: 0,
+    minTokenAAllocation: 0,
+    minTokenBAllocation: 0,
+    risk: '',
+    reviewInterval: '',
+    agentInstructions: '',
   });
 
   const updateMut = useMutation({
@@ -119,6 +114,10 @@ export default function ViewAgent() {
     },
   });
 
+  if (!data) return <div className="p-4">Loading...</div>;
+  if (data.status === 'draft') return <AgentPreview draft={data} />;
+
+  const isActive = data.status === 'active';
   const strategyData = {
     tokenA: data.tokenA,
     tokenB: data.tokenB,

--- a/frontend/src/routes/ViewAgent.tsx
+++ b/frontend/src/routes/ViewAgent.tsx
@@ -141,7 +141,7 @@ export default function ViewAgent() {
       </p>
       <div className="mt-4">
         <div
-          className="flex items-center justify-between cursor-pointer"
+          className="flex items-center gap-1 cursor-pointer"
           onClick={() => setShowStrategy((s) => !s)}
         >
           <h2 className="text-xl font-bold">Strategy</h2>
@@ -159,7 +159,7 @@ export default function ViewAgent() {
       </div>
       <div className="mt-4">
         <div className="flex items-center gap-1">
-          <h2 className="text-xl font-bold flex-1">Trading Agent Instructions</h2>
+          <h2 className="text-xl font-bold">Trading Instructions</h2>
           {showPrompt ? (
             <EyeOff
               className="w-4 h-4 cursor-pointer"


### PR DESCRIPTION
## Summary
- note rate limiting presets in AGENTS guidelines
- refresh start balance and reschedule when updating active agents
- collapse strategy and prompt sections on agent view with update modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a688d3df68832cbdf9d8db7b79f3fa