### PR TITLE
Enforce structured agent output

### DIFF
--- a/backend/src/util/ai.ts
+++ b/backend/src/util/ai.ts
@@ -1,4 +1,43 @@
 export async function callAi(model: string, input: unknown, apiKey: string): Promise<string> {
+  const schema = {
+    type: 'object',
+    properties: {
+      result: {
+        anyOf: [
+          {
+            type: 'object',
+            properties: {
+              rebalance: { type: 'boolean', const: false },
+              shortReport: { type: 'string' },
+            },
+            required: ['rebalance', 'shortReport'],
+            additionalProperties: false,
+          },
+          {
+            type: 'object',
+            properties: {
+              rebalance: { type: 'boolean', const: true },
+              newAllocation: { type: 'number' },
+              shortReport: { type: 'string' },
+            },
+            required: ['rebalance', 'newAllocation', 'shortReport'],
+            additionalProperties: false,
+          },
+          {
+            type: 'object',
+            properties: {
+              error: { type: 'string' },
+            },
+            required: ['error'],
+            additionalProperties: false,
+          },
+        ],
+      },
+    },
+    required: ['result'],
+    additionalProperties: false,
+  };
+
   const res = await fetch('https://api.openai.com/v1/responses', {
     method: 'POST',
     headers: {
@@ -9,6 +48,14 @@ export async function callAi(model: string, input: unknown, apiKey: string): Pro
       model,
       input: typeof input === 'string' ? input : JSON.stringify(input),
       tools: [{ type: 'web_search_preview' }],
+      text: {
+        format: {
+          type: 'json_schema',
+          name: 'rebalance_response',
+          strict: true,
+          schema,
+        },
+      },
     }),
   });
   return await res.text();

--- a/backend/test/callAi.test.ts
+++ b/backend/test/callAi.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest';
+
+describe('callAi structured output', () => {
+  it('includes json schema in request', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ text: async () => '' });
+    const originalFetch = globalThis.fetch;
+    (globalThis as any).fetch = fetchMock;
+    const { callAi } = await import('../src/util/ai.js');
+    await callAi('gpt-test', { foo: 'bar' }, 'key');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, opts] = fetchMock.mock.calls[0];
+    const body = JSON.parse(opts.body);
+    expect(body.text.format.type).toBe('json_schema');
+    const anyOf = body.text.format.schema.properties.result.anyOf;
+    expect(Array.isArray(anyOf)).toBe(true);
+    expect(anyOf).toHaveLength(3);
+    (globalThis as any).fetch = originalFetch;
+  });
+});

--- a/frontend/src/components/ExecLogItem.tsx
+++ b/frontend/src/components/ExecLogItem.tsx
@@ -34,10 +34,40 @@ export default function ExecLogItem({ log }: Props) {
           const { body: _body, ...rest } = parsed as any;
           text = Object.keys(rest).length > 0 ? JSON.stringify(rest, null, 2) : '';
         } else if ((parsed as any).object === 'response') {
-          response = parsed as Record<string, unknown>;
+          const outputs = Array.isArray((parsed as any).output)
+            ? (parsed as any).output
+            : [];
+          const msg = outputs.find((o: any) => o.type === 'message');
+          const textPart = msg?.content?.find((c: any) => c.type === 'output_text');
+          if (textPart && typeof textPart.text === 'string') {
+            try {
+              const out = JSON.parse(textPart.text);
+              if (out.result && typeof out.result === 'object') {
+                if ('error' in out.result)
+                  error = { message: (out.result as any).error };
+                else response = out.result as Record<string, unknown>;
+              }
+            } catch {
+              // ignore
+            }
+          }
           text = '';
         } else if (body && typeof body === 'object' && body.object === 'response') {
-          response = body as Record<string, unknown>;
+          const outputs = Array.isArray(body.output) ? body.output : [];
+          const msg = outputs.find((o: any) => o.type === 'message');
+          const textPart = msg?.content?.find((c: any) => c.type === 'output_text');
+          if (textPart && typeof textPart.text === 'string') {
+            try {
+              const out = JSON.parse(textPart.text);
+              if (out.result && typeof out.result === 'object') {
+                if ('error' in out.result)
+                  error = { message: (out.result as any).error };
+                else response = out.result as Record<string, unknown>;
+              }
+            } catch {
+              // ignore
+            }
+          }
           const { body: _body, ...rest } = parsed as any;
           text = Object.keys(rest).length > 0 ? JSON.stringify(rest, null, 2) : '';
         }

--- a/frontend/src/components/ExecSuccessItem.tsx
+++ b/frontend/src/components/ExecSuccessItem.tsx
@@ -3,26 +3,26 @@ import { CheckCircle, Eye } from 'lucide-react';
 import Modal from './ui/Modal';
 
 interface Props {
-  response: Record<string, any>;
+  response: {
+    rebalance: boolean;
+    newAllocation?: number;
+    shortReport: string;
+  };
 }
 
 export default function ExecSuccessItem({ response }: Props) {
   const [showJson, setShowJson] = useState(false);
-
-  let message = '';
-  const outputs = Array.isArray(response.output) ? response.output : [];
-  const msg = outputs.find((o) => o.type === 'message');
-  if (msg && Array.isArray(msg.content)) {
-    const textPart = msg.content.find((c: any) => c.type === 'output_text');
-    if (textPart && typeof textPart.text === 'string') message = textPart.text;
-  }
+  const { rebalance, newAllocation, shortReport } = response;
 
   return (
     <div className="mt-1 flex items-center gap-2 rounded border border-green-300 bg-green-50 p-2 text-green-800">
       <CheckCircle className="h-4 w-4" />
       <div className="flex-1 whitespace-pre-wrap break-words">
         <span className="font-bold mr-1">SUCCESS</span>
-        <span>{message}</span>
+        <span>{shortReport}</span>
+        {rebalance && typeof newAllocation === 'number' && (
+          <span className="ml-1">(new allocation: {newAllocation})</span>
+        )}
       </div>
       <Eye
         className="h-4 w-4 cursor-pointer"


### PR DESCRIPTION
## Summary
- request OpenAI responses with a JSON schema describing rebalance, allocation, and error formats
- parse structured agent outputs and surface errors in log UI
- test that `callAi` sends the expected structured-output schema

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6bd93eb4c832cb00cc27dfbbfdcdb