### PR TITLE
Parse and expose AI response text in exec logs

### DIFF
--- a/backend/src/util/parse-exec-log.ts
+++ b/backend/src/util/parse-exec-log.ts
@@ -1,0 +1,81 @@
+export interface ParsedExecLog {
+  text: string;
+  response?: {
+    rebalance: boolean;
+    newAllocation?: number;
+    shortReport: string;
+  };
+  error?: Record<string, unknown>;
+}
+
+export function parseExecLog(log: unknown): ParsedExecLog {
+  let text =
+    typeof log === 'string'
+      ? log
+      : log !== undefined
+        ? JSON.stringify(log)
+        : '';
+  let response: ParsedExecLog['response'];
+  let error: Record<string, unknown> | undefined;
+
+  let parsed: any;
+  try {
+    parsed = typeof log === 'string' ? JSON.parse(log) : log;
+  } catch {
+    return { text, response, error };
+  }
+
+  if (parsed && typeof parsed === 'object') {
+    if ('error' in parsed) {
+      error = (parsed as any).error as Record<string, unknown>;
+      const { error: _err, ...rest } = parsed as any;
+      text = Object.keys(rest).length > 0 ? JSON.stringify(rest) : '';
+    } else if ((parsed as any).object === 'response') {
+      const outputs = Array.isArray((parsed as any).output)
+        ? (parsed as any).output
+        : [];
+      // final assistant reply is in the output entry whose id starts with "msg_"
+      // and the text lives at content[0].text
+      const msg = outputs.find(
+        (o: any) => typeof o?.id === 'string' && o.id.startsWith('msg_'),
+      );
+      const textField = Array.isArray(msg?.content)
+        ? msg.content[0]?.text
+        : undefined;
+      if (typeof textField === 'string') {
+        text = textField;
+        try {
+          const sanitized = textField
+            .replace(/\r/g, '\\r')
+            .replace(/\n/g, '\\n');
+          const out = JSON.parse(sanitized);
+          if (out && typeof out === 'object' && 'result' in out) {
+            const result = (out as any).result;
+            if (result && typeof result === 'object') {
+              if ('error' in result) {
+                error = { message: (result as any).error };
+              } else {
+                response = result as ParsedExecLog['response'];
+              }
+            }
+          }
+        } catch {
+          const rebalanceMatch = textField.match(/"rebalance"\s*:\s*(true|false)/);
+          const reportMatch = textField.match(/"shortReport"\s*:\s*"([^"]*)"/s);
+          if (rebalanceMatch && reportMatch) {
+            response = {
+              rebalance: rebalanceMatch[1] === 'true',
+              shortReport: reportMatch[1],
+            };
+            const allocMatch = textField.match(/"newAllocation"\s*:\s*([0-9.eE+-]+)/);
+            if (allocMatch) response.newAllocation = Number(allocMatch[1]);
+          }
+        }
+      } else {
+        text = '';
+      }
+    }
+  }
+
+  return { text, response, error };
+}

--- a/backend/test/fixtures/real-openai-log.json
+++ b/backend/test/fixtures/real-openai-log.json
@@ -1,0 +1,175 @@
+{
+  "id": "resp_68a6d002b414819e8fe0f0a4caab92430f373a9f2f078f83",
+  "object": "response",
+  "created_at": 1755762690,
+  "status": "completed",
+  "background": false,
+  "incomplete_details": null,
+  "instructions": "You assist a real trader in taking decisions on a given tokens configuration. The user's comment may be found in the trading instructions field. Use the web search tool to find fresh news and prices and advise the user whether to rebalance or not.",
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_68a6d0039618819eb6f0f50be0137ce60f373a9f2f078f83",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_68a6d00e0074819e96df00cfe992a6de0f373a9f2f078f83",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "search",
+        "query": "Solana price SOL USD August 2025"
+      }
+    },
+    {
+      "id": "rs_68a6d01096a4819e844d07d904c92f750f373a9f2f078f83",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_68a6d0158bdc819e82c47c4fcca554df0f373a9f2f078f83",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "search",
+        "query": "Solana unlock 2025 FTX estate March 1 2025 unlocks SOL official"
+      }
+    },
+    {
+      "id": "rs_68a6d017709c819eb5acce6718c53d020f373a9f2f078f83",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_68a6d025db08819e9074e6245990e5810f373a9f2f078f83",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "{\"result\":{\"rebalance\":true,\"newAllocation\":0,\"shortReport\":\"Data-driven note: Your config implies USDT target of 20% (hence SOL target ~80%), with a hard minimum SOL allocation of 30%. I recommend a cautious, rule-based rebalance threshold rather than chasing sharp moves. Here's what I’m seeing and why:\n\n- SOL price today (USD): around $187, with roughly +6% gain over the last 24 hours and a small +0.2% move in the last hour. This is a momentum signal that could push SOL’s share higher if your current mix is already SOL-heavy. \uE000cite\uE002turn0search1\uE001\n\n- Market/news backdrop: Solana has notable institutional activity (e.g., banks/financial firms exploring Solana via partnerships like R3), which supports longer-term demand but can also lead to short-term volatility on big moves. This environment argues for rebalancing to lock in gains when SOL becomes a larger-than-desired portion of the portfolio. \uE000cite\uE002turn0news14\uE001\n\n- Important unlock event (past): On March 1, 2025, a sizable amount of SOL from the FTX estate unlocked (~11.2 million SOL, ~2% of circulating supply). Such unlocks can put selling pressure on price in the short term. While this event is past, it’s a useful signal for understanding potential post-unlock dynamics in SOL markets. \uE000cite\uE002turn1search0\uE001\n\nRecommendation rationale and action\n- Given your target allocation (USDT 20%, SOL ~80%) and the recent SOL strength, a small rebalancing to trim SOL and add USDT is prudent to keep you near the target and reduce tail risk from further short-term moves. If you’re already near the target but SOL has drifted above ~85% due to price moves, locking in some gains now is sensible. If SOL is still around 75–85%, you may choose to wait for a clearer local high or a pullback before rebalancing.\n\n- Suggested initial action (low-impact): sell a small SOL tranche equivalent to 2–5% of the total portfolio value and convert to USDT, aiming to bring SOL exposure closer to 75–80% and USDT toward 20–25%. This respects the min SOL allocation of 30% and avoids overreacting to a short-term rally.\n\n- Safety checks you should run before executing:\n  - Confirm current actual allocations (your total portfolio value and current SOL vs USDT amounts) to size the trade precisely.\n  - Ensure post-trade SOL allocation stays >= 30% (your hard floor) per minTokenBAllocation.\n  - Consider any fees/slippage from your exchange when sizing the trade.\n\nWhat I need to complete an exact rebalance size for you\n- Total current portfolio value of the index.\n- Current amount of SOL and USDT you hold in the index.\n\nWould you like me to compute an exact trade amount to hit a target SOL allocation of 80% (USDT 20%), given your current holdings? I can also set up hourly monitoring and alert you if SOL moves to trigger a new rebalance.\"}"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "json_schema",
+      "description": null,
+      "name": "rebalance_response",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "rebalance": {
+                    "type": "boolean",
+                    "const": false
+                  },
+                  "shortReport": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "rebalance",
+                  "shortReport"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "rebalance": {
+                    "type": "boolean",
+                    "const": true
+                  },
+                  "newAllocation": {
+                    "type": "number"
+                  },
+                  "shortReport": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "rebalance",
+                  "newAllocation",
+                  "shortReport"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "error"
+                ],
+                "additionalProperties": false
+              }
+            ]
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "additionalProperties": false
+      },
+      "strict": true
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [
+    {
+      "type": "web_search_preview",
+      "search_context_size": "medium",
+      "user_location": {
+        "type": "approximate",
+        "city": null,
+        "country": "US",
+        "region": null,
+        "timezone": null
+      }
+    }
+  ],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 30550,
+    "input_tokens_details": {
+      "cached_tokens": 12544
+    },
+    "output_tokens": 6396,
+    "output_tokens_details": {
+      "reasoning_tokens": 5696
+    },
+    "total_tokens": 36946
+  },
+  "user": null,
+  "metadata": {}
+}
+

--- a/frontend/src/components/ExecLogItem.tsx
+++ b/frontend/src/components/ExecLogItem.tsx
@@ -6,6 +6,11 @@ import ExecSuccessItem from './ExecSuccessItem';
 export interface ExecLog {
   id: string;
   log: string;
+  response?: {
+    rebalance: boolean;
+    newAllocation?: number;
+    shortReport: string;
+  };
   error?: Record<string, unknown>;
   createdAt: number;
 }
@@ -16,72 +21,14 @@ interface Props {
 
 export default function ExecLogItem({ log }: Props) {
   const [showJson, setShowJson] = useState(false);
-  let error = log.error;
-  let response: Record<string, unknown> | undefined;
-  let text = log.log;
-
-  if (!error) {
-    try {
-      const parsed = JSON.parse(log.log);
-      if (parsed && typeof parsed === 'object') {
-        const body = (parsed as any).body;
-        if ('error' in parsed) {
-          error = (parsed as any).error;
-          const { error: _err, ...rest } = parsed as any;
-          text = Object.keys(rest).length > 0 ? JSON.stringify(rest, null, 2) : '';
-        } else if (body && typeof body === 'object' && 'error' in body) {
-          error = body.error;
-          const { body: _body, ...rest } = parsed as any;
-          text = Object.keys(rest).length > 0 ? JSON.stringify(rest, null, 2) : '';
-        } else if ((parsed as any).object === 'response') {
-          const outputs = Array.isArray((parsed as any).output)
-            ? (parsed as any).output
-            : [];
-          const msg = outputs.find((o: any) => o.type === 'message');
-          const textPart = msg?.content?.find((c: any) => c.type === 'output_text');
-          if (textPart && typeof textPart.text === 'string') {
-            try {
-              const out = JSON.parse(textPart.text);
-              if (out.result && typeof out.result === 'object') {
-                if ('error' in out.result)
-                  error = { message: (out.result as any).error };
-                else response = out.result as Record<string, unknown>;
-              }
-            } catch {
-              // ignore
-            }
-          }
-          text = '';
-        } else if (body && typeof body === 'object' && body.object === 'response') {
-          const outputs = Array.isArray(body.output) ? body.output : [];
-          const msg = outputs.find((o: any) => o.type === 'message');
-          const textPart = msg?.content?.find((c: any) => c.type === 'output_text');
-          if (textPart && typeof textPart.text === 'string') {
-            try {
-              const out = JSON.parse(textPart.text);
-              if (out.result && typeof out.result === 'object') {
-                if ('error' in out.result)
-                  error = { message: (out.result as any).error };
-                else response = out.result as Record<string, unknown>;
-              }
-            } catch {
-              // ignore
-            }
-          }
-          const { body: _body, ...rest } = parsed as any;
-          text = Object.keys(rest).length > 0 ? JSON.stringify(rest, null, 2) : '';
-        }
-      }
-    } catch {
-      // ignore parse errors
-    }
-  }
-
+  const { log: text, error, response } = log;
   const hasError = error && Object.keys(error).length > 0;
   const hasResponse = response && Object.keys(response).length > 0;
   return (
     <div>
-      {text && <div className="whitespace-pre-wrap">{text}</div>}
+      {!hasError && !hasResponse && text && (
+        <div className="whitespace-pre-wrap">{text}</div>
+      )}
       {hasError && (
         <div className="mt-1 flex items-center gap-2 rounded border border-red-300 bg-red-50 p-2 text-red-800">
           <AlertCircle className="h-4 w-4" />
@@ -100,7 +47,7 @@ export default function ExecLogItem({ log }: Props) {
           </Modal>
         </div>
       )}
-      {hasResponse && <ExecSuccessItem response={response as any} />}
+      {hasResponse && <ExecSuccessItem response={response} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- parse OpenAI response logs to extract text, structured response, and errors
- return parsed data from agent exec-log API and simplify frontend display
- cover exec-log parsing with new unit test
- handle stored object logs and hide raw OpenAI payload once response/error parsed
- fix exec log parser to pull message text from `msg_` output entries
- parse newline-laden OpenAI text and fallback to regex extraction when JSON parsing fails
- add real OpenAI log fixture to ensure parser extracts response body

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6c82bee14832cb26d4fba2ca609b3