### PR TITLE
Add terms and privacy pages with footer links

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,8 @@ import Keys from './routes/Keys';
 import AgentPreview from './routes/AgentPreview';
 import ViewAgent from './routes/ViewAgent';
 import Settings from './routes/Settings';
+import Terms from './routes/Terms';
+import Privacy from './routes/Privacy';
 
 export default function App() {
   return (
@@ -15,6 +17,8 @@ export default function App() {
         <Route path="/settings" element={<Settings />} />
         <Route path="/agent-preview" element={<AgentPreview />} />
         <Route path="/agents/:id" element={<ViewAgent />} />
+        <Route path="/terms" element={<Terms />} />
+        <Route path="/privacy" element={<Privacy />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Route>
     </Routes>

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -24,33 +24,34 @@ export default function AppShell() {
         </div>
       </header>
       <div className="flex flex-1">
-        <nav className="w-48 bg-gray-100 p-4">
-          <Link to="/" className="flex items-center gap-2 mb-2 text-gray-700 hover:text-gray-900">
-            <Bot className="w-4 h-4" />
-            Agents
-          </Link>
-          <Link to="/keys" className="flex items-center gap-2 mb-2 text-gray-700 hover:text-gray-900">
-            <Key className="w-4 h-4" />
-            Keys
-          </Link>
-          <Link to="/settings" className="flex items-center gap-2 mb-2 text-gray-700 hover:text-gray-900">
-            <SettingsIcon className="w-4 h-4" />
-            Settings
-          </Link>
+        <nav className="w-48 bg-gray-100 p-4 flex flex-col justify-between h-full">
+          <div>
+            <Link to="/" className="flex items-center gap-2 mb-2 text-gray-700 hover:text-gray-900">
+              <Bot className="w-4 h-4" />
+              Agents
+            </Link>
+            <Link to="/keys" className="flex items-center gap-2 mb-2 text-gray-700 hover:text-gray-900">
+              <Key className="w-4 h-4" />
+              Keys
+            </Link>
+            <Link to="/settings" className="flex items-center gap-2 mb-2 text-gray-700 hover:text-gray-900">
+              <SettingsIcon className="w-4 h-4" />
+              Settings
+            </Link>
+          </div>
+          <div className="text-sm text-gray-600">
+            <Link to="/terms" className="block mb-2 hover:text-gray-900">
+              Terms
+            </Link>
+            <Link to="/privacy" className="block hover:text-gray-900">
+              Privacy
+            </Link>
+          </div>
         </nav>
         <main className="flex-1 p-3 bg-white">
           <Outlet />
         </main>
       </div>
-      <footer className="bg-gray-100 text-center text-sm text-gray-600 p-4">
-        <Link to="/terms" className="mx-2 hover:text-gray-800">
-          Terms
-        </Link>
-        •
-        <Link to="/privacy" className="mx-2 hover:text-gray-800">
-          Privacy
-        </Link>
-      </footer>
     </div>
   );
 }

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -42,6 +42,15 @@ export default function AppShell() {
           <Outlet />
         </main>
       </div>
+      <footer className="bg-gray-100 text-center text-sm text-gray-600 p-4">
+        <Link to="/terms" className="mx-2 hover:text-gray-800">
+          Terms
+        </Link>
+        •
+        <Link to="/privacy" className="mx-2 hover:text-gray-800">
+          Privacy
+        </Link>
+      </footer>
     </div>
   );
 }

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -15,43 +15,41 @@ function ApiStatus() {
 
 export default function AppShell() {
   return (
-    <div className="min-h-screen flex flex-col">
-      <header className="bg-gray-800 text-white p-4 flex justify-between">
+    <div className="h-screen flex flex-col">
+      <header className="fixed top-0 left-0 right-0 bg-gray-800 text-white p-4 flex justify-between z-10">
         <span className="font-bold">PromptSwap</span>
         <div className="flex items-center gap-4">
           <ApiStatus />
           <GoogleLoginButton />
         </div>
       </header>
-      <div className="flex flex-1">
-        <nav className="w-48 bg-gray-100 p-4 flex flex-col justify-between h-full">
-          <div>
-            <Link to="/" className="flex items-center gap-2 mb-2 text-gray-700 hover:text-gray-900">
-              <Bot className="w-4 h-4" />
-              Agents
-            </Link>
-            <Link to="/keys" className="flex items-center gap-2 mb-2 text-gray-700 hover:text-gray-900">
-              <Key className="w-4 h-4" />
-              Keys
-            </Link>
-            <Link to="/settings" className="flex items-center gap-2 mb-2 text-gray-700 hover:text-gray-900">
-              <SettingsIcon className="w-4 h-4" />
-              Settings
-            </Link>
-          </div>
-          <div className="text-sm text-gray-600">
-            <Link to="/terms" className="block mb-2 hover:text-gray-900">
-              Terms
-            </Link>
-            <Link to="/privacy" className="block hover:text-gray-900">
-              Privacy
-            </Link>
-          </div>
+      <div className="flex flex-1 pt-16 pb-8 overflow-hidden">
+        <nav className="w-48 bg-gray-100 p-4 overflow-y-auto">
+          <Link to="/" className="flex items-center gap-2 mb-2 text-gray-700 hover:text-gray-900">
+            <Bot className="w-4 h-4" />
+            Agents
+          </Link>
+          <Link to="/keys" className="flex items-center gap-2 mb-2 text-gray-700 hover:text-gray-900">
+            <Key className="w-4 h-4" />
+            Keys
+          </Link>
+          <Link to="/settings" className="flex items-center gap-2 mb-2 text-gray-700 hover:text-gray-900">
+            <SettingsIcon className="w-4 h-4" />
+            Settings
+          </Link>
         </nav>
-        <main className="flex-1 p-3 bg-white">
+        <main className="flex-1 p-3 bg-white overflow-y-auto">
           <Outlet />
         </main>
       </div>
+      <footer className="fixed bottom-0 left-0 right-0 bg-gray-100 text-xs text-center py-1 border-t">
+        <Link to="/terms" className="mx-2 hover:text-gray-900">
+          Terms
+        </Link>
+        <Link to="/privacy" className="mx-2 hover:text-gray-900">
+          Privacy
+        </Link>
+      </footer>
     </div>
   );
 }

--- a/frontend/src/routes/Privacy.tsx
+++ b/frontend/src/routes/Privacy.tsx
@@ -4,7 +4,7 @@ export default function Privacy() {
       <h2 className="text-xl font-bold">Privacy Policy</h2>
       <p>
         We collect only the information required to run the service. When you sign
-        in with Google we record your Google account ID; your email is used only for
+        in with Google we record your Google account ID. Your email is used only for
         display and is not stored in our database. Agent configuration data and
         optional two-factor authentication secrets are also saved.
       </p>

--- a/frontend/src/routes/Privacy.tsx
+++ b/frontend/src/routes/Privacy.tsx
@@ -1,0 +1,22 @@
+export default function Privacy() {
+  return (
+    <div className="max-w-2xl mx-auto space-y-4">
+      <h2 className="text-xl font-bold">Privacy Policy</h2>
+      <p>
+        We collect only the information required to run the service. When you sign
+        in with Google we record your Google account ID; your email is used only for
+        display and is not stored in our database. Agent configuration data and
+        optional two-factor authentication secrets are also saved.
+      </p>
+      <p>
+        API keys for AI providers and exchanges are encrypted using a server-side
+        password before being saved in our database. These keys are used solely to
+        make requests on your behalf and are never shared with third parties.
+      </p>
+      <p>
+        You may delete your API keys or disable two-factor authentication at any
+        time from the application settings.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/routes/Terms.tsx
+++ b/frontend/src/routes/Terms.tsx
@@ -1,0 +1,25 @@
+export default function Terms() {
+  return (
+    <div className="max-w-2xl mx-auto space-y-4">
+      <h2 className="text-xl font-bold">Terms of Use</h2>
+      <p>
+        PromptSwap is open source software provided "as is" without warranties or
+        guarantees of any kind. Use it at your own risk.
+      </p>
+      <p>
+        You are free to review the source code and run your own instance on your
+        infrastructure. The code is available at{' '}
+        <a
+          href="https://github.com/prompt-swap/prompt-swap"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-600 underline"
+        >
+          this GitHub repository
+        </a>
+        .
+      </p>
+      <p>By using the service you agree that the authors are not liable for any damages.</p>
+    </div>
+  );
+}

--- a/frontend/src/routes/Terms.tsx
+++ b/frontend/src/routes/Terms.tsx
@@ -10,7 +10,7 @@ export default function Terms() {
         You are free to review the source code and run your own instance on your
         infrastructure. The code is available at{' '}
         <a
-          href="https://github.com/prompt-swap/prompt-swap"
+          href="https://github.com/dexstandard/prompt-swap"
           target="_blank"
           rel="noopener noreferrer"
           className="text-blue-600 underline"


### PR DESCRIPTION
## Summary
- add Terms of Use and Privacy Policy pages
- route terms and privacy pages in app router
- expose footer links to terms and privacy pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a69bc3a320832c9f8d93e6ee49e0fc