### PR TITLE
Parse and expose AI response text in exec logs

### DIFF
--- a/backend/src/util/parse-exec-log.ts
+++ b/backend/src/util/parse-exec-log.ts
@@ -1,0 +1,54 @@
+export interface ParsedExecLog {
+  text: string;
+  response?: {
+    rebalance: boolean;
+    newAllocation?: number;
+    shortReport: string;
+  };
+  error?: Record<string, unknown>;
+}
+
+export function parseExecLog(log: string): ParsedExecLog {
+  let text = log;
+  let response: ParsedExecLog['response'];
+  let error: Record<string, unknown> | undefined;
+  try {
+    const parsed = JSON.parse(log);
+    if (parsed && typeof parsed === 'object') {
+      if ('error' in parsed) {
+        error = (parsed as any).error as Record<string, unknown>;
+        const { error: _err, ...rest } = parsed as any;
+        text = Object.keys(rest).length > 0 ? JSON.stringify(rest) : '';
+      } else if ((parsed as any).object === 'response') {
+        const outputs = Array.isArray((parsed as any).output)
+          ? (parsed as any).output
+          : [];
+        const msg = outputs.find((o: any) => o.type === 'message');
+        const textPart = msg?.content?.find((c: any) => c.type === 'output_text');
+        if (textPart && typeof textPart.text === 'string') {
+          text = textPart.text;
+          try {
+            const out = JSON.parse(textPart.text);
+            if (out && typeof out === 'object' && 'result' in out) {
+              const result = (out as any).result;
+              if (result && typeof result === 'object') {
+                if ('error' in result) {
+                  error = { message: (result as any).error };
+                } else {
+                  response = result as ParsedExecLog['response'];
+                }
+              }
+            }
+          } catch {
+            // ignore
+          }
+        } else {
+          text = '';
+        }
+      }
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return { text, response, error };
+}

--- a/backend/src/util/parse-exec-log.ts
+++ b/backend/src/util/parse-exec-log.ts
@@ -8,47 +8,56 @@ export interface ParsedExecLog {
   error?: Record<string, unknown>;
 }
 
-export function parseExecLog(log: string): ParsedExecLog {
-  let text = log;
+export function parseExecLog(log: unknown): ParsedExecLog {
+  let text =
+    typeof log === 'string'
+      ? log
+      : log !== undefined
+        ? JSON.stringify(log)
+        : '';
   let response: ParsedExecLog['response'];
   let error: Record<string, unknown> | undefined;
+
+  let parsed: any;
   try {
-    const parsed = JSON.parse(log);
-    if (parsed && typeof parsed === 'object') {
-      if ('error' in parsed) {
-        error = (parsed as any).error as Record<string, unknown>;
-        const { error: _err, ...rest } = parsed as any;
-        text = Object.keys(rest).length > 0 ? JSON.stringify(rest) : '';
-      } else if ((parsed as any).object === 'response') {
-        const outputs = Array.isArray((parsed as any).output)
-          ? (parsed as any).output
-          : [];
-        const msg = outputs.find((o: any) => o.type === 'message');
-        const textPart = msg?.content?.find((c: any) => c.type === 'output_text');
-        if (textPart && typeof textPart.text === 'string') {
-          text = textPart.text;
-          try {
-            const out = JSON.parse(textPart.text);
-            if (out && typeof out === 'object' && 'result' in out) {
-              const result = (out as any).result;
-              if (result && typeof result === 'object') {
-                if ('error' in result) {
-                  error = { message: (result as any).error };
-                } else {
-                  response = result as ParsedExecLog['response'];
-                }
+    parsed = typeof log === 'string' ? JSON.parse(log) : log;
+  } catch {
+    return { text, response, error };
+  }
+
+  if (parsed && typeof parsed === 'object') {
+    if ('error' in parsed) {
+      error = (parsed as any).error as Record<string, unknown>;
+      const { error: _err, ...rest } = parsed as any;
+      text = Object.keys(rest).length > 0 ? JSON.stringify(rest) : '';
+    } else if ((parsed as any).object === 'response') {
+      const outputs = Array.isArray((parsed as any).output)
+        ? (parsed as any).output
+        : [];
+      const msg = outputs.find((o: any) => o.type === 'message');
+      const textPart = msg?.content?.find((c: any) => c.type === 'output_text');
+      if (textPart && typeof textPart.text === 'string') {
+        text = textPart.text;
+        try {
+          const out = JSON.parse(textPart.text);
+          if (out && typeof out === 'object' && 'result' in out) {
+            const result = (out as any).result;
+            if (result && typeof result === 'object') {
+              if ('error' in result) {
+                error = { message: (result as any).error };
+              } else {
+                response = result as ParsedExecLog['response'];
               }
             }
-          } catch {
-            // ignore
           }
-        } else {
-          text = '';
+        } catch {
+          // ignore
         }
+      } else {
+        text = '';
       }
     }
-  } catch {
-    // ignore parse errors
   }
+
   return { text, response, error };
 }

--- a/backend/src/util/parse-exec-log.ts
+++ b/backend/src/util/parse-exec-log.ts
@@ -34,12 +34,18 @@ export function parseExecLog(log: unknown): ParsedExecLog {
       const outputs = Array.isArray((parsed as any).output)
         ? (parsed as any).output
         : [];
-      const msg = outputs.find((o: any) => o.type === 'message');
-      const textPart = msg?.content?.find((c: any) => c.type === 'output_text');
-      if (textPart && typeof textPart.text === 'string') {
-        text = textPart.text;
+      // final assistant reply is in the output entry whose id starts with "msg_"
+      // and the text lives at content[0].text
+      const msg = outputs.find(
+        (o: any) => typeof o?.id === 'string' && o.id.startsWith('msg_'),
+      );
+      const textField = Array.isArray(msg?.content)
+        ? msg.content[0]?.text
+        : undefined;
+      if (typeof textField === 'string') {
+        text = textField;
         try {
-          const out = JSON.parse(textPart.text);
+          const out = JSON.parse(textField);
           if (out && typeof out === 'object' && 'result' in out) {
             const result = (out as any).result;
             if (result && typeof result === 'object') {

--- a/backend/test/agentExecLog.test.ts
+++ b/backend/test/agentExecLog.test.ts
@@ -58,7 +58,7 @@ describe('agent exec log routes', () => {
       output: [
         {
           type: 'message',
-          id: 'msg',
+          id: 'msg_0',
           role: 'assistant',
           content: [
             {

--- a/frontend/src/components/ExecLogItem.tsx
+++ b/frontend/src/components/ExecLogItem.tsx
@@ -26,7 +26,9 @@ export default function ExecLogItem({ log }: Props) {
   const hasResponse = response && Object.keys(response).length > 0;
   return (
     <div>
-      {text && <div className="whitespace-pre-wrap">{text}</div>}
+      {!hasError && !hasResponse && text && (
+        <div className="whitespace-pre-wrap">{text}</div>
+      )}
       {hasError && (
         <div className="mt-1 flex items-center gap-2 rounded border border-red-300 bg-red-50 p-2 text-red-800">
           <AlertCircle className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- parse OpenAI response logs to extract text, structured response, and errors
- return parsed data from agent exec-log API and simplify frontend display
- cover exec-log parsing with new unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6c82bee14832cb26d4fba2ca609b3