### PR TITLE
Run initial agent review asynchronously

### DIFF
--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -421,7 +421,9 @@ export default async function agentRoutes(app: FastifyInstance) {
       const bal = await getStartBalance(log, userId);
       if (typeof bal !== 'number') return reply.code(bal.code).send(bal.body);
       repoStartAgent(id, bal);
-      await reviewPortfolio(req.log, id);
+      reviewPortfolio(req.log, id).catch((err) =>
+        log.error({ err }, 'initial review failed')
+      );
       const row = getAgent(id)!;
       log.info('started agent');
       return toApi(row);

--- a/backend/test/agentStartAsync.test.ts
+++ b/backend/test/agentStartAsync.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+
+process.env.DATABASE_URL = ':memory:';
+process.env.KEY_PASSWORD = 'test-pass';
+process.env.GOOGLE_CLIENT_ID = 'test-client';
+
+const { db, migrate } = await import('../src/db/index.js');
+
+const reviewPortfolioMock = vi.fn(() => new Promise(() => {}));
+vi.mock('../src/jobs/review-portfolio.js', () => ({ default: reviewPortfolioMock }));
+
+import buildServer from '../src/server.js';
+import { encrypt } from '../src/util/crypto.js';
+
+migrate();
+
+function addUser(id: string) {
+  const ai = encrypt('aikey', process.env.KEY_PASSWORD!);
+  const bk = encrypt('bkey', process.env.KEY_PASSWORD!);
+  const bs = encrypt('skey', process.env.KEY_PASSWORD!);
+  db.prepare(
+    'INSERT INTO users (id, ai_api_key_enc, binance_api_key_enc, binance_api_secret_enc) VALUES (?, ?, ?, ?)'
+  ).run(id, ai, bk, bs);
+}
+
+describe('agent start', () => {
+  it('does not await initial review', async () => {
+    const app = await buildServer();
+    addUser('u1');
+    const payload = {
+      userId: 'u1',
+      model: 'm',
+      name: 'Draft',
+      tokenA: 'BTC',
+      tokenB: 'ETH',
+      targetAllocation: 60,
+      minTokenAAllocation: 10,
+      minTokenBAllocation: 20,
+      risk: 'low',
+      reviewInterval: '1h',
+      agentInstructions: 'prompt',
+      status: 'draft',
+    };
+    const resCreate = await app.inject({
+      method: 'POST',
+      url: '/api/agents',
+      headers: { 'x-user-id': 'u1' },
+      payload,
+    });
+    const id = resCreate.json().id as string;
+
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ balances: [{ asset: 'USDT', free: '100', locked: '0' }] }),
+    } as any);
+    const originalFetch = globalThis.fetch;
+    (globalThis as any).fetch = fetchMock;
+
+    const startPromise = app.inject({
+      method: 'POST',
+      url: `/api/agents/${id}/start`,
+      headers: { 'x-user-id': 'u1' },
+    });
+    const res = await Promise.race([
+      startPromise,
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('timeout')), 200)),
+    ]);
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ status: 'active' });
+    expect(reviewPortfolioMock).toHaveBeenCalledTimes(1);
+    expect(reviewPortfolioMock.mock.calls[0][1]).toBe(id);
+
+    (globalThis as any).fetch = originalFetch;
+    await app.close();
+  });
+});


### PR DESCRIPTION
## Summary
- Start agents without awaiting the initial portfolio review to keep startup responsive
- Add regression test to verify agent startup does not wait for first review

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a72887832c832ca1e6f6c231b634ed