### PR TITLE
refactor: remove target allocation from UI

### DIFF
--- a/frontend/src/components/StrategyForm.tsx
+++ b/frontend/src/components/StrategyForm.tsx
@@ -7,7 +7,6 @@ import FormField from './forms/FormField';
 interface StrategyData {
   tokenA: string;
   tokenB: string;
-  targetAllocation: number;
   minTokenAAllocation: number;
   minTokenBAllocation: number;
   risk: string;
@@ -47,7 +46,6 @@ export default function StrategyForm({ data, onChange, disabled = false }: Props
   const {
     tokenA,
     tokenB,
-    targetAllocation,
     minTokenAAllocation,
     minTokenBAllocation,
     risk,
@@ -76,33 +74,13 @@ export default function StrategyForm({ data, onChange, disabled = false }: Props
           />
         </FormField>
       </div>
-      <FormField label="Target Allocation" htmlFor="targetAllocation">
-        <div className="flex items-center gap-2">
-          <span className="w-24 text-right">
-            {targetAllocation}% {tokenA.toUpperCase()}
-          </span>
-          <input
-            id="targetAllocation"
-            type="range"
-            min={minTokenAAllocation}
-            max={100 - minTokenBAllocation}
-            value={targetAllocation}
-            onChange={(e) => onChange('targetAllocation', Number(e.target.value))}
-            className="flex-1"
-            disabled={disabled}
-          />
-          <span className="w-24">
-            {100 - targetAllocation}% {tokenB.toUpperCase()}
-          </span>
-        </div>
-      </FormField>
       <div className="grid grid-cols-2 gap-4">
         <FormField label={`Min ${tokenA.toUpperCase()} allocation`} htmlFor="minTokenAAllocation">
           <TextInput
             id="minTokenAAllocation"
             type="number"
             min={0}
-            max={100}
+            max={95}
             value={minTokenAAllocation}
             onChange={(e) => onChange('minTokenAAllocation', Number(e.target.value))}
             disabled={disabled}
@@ -113,7 +91,7 @@ export default function StrategyForm({ data, onChange, disabled = false }: Props
             id="minTokenBAllocation"
             type="number"
             min={0}
-            max={100}
+            max={95}
             value={minTokenBAllocation}
             onChange={(e) => onChange('minTokenBAllocation', Number(e.target.value))}
             disabled={disabled}

--- a/frontend/src/lib/allocations.ts
+++ b/frontend/src/lib/allocations.ts
@@ -3,15 +3,14 @@ export function clamp(value: number, min: number, max: number): number {
 }
 
 export function normalizeAllocations(
-  targetAllocation: number,
   minTokenAAllocation: number,
-  minTokenBAllocation: number
+  minTokenBAllocation: number,
 ) {
   let minA = clamp(minTokenAAllocation, 0, 100);
   let minB = clamp(minTokenBAllocation, 0, 100);
 
-  if (minA + minB > 100) {
-    const excess = minA + minB - 100;
+  if (minA + minB > 95) {
+    const excess = minA + minB - 95;
     if (minA >= minB) {
       minA -= excess;
     } else {
@@ -19,10 +18,7 @@ export function normalizeAllocations(
     }
   }
 
-  const target = clamp(targetAllocation, minA, 100 - minB);
-
   return {
-    targetAllocation: target,
     minTokenAAllocation: minA,
     minTokenBAllocation: minB,
   };

--- a/frontend/src/routes/AgentPreview.tsx
+++ b/frontend/src/routes/AgentPreview.tsx
@@ -19,7 +19,6 @@ interface AgentPreviewDetails {
   name: string;
   tokenA: string;
   tokenB: string;
-  targetAllocation: number;
   minTokenAAllocation: number;
   minTokenBAllocation: number;
   risk: string;
@@ -131,7 +130,6 @@ export default function AgentPreview({ draft }: Props) {
               if (!d) return d;
               const updated = { ...d, [key]: value } as AgentPreviewDetails;
               const normalized = normalizeAllocations(
-                updated.targetAllocation,
                 updated.minTokenAAllocation,
                 updated.minTokenBAllocation,
               );
@@ -203,7 +201,6 @@ export default function AgentPreview({ draft }: Props) {
                     name: agentData.name,
                     tokenA: agentData.tokenA,
                     tokenB: agentData.tokenB,
-                    targetAllocation: agentData.targetAllocation,
                     minTokenAAllocation: agentData.minTokenAAllocation,
                     minTokenBAllocation: agentData.minTokenBAllocation,
                     risk: agentData.risk,
@@ -218,7 +215,6 @@ export default function AgentPreview({ draft }: Props) {
                     name: agentData.name,
                     tokenA: agentData.tokenA,
                     tokenB: agentData.tokenB,
-                    targetAllocation: agentData.targetAllocation,
                     minTokenAAllocation: agentData.minTokenAAllocation,
                     minTokenBAllocation: agentData.minTokenBAllocation,
                     risk: agentData.risk,
@@ -265,7 +261,6 @@ export default function AgentPreview({ draft }: Props) {
                     name: agentData.name,
                     tokenA: agentData.tokenA,
                     tokenB: agentData.tokenB,
-                    targetAllocation: agentData.targetAllocation,
                     minTokenAAllocation: agentData.minTokenAAllocation,
                     minTokenBAllocation: agentData.minTokenBAllocation,
                     risk: agentData.risk,

--- a/frontend/src/routes/ViewAgent.tsx
+++ b/frontend/src/routes/ViewAgent.tsx
@@ -26,7 +26,6 @@ interface Agent {
   name: string;
   tokenA: string;
   tokenB: string;
-  targetAllocation: number;
   minTokenAAllocation: number;
   minTokenBAllocation: number;
   risk: string;
@@ -83,7 +82,6 @@ export default function ViewAgent() {
   const [updateData, setUpdateData] = useState({
     tokenA: '',
     tokenB: '',
-    targetAllocation: 0,
     minTokenAAllocation: 0,
     minTokenBAllocation: 0,
     risk: '',
@@ -139,7 +137,6 @@ export default function ViewAgent() {
   const strategyData = {
     tokenA: data.tokenA,
     tokenB: data.tokenB,
-    targetAllocation: data.targetAllocation,
     minTokenAAllocation: data.minTokenAAllocation,
     minTokenBAllocation: data.minTokenBAllocation,
     risk: data.risk,
@@ -207,15 +204,14 @@ export default function ViewAgent() {
       {isActive ? (
         <div className="mt-4 flex gap-2">
           <Button onClick={() => {
-            setUpdateData({
-              tokenA: data.tokenA,
-              tokenB: data.tokenB,
-              targetAllocation: data.targetAllocation,
-              minTokenAAllocation: data.minTokenAAllocation,
-              minTokenBAllocation: data.minTokenBAllocation,
-              risk: data.risk,
-              reviewInterval: data.reviewInterval,
-              agentInstructions: data.agentInstructions,
+          setUpdateData({
+            tokenA: data.tokenA,
+            tokenB: data.tokenB,
+            minTokenAAllocation: data.minTokenAAllocation,
+            minTokenBAllocation: data.minTokenBAllocation,
+            risk: data.risk,
+            reviewInterval: data.reviewInterval,
+            agentInstructions: data.agentInstructions,
             });
             setShowUpdate(true);
           }}>
@@ -297,7 +293,6 @@ export default function ViewAgent() {
               setUpdateData((d) => {
                 const updated = { ...d, [key]: value };
                 const normalized = normalizeAllocations(
-                  updated.targetAllocation,
                   updated.minTokenAAllocation,
                   updated.minTokenBAllocation,
                 );


### PR DESCRIPTION
## Summary
- drop target allocation fields across the frontend
- only collect minimum token allocations (<=95%) and enforce 5% free room
- update agent preview and view flows to use and persist min allocations only

## Testing
- `npm --prefix frontend run build` *(fails: ReactNode is a type and must be imported using a type-only import, mocks.ts destructured elements unused, Settings.tsx FormEvent type-only import)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7bd0b0da4832caac8a7d89ec35f94