### PR TITLE
fix: add web search tool and validate input

### DIFF
--- a/backend/src/util/ai.ts
+++ b/backend/src/util/ai.ts
@@ -5,7 +5,11 @@ export async function callAi(model: string, input: unknown, apiKey: string): Pro
       Authorization: `Bearer ${apiKey}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ model, input }),
+    body: JSON.stringify({
+      model,
+      input: typeof input === 'string' ? input : JSON.stringify(input),
+      tools: [{ type: 'web_search_preview' }],
+    }),
   });
   return await res.text();
 }


### PR DESCRIPTION
## Summary
- ensure all AI calls include the web search tool
- stringify object prompts before sending to OpenAI to avoid invalid input errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a69f14b888832cbcf0b9379bdceeb8