### PR TITLE
feat: store rebalancing prompts

### DIFF
--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -42,6 +42,17 @@ CREATE TABLE IF NOT EXISTS agent_exec_log(
   created_at INTEGER
 );
 
+CREATE TABLE IF NOT EXISTS agent_exec_result(
+  id TEXT PRIMARY KEY,
+  agent_id TEXT,
+  log TEXT,
+  rebalance INTEGER,
+  new_allocation REAL,
+  short_report TEXT,
+  error TEXT,
+  created_at INTEGER
+);
+
 -- Indexes to optimize duplicate detection queries
 CREATE INDEX IF NOT EXISTS idx_agents_draft_all_fields
   ON agents(

--- a/backend/src/repos/agent-exec-result.ts
+++ b/backend/src/repos/agent-exec-result.ts
@@ -1,0 +1,47 @@
+import { db } from '../db/index.js';
+
+export interface ExecResultEntry {
+  id: string;
+  agentId: string;
+  log: string;
+  rebalance?: boolean;
+  newAllocation?: number;
+  shortReport?: string;
+  error?: Record<string, unknown>;
+  createdAt: number;
+}
+
+export function insertExecResult(entry: ExecResultEntry): void {
+  db.prepare(
+    'INSERT INTO agent_exec_result (id, agent_id, log, rebalance, new_allocation, short_report, error, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+  ).run(
+    entry.id,
+    entry.agentId,
+    entry.log,
+    entry.rebalance === undefined ? null : entry.rebalance ? 1 : 0,
+    entry.newAllocation ?? null,
+    entry.shortReport ?? null,
+    entry.error ? JSON.stringify(entry.error) : null,
+    entry.createdAt,
+  );
+}
+
+export function getAgentExecResults(agentId: string, limit: number, offset: number) {
+  const totalRow = db
+    .prepare('SELECT COUNT(*) as count FROM agent_exec_result WHERE agent_id = ?')
+    .get(agentId) as { count: number };
+    const rows = db
+      .prepare(
+        'SELECT id, log, rebalance, new_allocation, short_report, error, created_at FROM agent_exec_result WHERE agent_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?',
+      )
+      .all(agentId, limit, offset) as {
+      id: string;
+      log: string;
+      rebalance: number | null;
+      new_allocation: number | null;
+      short_report: string | null;
+      error: string | null;
+      created_at: number;
+    }[];
+  return { rows, total: totalRow.count };
+}

--- a/backend/src/repos/agents.ts
+++ b/backend/src/repos/agents.ts
@@ -16,11 +16,6 @@ export interface AgentRow {
   agent_instructions: string;
 }
 
-export interface ExecLogRow {
-  id: string;
-  log: string;
-  created_at: number;
-}
 
 export function toApi(row: AgentRow) {
   return {
@@ -181,21 +176,6 @@ export function insertAgent(data: {
   );
 }
 
-export function getAgentExecLog(
-  agentId: string,
-  limit: number,
-  offset: number,
-) {
-  const totalRow = db
-    .prepare('SELECT COUNT(*) as count FROM agent_exec_log WHERE agent_id = ?')
-    .get(agentId) as { count: number };
-  const rows = db
-    .prepare(
-      'SELECT id, log, created_at FROM agent_exec_log WHERE agent_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?',
-    )
-    .all(agentId, limit, offset) as ExecLogRow[];
-  return { rows, total: totalRow.count };
-}
 
 export function updateAgent(data: {
   id: string;

--- a/backend/src/util/parse-exec-log.ts
+++ b/backend/src/util/parse-exec-log.ts
@@ -27,6 +27,16 @@ export function parseExecLog(log: unknown): ParsedExecLog {
   }
 
   if (parsed && typeof parsed === 'object') {
+    if ('prompt' in parsed) {
+      if ('response' in parsed)
+        return parseExecLog((parsed as any).response);
+      if ('error' in parsed)
+        return {
+          text: '',
+          response: undefined,
+          error: { message: String((parsed as any).error) },
+        };
+    }
     // *** FIX: only treat as error if value is truthy, not when it's null ***
     if ('error' in parsed && parsed.error) {
       error = parsed.error as Record<string, unknown>;

--- a/backend/test/agentExecLog.test.ts
+++ b/backend/test/agentExecLog.test.ts
@@ -3,6 +3,8 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { db } from '../src/db/index.js';
 import buildServer from '../src/server.js';
+import { parseExecLog } from '../src/util/parse-exec-log.js';
+import { insertExecResult } from '../src/repos/agent-exec-result.js';
 
 function addUser(id: string) {
   db.prepare('INSERT INTO users (id) VALUES (?)').run(id);
@@ -24,6 +26,21 @@ describe('agent exec log routes', () => {
       db.prepare(
           'INSERT INTO agent_exec_log (id, agent_id, log, created_at) VALUES (?, ?, ?, ?)'
       ).run(`log${i}`, agentId, `log-${i}`, i);
+      const parsed = parseExecLog(`log-${i}`);
+      insertExecResult({
+        id: `log${i}`,
+        agentId,
+        log: parsed.text,
+        ...(parsed.response
+          ? {
+              rebalance: parsed.response.rebalance,
+              newAllocation: parsed.response.newAllocation,
+              shortReport: parsed.response.shortReport,
+            }
+          : {}),
+        ...(parsed.error ? { error: parsed.error } : {}),
+        createdAt: i,
+      });
     }
 
     let res = await app.inject({
@@ -63,6 +80,21 @@ describe('agent exec log routes', () => {
     db.prepare(
         'INSERT INTO agent_exec_log (id, agent_id, log, created_at) VALUES (?, ?, ?, ?)',
     ).run('log-new', agentId, aiLog, 0);
+    const parsedAi = parseExecLog(aiLog);
+    insertExecResult({
+      id: 'log-new',
+      agentId,
+      log: parsedAi.text,
+      ...(parsedAi.response
+        ? {
+            rebalance: parsedAi.response.rebalance,
+            newAllocation: parsedAi.response.newAllocation,
+            shortReport: parsedAi.response.shortReport,
+          }
+        : {}),
+      ...(parsedAi.error ? { error: parsedAi.error } : {}),
+      createdAt: 0,
+    });
 
     const res = await app.inject({
       method: 'GET',
@@ -86,6 +118,44 @@ describe('agent exec log routes', () => {
     expect(typeof body.items[0].response.shortReport).toBe('string');
     expect(body.items[0].response.shortReport.length).toBeGreaterThan(0);
 
+    await app.close();
+  });
+
+  it('handles exec log entries with prompt wrapper', async () => {
+    const app = await buildServer();
+    addUser('u5');
+    const agentId = 'a5';
+    db.prepare(
+        `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
+         VALUES (?, ?, 'gpt', 'active', 0, 'A', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`
+    ).run(agentId, 'u5');
+    const entry = JSON.stringify({ prompt: { instructions: 'inst' }, response: 'ok' });
+    db.prepare(
+        'INSERT INTO agent_exec_log (id, agent_id, log, created_at) VALUES (?, ?, ?, ?)',
+    ).run('logp', agentId, entry, 0);
+    const parsedP = parseExecLog(entry);
+    insertExecResult({
+      id: 'logp',
+      agentId,
+      log: parsedP.text,
+      ...(parsedP.response
+        ? {
+            rebalance: parsedP.response.rebalance,
+            newAllocation: parsedP.response.newAllocation,
+            shortReport: parsedP.response.shortReport,
+          }
+        : {}),
+      ...(parsedP.error ? { error: parsedP.error } : {}),
+      createdAt: 0,
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/agents/${agentId}/exec-log?page=1&pageSize=10`,
+      headers: { 'x-user-id': 'u5' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.items[0].log).toBe('ok');
     await app.close();
   });
 });


### PR DESCRIPTION
## Summary
- save full input prompts in exec logs for rebalancing runs
- persist structured exec results with dedicated table columns
- serve parsed exec results through the API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7e681b43c832c8a8523ad6973c520