### PR TITLE
Include developer instructions and memory in AI requests

### DIFF
--- a/backend/src/jobs/review-portfolio.ts
+++ b/backend/src/jobs/review-portfolio.ts
@@ -31,7 +31,13 @@ export default async function reviewPortfolio(
           risk: row.risk,
           reviewInterval: row.review_interval,
         };
-        const text = await callAi(row.model, prompt, key);
+        const prevRows = db
+          .prepare(
+            'SELECT log FROM agent_exec_log WHERE agent_id = ? ORDER BY created_at DESC LIMIT 5',
+          )
+          .all(row.id) as { log: string }[];
+        const previousResponses = prevRows.map((r) => r.log);
+        const text = await callAi(row.model, prompt, key, previousResponses);
         db.prepare(
           'INSERT INTO agent_exec_log (id, agent_id, log, created_at) VALUES (?, ?, ?, ?)',
         ).run(execLogId, row.id, text, Date.now());

--- a/backend/src/util/ai.ts
+++ b/backend/src/util/ai.ts
@@ -1,4 +1,12 @@
-export async function callAi(model: string, input: unknown, apiKey: string): Promise<string> {
+const developerInstructions =
+  'You assist a real trader in taking decisions on a given tokens configuration. Use the web search tool to find fresh news and prices and advise the user whether to rebalance or not.';
+
+export async function callAi(
+  model: string,
+  input: unknown,
+  apiKey: string,
+  previousResponses: string[],
+): Promise<string> {
   const schema = {
     type: 'object',
     properties: {
@@ -47,6 +55,8 @@ export async function callAi(model: string, input: unknown, apiKey: string): Pro
     body: JSON.stringify({
       model,
       input: typeof input === 'string' ? input : JSON.stringify(input),
+      developer: developerInstructions,
+      previous_responses: previousResponses,
       tools: [{ type: 'web_search_preview' }],
       text: {
         format: {

--- a/backend/src/util/ai.ts
+++ b/backend/src/util/ai.ts
@@ -1,5 +1,5 @@
 const developerInstructions =
-  'You assist a real trader in taking decisions on a given tokens configuration. Use the web search tool to find fresh news and prices and advise the user whether to rebalance or not.';
+  "You assist a real trader in taking decisions on a given tokens configuration. The user's comment may be found in the trading instructions field. Use the web search tool to find fresh news and prices and advise the user whether to rebalance or not.";
 
 export async function callAi(
   model: string,
@@ -54,9 +54,11 @@ export async function callAi(
     },
     body: JSON.stringify({
       model,
-      input: typeof input === 'string' ? input : JSON.stringify(input),
-      developer: developerInstructions,
-      previous_responses: previousResponses,
+      input:
+        typeof input === 'string'
+          ? JSON.stringify({ prompt: input, previous_responses: previousResponses })
+          : JSON.stringify({ ...(input as Record<string, unknown>), previous_responses: previousResponses }),
+      instructions: developerInstructions,
       tools: [{ type: 'web_search_preview' }],
       text: {
         format: {

--- a/backend/test/callAi.test.ts
+++ b/backend/test/callAi.test.ts
@@ -6,10 +6,12 @@ describe('callAi structured output', () => {
     const originalFetch = globalThis.fetch;
     (globalThis as any).fetch = fetchMock;
     const { callAi } = await import('../src/util/ai.js');
-    await callAi('gpt-test', { foo: 'bar' }, 'key');
+    await callAi('gpt-test', { foo: 'bar' }, 'key', ['p1', 'p2']);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [, opts] = fetchMock.mock.calls[0];
     const body = JSON.parse(opts.body);
+    expect(body.developer).toMatch(/assist a real trader/i);
+    expect(body.previous_responses).toEqual(['p1', 'p2']);
     expect(body.text.format.type).toBe('json_schema');
     const anyOf = body.text.format.schema.properties.result.anyOf;
     expect(Array.isArray(anyOf)).toBe(true);

--- a/backend/test/callAi.test.ts
+++ b/backend/test/callAi.test.ts
@@ -10,8 +10,9 @@ describe('callAi structured output', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [, opts] = fetchMock.mock.calls[0];
     const body = JSON.parse(opts.body);
-    expect(body.developer).toMatch(/assist a real trader/i);
-    expect(body.previous_responses).toEqual(['p1', 'p2']);
+    expect(body.instructions).toMatch(/assist a real trader/i);
+    const parsedInput = JSON.parse(body.input);
+    expect(parsedInput.previous_responses).toEqual(['p1', 'p2']);
     expect(body.text.format.type).toBe('json_schema');
     const anyOf = body.text.format.schema.properties.result.anyOf;
     expect(Array.isArray(anyOf)).toBe(true);

--- a/backend/test/reviewPortfolio.test.ts
+++ b/backend/test/reviewPortfolio.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+
+process.env.DATABASE_URL = ':memory:';
+process.env.KEY_PASSWORD = 'test-pass';
+process.env.GOOGLE_CLIENT_ID = 'test-client';
+
+const { db, migrate } = await import('../src/db/index.js');
+
+vi.mock('../src/util/ai.js', () => ({
+  callAi: vi.fn().mockResolvedValue('ok'),
+}));
+
+vi.mock('../src/util/crypto.js', () => ({
+  decrypt: vi.fn().mockReturnValue('key'),
+}));
+
+migrate();
+
+const reviewPortfolio = (await import('../src/jobs/review-portfolio.js')).default;
+const { callAi } = await import('../src/util/ai.js');
+
+describe('reviewPortfolio', () => {
+  it('passes last five responses to callAi', async () => {
+    db.prepare('INSERT INTO users (id, ai_api_key_enc) VALUES (?, ?)').run('u1', 'enc');
+    db.prepare(
+      `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, target_allocation, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
+       VALUES (?, ?, 'gpt', 'active', 0, 'Agent', 'BTC', 'ETH', 60, 10, 20, 'low', '1h', 'inst')`
+    ).run('a1', 'u1');
+    for (let i = 0; i < 6; i++) {
+      db.prepare('INSERT INTO agent_exec_log (id, agent_id, log, created_at) VALUES (?, ?, ?, ?)').run(`id${i}`, 'a1', `resp-${i}`, i);
+    }
+    const log: any = { child: () => log, info: () => {}, error: () => {} };
+    await reviewPortfolio(log, 'a1');
+    expect(callAi).toHaveBeenCalledTimes(1);
+    const args = (callAi as any).mock.calls[0];
+    expect(args[3]).toEqual(['resp-5', 'resp-4', 'resp-3', 'resp-2', 'resp-1']);
+  });
+});


### PR DESCRIPTION
## Summary
- add developer guidance for the trading assistant to AI request payload
- send the last five agent responses as previous_responses for context
- test AI request formatting and portfolio review memory handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6c1edaeb4832cba53de4811706988