### PR TITLE
Add Binance market data and agent enrichment

### DIFF
--- a/backend/src/repos/agent-exec-log.ts
+++ b/backend/src/repos/agent-exec-log.ts
@@ -1,0 +1,24 @@
+import { db } from '../db/index.js';
+
+export interface ExecLogEntry {
+  id: string;
+  agentId: string;
+  log: string;
+  createdAt: number;
+}
+
+export function insertExecLog(entry: ExecLogEntry): void {
+  db
+    .prepare(
+      'INSERT INTO agent_exec_log (id, agent_id, log, created_at) VALUES (?, ?, ?, ?)',
+    )
+    .run(entry.id, entry.agentId, entry.log, entry.createdAt);
+}
+
+export function getRecentExecLogs(agentId: string, limit: number) {
+  return db
+    .prepare<unknown[], { log: string }>(
+      'SELECT log FROM agent_exec_log WHERE agent_id = ? ORDER BY created_at DESC LIMIT ?',
+    )
+    .all(agentId, limit) as { log: string }[];
+}


### PR DESCRIPTION
## Summary
- fetch Binance market data for token pairs including price, depth and historical spans
- enrich agent review requests with market data
- abstract agent exec log persistence into repository and remove public market endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7dc8ca07c832cb4d3129faf7189ab