### PR TITLE
Rename ViewAgent to AgentView and fix dashboard margin

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,7 @@ import AppShell from './components/layout/AppShell';
 import Dashboard from './routes/Dashboard';
 import Keys from './routes/Keys';
 import AgentPreview from './routes/AgentPreview';
-import ViewAgent from './routes/ViewAgent';
+import AgentView from './routes/AgentView';
 import Settings from './routes/Settings';
 import Terms from './routes/Terms';
 import Privacy from './routes/Privacy';
@@ -16,7 +16,7 @@ export default function App() {
         <Route path="/keys" element={<Keys />} />
         <Route path="/settings" element={<Settings />} />
         <Route path="/agent-preview" element={<AgentPreview />} />
-        <Route path="/agents/:id" element={<ViewAgent />} />
+        <Route path="/agents/:id" element={<AgentView />} />
         <Route path="/terms" element={<Terms />} />
         <Route path="/privacy" element={<Privacy />} />
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -38,7 +38,7 @@ export default function AppShell() {
             Settings
           </Link>
         </nav>
-        <main className="flex-1 p-3 bg-white overflow-y-auto">
+        <main className="flex-1 p-3 pt-0 bg-white overflow-y-auto">
           <Outlet />
         </main>
       </div>

--- a/frontend/src/routes/AgentView.tsx
+++ b/frontend/src/routes/AgentView.tsx
@@ -33,7 +33,7 @@ interface Agent {
   agentInstructions: string;
 }
 
-export default function ViewAgent() {
+export default function AgentView() {
   const { id } = useParams();
   const { user } = useUser();
   const { data } = useQuery({


### PR DESCRIPTION
## Summary
- rename ViewAgent component and route to AgentView
- align main dashboard content with left navigation by removing extra top padding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7d92c46c8832c98a9e3c35ed4cccd