### PR TITLE
feat: show agent execution log in view page

### DIFF
--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -286,6 +286,56 @@ export default async function agentRoutes(app: FastifyInstance) {
     }
   );
 
+  app.get(
+    '/agents/:id/exec-log',
+    { config: { rateLimit: RATE_LIMITS.RELAXED } },
+    async (req, reply) => {
+      const userId = requireUserId(req, reply);
+      if (!userId) return;
+      const id = (req.params as any).id;
+      const agent = getAgent(id);
+      if (!agent)
+        return reply
+          .code(404)
+          .send(errorResponse(ERROR_MESSAGES.notFound));
+      if (agent.user_id !== userId)
+        return reply
+          .code(403)
+          .send(errorResponse(ERROR_MESSAGES.forbidden));
+      const { page = '1', pageSize = '10' } = req.query as {
+        page?: string;
+        pageSize?: string;
+      };
+      const p = Math.max(parseInt(page, 10), 1);
+      const ps = Math.max(parseInt(pageSize, 10), 1);
+      const offset = (p - 1) * ps;
+      const totalRow = db
+        .prepare(
+          'SELECT COUNT(*) as count FROM agent_exec_log WHERE agent_id = ?'
+        )
+        .get(id) as { count: number };
+      const rows = db
+        .prepare(
+          'SELECT id, log, created_at FROM agent_exec_log WHERE agent_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?'
+        )
+        .all(id, ps, offset) as {
+          id: string;
+          log: string;
+          created_at: number;
+        }[];
+      return {
+        items: rows.map((r) => ({
+          id: r.id,
+          log: r.log,
+          createdAt: r.created_at,
+        })),
+        total: totalRow.count,
+        page: p,
+        pageSize: ps,
+      };
+    }
+  );
+
   app.put(
     '/agents/:id',
     { config: { rateLimit: RATE_LIMITS.TIGHT } },

--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -251,42 +251,6 @@ export default async function agentRoutes(app: FastifyInstance) {
   );
 
   app.get(
-    '/agents/:id',
-    { config: { rateLimit: RATE_LIMITS.RELAXED } },
-    async (req, reply) => {
-      const userId = requireUserId(req, reply);
-      if (!userId) return;
-      const id = (req.params as any).id;
-      const row = getAgent(id);
-      if (!row)
-        return reply
-          .code(404)
-          .send(errorResponse(ERROR_MESSAGES.notFound));
-      if (row.user_id !== userId)
-        return reply
-          .code(403)
-          .send(errorResponse(ERROR_MESSAGES.forbidden));
-      return toApi(row);
-    }
-  );
-
-  app.get(
-    '/agents/:id/pnl',
-    { config: { rateLimit: RATE_LIMITS.VERY_TIGHT } },
-    async (req, reply) => {
-      const userId = requireUserId(req, reply);
-      if (!userId) return;
-      const id = (req.params as any).id;
-      const perf = await calculatePnl(id, userId);
-      if (!perf)
-        return reply
-          .code(404)
-          .send(errorResponse(ERROR_MESSAGES.notFound));
-      return perf;
-    }
-  );
-
-  app.get(
     '/agents/:id/exec-log',
     { config: { rateLimit: RATE_LIMITS.RELAXED } },
     async (req, reply) => {
@@ -333,6 +297,42 @@ export default async function agentRoutes(app: FastifyInstance) {
         page: p,
         pageSize: ps,
       };
+    }
+  );
+
+  app.get(
+    '/agents/:id',
+    { config: { rateLimit: RATE_LIMITS.RELAXED } },
+    async (req, reply) => {
+      const userId = requireUserId(req, reply);
+      if (!userId) return;
+      const id = (req.params as any).id;
+      const row = getAgent(id);
+      if (!row)
+        return reply
+          .code(404)
+          .send(errorResponse(ERROR_MESSAGES.notFound));
+      if (row.user_id !== userId)
+        return reply
+          .code(403)
+          .send(errorResponse(ERROR_MESSAGES.forbidden));
+      return toApi(row);
+    }
+  );
+
+  app.get(
+    '/agents/:id/pnl',
+    { config: { rateLimit: RATE_LIMITS.VERY_TIGHT } },
+    async (req, reply) => {
+      const userId = requireUserId(req, reply);
+      if (!userId) return;
+      const id = (req.params as any).id;
+      const perf = await calculatePnl(id, userId);
+      if (!perf)
+        return reply
+          .code(404)
+          .send(errorResponse(ERROR_MESSAGES.notFound));
+      return perf;
     }
   );
 

--- a/backend/test/agentExecLog.test.ts
+++ b/backend/test/agentExecLog.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+
+process.env.DATABASE_URL = ':memory:';
+process.env.KEY_PASSWORD = 'test-pass';
+process.env.GOOGLE_CLIENT_ID = 'test-client';
+
+const { db, migrate } = await import('../src/db/index.js');
+import buildServer from '../src/server.js';
+
+migrate();
+
+function addUser(id: string) {
+  db.prepare('INSERT INTO users (id) VALUES (?)').run(id);
+}
+
+describe('agent exec log routes', () => {
+  it('returns paginated logs and enforces ownership', async () => {
+    const app = await buildServer();
+    addUser('u1');
+    addUser('u2');
+    const agentId = 'a1';
+    db.prepare(
+      `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
+       VALUES (?, ?, 'gpt', 'active', 0, 'A', 'BTC', 'ETH', 60, 10, 20, 'low', '1h', 'inst')`
+    ).run(agentId, 'u1');
+    for (let i = 0; i < 3; i++) {
+      db.prepare(
+        'INSERT INTO agent_exec_log (id, agent_id, log, created_at) VALUES (?, ?, ?, ?)'
+      ).run(`log${i}`, agentId, `log-${i}`, i);
+    }
+    let res = await app.inject({
+      method: 'GET',
+      url: `/api/agents/${agentId}/exec-log?page=1&pageSize=2`,
+      headers: { 'x-user-id': 'u1' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ total: 3, page: 1, pageSize: 2 });
+    expect(res.json().items).toHaveLength(2);
+    res = await app.inject({
+      method: 'GET',
+      url: `/api/agents/${agentId}/exec-log?page=1&pageSize=2`,
+      headers: { 'x-user-id': 'u2' },
+    });
+    expect(res.statusCode).toBe(403);
+    await app.close();
+  });
+});


### PR DESCRIPTION
## Summary
- add paginated exec log endpoint for agents
- show execution log table and inline agent name on active agent page
- test exec log endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a698c52e0c832c858063d55ca67430