### PR TITLE
feat(frontend): add exec log error display

### DIFF
--- a/frontend/src/components/ExecLogItem.tsx
+++ b/frontend/src/components/ExecLogItem.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import { AlertCircle, Eye } from 'lucide-react';
+import Modal from './ui/Modal';
+
+export interface ExecLog {
+  id: string;
+  log: string;
+  error?: Record<string, unknown>;
+  createdAt: number;
+}
+
+interface Props {
+  log: ExecLog;
+}
+
+export default function ExecLogItem({ log }: Props) {
+  const [showJson, setShowJson] = useState(false);
+  const hasError = log.error && Object.keys(log.error).length > 0;
+  return (
+    <div>
+      <div className="whitespace-pre-wrap">{log.log}</div>
+      {hasError && (
+        <div className="mt-1 rounded border border-red-300 bg-red-50 p-2 text-red-800 flex items-start gap-2">
+          <AlertCircle className="h-4 w-4" />
+          <div className="flex-1">
+            <span className="font-bold mr-1">ERROR</span>
+            <span>{(log.error as any).message || JSON.stringify(log.error)}</span>
+          </div>
+          <Eye
+            className="h-4 w-4 cursor-pointer"
+            onClick={() => setShowJson(true)}
+          />
+          <Modal open={showJson} onClose={() => setShowJson(false)}>
+            <pre className="whitespace-pre-wrap text-sm">
+              {JSON.stringify(log.error, null, 2)}
+            </pre>
+          </Modal>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ExecLogItem.tsx
+++ b/frontend/src/components/ExecLogItem.tsx
@@ -36,7 +36,7 @@ export default function ExecLogItem({ log }: Props) {
     <div>
       {text && <div className="whitespace-pre-wrap">{text}</div>}
       {hasError && (
-        <div className="mt-1 rounded border border-red-300 bg-red-50 p-2 text-red-800 flex items-start gap-2">
+        <div className="mt-1 flex items-center gap-2 rounded border border-red-300 bg-red-50 p-2 text-red-800">
           <AlertCircle className="h-4 w-4" />
           <div className="flex-1">
             <span className="font-bold mr-1">ERROR</span>

--- a/frontend/src/components/ExecLogItem.tsx
+++ b/frontend/src/components/ExecLogItem.tsx
@@ -24,13 +24,22 @@ export default function ExecLogItem({ log }: Props) {
     try {
       const parsed = JSON.parse(log.log);
       if (parsed && typeof parsed === 'object') {
+        const body = (parsed as any).body;
         if ('error' in parsed) {
           error = (parsed as any).error;
           const { error: _err, ...rest } = parsed as any;
           text = Object.keys(rest).length > 0 ? JSON.stringify(rest, null, 2) : '';
+        } else if (body && typeof body === 'object' && 'error' in body) {
+          error = body.error;
+          const { body: _body, ...rest } = parsed as any;
+          text = Object.keys(rest).length > 0 ? JSON.stringify(rest, null, 2) : '';
         } else if ((parsed as any).object === 'response') {
           response = parsed as Record<string, unknown>;
           text = '';
+        } else if (body && typeof body === 'object' && body.object === 'response') {
+          response = body as Record<string, unknown>;
+          const { body: _body, ...rest } = parsed as any;
+          text = Object.keys(rest).length > 0 ? JSON.stringify(rest, null, 2) : '';
         }
       }
     } catch {

--- a/frontend/src/components/ExecLogItem.tsx
+++ b/frontend/src/components/ExecLogItem.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { AlertCircle, Eye } from 'lucide-react';
 import Modal from './ui/Modal';
+import ExecSuccessItem from './ExecSuccessItem';
 
 export interface ExecLog {
   id: string;
@@ -16,15 +17,21 @@ interface Props {
 export default function ExecLogItem({ log }: Props) {
   const [showJson, setShowJson] = useState(false);
   let error = log.error;
+  let response: Record<string, unknown> | undefined;
   let text = log.log;
 
   if (!error) {
     try {
       const parsed = JSON.parse(log.log);
-      if (parsed && typeof parsed === 'object' && 'error' in parsed) {
-        error = (parsed as any).error;
-        const { error: _err, ...rest } = parsed as any;
-        text = Object.keys(rest).length > 0 ? JSON.stringify(rest, null, 2) : '';
+      if (parsed && typeof parsed === 'object') {
+        if ('error' in parsed) {
+          error = (parsed as any).error;
+          const { error: _err, ...rest } = parsed as any;
+          text = Object.keys(rest).length > 0 ? JSON.stringify(rest, null, 2) : '';
+        } else if ((parsed as any).object === 'response') {
+          response = parsed as Record<string, unknown>;
+          text = '';
+        }
       }
     } catch {
       // ignore parse errors
@@ -32,6 +39,7 @@ export default function ExecLogItem({ log }: Props) {
   }
 
   const hasError = error && Object.keys(error).length > 0;
+  const hasResponse = response && Object.keys(response).length > 0;
   return (
     <div>
       {text && <div className="whitespace-pre-wrap">{text}</div>}
@@ -53,6 +61,7 @@ export default function ExecLogItem({ log }: Props) {
           </Modal>
         </div>
       )}
+      {hasResponse && <ExecSuccessItem response={response as any} />}
     </div>
   );
 }

--- a/frontend/src/components/ExecSuccessItem.tsx
+++ b/frontend/src/components/ExecSuccessItem.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { CheckCircle, Eye } from 'lucide-react';
+import Modal from './ui/Modal';
+
+interface Props {
+  response: Record<string, any>;
+}
+
+export default function ExecSuccessItem({ response }: Props) {
+  const [showJson, setShowJson] = useState(false);
+
+  let message = '';
+  const outputs = Array.isArray(response.output) ? response.output : [];
+  const msg = outputs.find((o) => o.type === 'message');
+  if (msg && Array.isArray(msg.content)) {
+    const textPart = msg.content.find((c: any) => c.type === 'output_text');
+    if (textPart && typeof textPart.text === 'string') message = textPart.text;
+  }
+
+  return (
+    <div className="mt-1 flex items-center gap-2 rounded border border-green-300 bg-green-50 p-2 text-green-800">
+      <CheckCircle className="h-4 w-4" />
+      <div className="flex-1 whitespace-pre-wrap break-words">
+        <span className="font-bold mr-1">SUCCESS</span>
+        <span>{message}</span>
+      </div>
+      <Eye
+        className="h-4 w-4 cursor-pointer"
+        onClick={() => setShowJson(true)}
+      />
+      <Modal open={showJson} onClose={() => setShowJson(false)}>
+        <pre className="whitespace-pre-wrap break-words text-sm">
+          {JSON.stringify(response, null, 2)}
+        </pre>
+      </Modal>
+    </div>
+  );
+}
+

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -14,7 +14,7 @@ export default function Modal({ open, onClose, children }: Props) {
         {children}
         <button
           type="button"
-          className="absolute top-2 right-2 ml-2 text-gray-600"
+          className="absolute top-2 right-2 mr-2 text-gray-600"
           onClick={onClose}
         >
           ×

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -14,7 +14,7 @@ export default function Modal({ open, onClose, children }: Props) {
         {children}
         <button
           type="button"
-          className="absolute top-2 right-2 text-gray-600"
+          className="absolute top-2 right-2 ml-2 text-gray-600"
           onClick={onClose}
         >
           ×

--- a/frontend/src/routes/ViewAgent.tsx
+++ b/frontend/src/routes/ViewAgent.tsx
@@ -12,6 +12,7 @@ import { useToast } from '../components/Toast';
 import AgentPreview from './AgentPreview';
 import StrategyForm from '../components/StrategyForm';
 import { Eye, EyeOff, ChevronDown, ChevronRight } from 'lucide-react';
+import ExecLogItem, { type ExecLog } from '../components/ExecLogItem';
 import Modal from '../components/ui/Modal';
 import AgentInstructions from '../components/AgentInstructions';
 import { normalizeAllocations } from '../lib/allocations';
@@ -31,12 +32,6 @@ interface Agent {
   risk: string;
   reviewInterval: string;
   agentInstructions: string;
-}
-
-interface ExecLog {
-  id: string;
-  log: string;
-  createdAt: number;
 }
 
 export default function ViewAgent() {
@@ -266,7 +261,9 @@ export default function ViewAgent() {
                       <td className="align-top pr-2">
                         {new Date(log.createdAt).toLocaleString()}
                       </td>
-                      <td className="whitespace-pre-wrap">{log.log}</td>
+                      <td>
+                        <ExecLogItem log={log} />
+                      </td>
                     </tr>
                   ))}
                 </tbody>


### PR DESCRIPTION
## Summary
- add `ExecLogItem` component to show logs with optional error details
- show error bar with eye icon in agent execution log rows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6a976ea94832ca1d66c73831e97ed