### PR TITLE
feat: store rebalancing prompts

### DIFF
--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -38,7 +38,8 @@ CREATE TABLE IF NOT EXISTS agents(
 CREATE TABLE IF NOT EXISTS agent_exec_log(
   id TEXT PRIMARY KEY,
   agent_id TEXT,
-  log TEXT,
+  prompt_json TEXT,
+  response_json TEXT,
   created_at INTEGER
 );
 

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -38,8 +38,8 @@ CREATE TABLE IF NOT EXISTS agents(
 CREATE TABLE IF NOT EXISTS agent_exec_log(
   id TEXT PRIMARY KEY,
   agent_id TEXT,
-  prompt_json TEXT,
-  response_json TEXT,
+  prompt TEXT,
+  response TEXT,
   created_at INTEGER
 );
 
@@ -53,6 +53,9 @@ CREATE TABLE IF NOT EXISTS agent_exec_result(
   error TEXT,
   created_at INTEGER
 );
+
+CREATE INDEX IF NOT EXISTS idx_agent_exec_result_agent_id_created_at
+  ON agent_exec_result(agent_id, created_at);
 
 -- Indexes to optimize duplicate detection queries
 CREATE INDEX IF NOT EXISTS idx_agents_draft_all_fields

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -42,6 +42,17 @@ CREATE TABLE IF NOT EXISTS agent_exec_log(
   created_at INTEGER
 );
 
+CREATE TABLE IF NOT EXISTS agent_exec_result(
+  id TEXT PRIMARY KEY,
+  agent_id TEXT,
+  log TEXT,
+  rebalance INTEGER,
+  new_allocation REAL,
+  short_report TEXT,
+  error TEXT,
+  created_at INTEGER
+);
+
 -- Indexes to optimize duplicate detection queries
 CREATE INDEX IF NOT EXISTS idx_agents_draft_all_fields
   ON agents(

--- a/backend/src/repos/agent-exec-log.ts
+++ b/backend/src/repos/agent-exec-log.ts
@@ -11,7 +11,7 @@ export interface ExecLogEntry {
 export function insertExecLog(entry: ExecLogEntry): void {
   db
     .prepare(
-      'INSERT INTO agent_exec_log (id, agent_id, prompt_json, response_json, created_at) VALUES (?, ?, ?, ?, ?)',
+      'INSERT INTO agent_exec_log (id, agent_id, prompt, response, created_at) VALUES (?, ?, ?, ?, ?)',
     )
     .run(
       entry.id,
@@ -24,9 +24,9 @@ export function insertExecLog(entry: ExecLogEntry): void {
 
 export function getRecentExecLogs(agentId: string, limit: number) {
   const rows = db
-    .prepare<unknown[], { response_json: string | null }>(
-      'SELECT response_json FROM agent_exec_log WHERE agent_id = ? ORDER BY created_at DESC LIMIT ?',
+    .prepare<unknown[], { response: string | null }>(
+      'SELECT response FROM agent_exec_log WHERE agent_id = ? ORDER BY created_at DESC LIMIT ?',
     )
-    .all(agentId, limit) as { response_json: string | null }[];
-  return rows.map((r) => ({ response: r.response_json }));
+    .all(agentId, limit) as { response: string | null }[];
+  return rows.map((r) => ({ response: r.response }));
 }

--- a/backend/src/repos/agent-exec-log.ts
+++ b/backend/src/repos/agent-exec-log.ts
@@ -3,22 +3,30 @@ import { db } from '../db/index.js';
 export interface ExecLogEntry {
   id: string;
   agentId: string;
-  log: string;
+  prompt?: unknown;
+  response: unknown;
   createdAt: number;
 }
 
 export function insertExecLog(entry: ExecLogEntry): void {
   db
     .prepare(
-      'INSERT INTO agent_exec_log (id, agent_id, log, created_at) VALUES (?, ?, ?, ?)',
+      'INSERT INTO agent_exec_log (id, agent_id, prompt_json, response_json, created_at) VALUES (?, ?, ?, ?, ?)',
     )
-    .run(entry.id, entry.agentId, entry.log, entry.createdAt);
+    .run(
+      entry.id,
+      entry.agentId,
+      entry.prompt === undefined ? null : JSON.stringify(entry.prompt),
+      JSON.stringify(entry.response),
+      entry.createdAt,
+    );
 }
 
 export function getRecentExecLogs(agentId: string, limit: number) {
-  return db
-    .prepare<unknown[], { log: string }>(
-      'SELECT log FROM agent_exec_log WHERE agent_id = ? ORDER BY created_at DESC LIMIT ?',
+  const rows = db
+    .prepare<unknown[], { response_json: string | null }>(
+      'SELECT response_json FROM agent_exec_log WHERE agent_id = ? ORDER BY created_at DESC LIMIT ?',
     )
-    .all(agentId, limit) as { log: string }[];
+    .all(agentId, limit) as { response_json: string | null }[];
+  return rows.map((r) => ({ response: r.response_json }));
 }

--- a/backend/src/repos/agent-exec-result.ts
+++ b/backend/src/repos/agent-exec-result.ts
@@ -1,0 +1,47 @@
+import { db } from '../db/index.js';
+
+export interface ExecResultEntry {
+  id: string;
+  agentId: string;
+  log: string;
+  rebalance?: boolean;
+  newAllocation?: number;
+  shortReport?: string;
+  error?: Record<string, unknown>;
+  createdAt: number;
+}
+
+export function insertExecResult(entry: ExecResultEntry): void {
+  db.prepare(
+    'INSERT INTO agent_exec_result (id, agent_id, log, rebalance, new_allocation, short_report, error, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+  ).run(
+    entry.id,
+    entry.agentId,
+    entry.log,
+    entry.rebalance === undefined ? null : entry.rebalance ? 1 : 0,
+    entry.newAllocation ?? null,
+    entry.shortReport ?? null,
+    entry.error ? JSON.stringify(entry.error) : null,
+    entry.createdAt,
+  );
+}
+
+export function getAgentExecResults(agentId: string, limit: number, offset: number) {
+  const totalRow = db
+    .prepare('SELECT COUNT(*) as count FROM agent_exec_result WHERE agent_id = ?')
+    .get(agentId) as { count: number };
+    const rows = db
+      .prepare(
+        'SELECT id, log, rebalance, new_allocation, short_report, error, created_at FROM agent_exec_result WHERE agent_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?',
+      )
+      .all(agentId, limit, offset) as {
+      id: string;
+      log: string;
+      rebalance: number | null;
+      new_allocation: number | null;
+      short_report: string | null;
+      error: string | null;
+      created_at: number;
+    }[];
+  return { rows, total: totalRow.count };
+}

--- a/backend/src/repos/agents.ts
+++ b/backend/src/repos/agents.ts
@@ -16,11 +16,6 @@ export interface AgentRow {
   agent_instructions: string;
 }
 
-export interface ExecLogRow {
-  id: string;
-  log: string;
-  created_at: number;
-}
 
 export function toApi(row: AgentRow) {
   return {
@@ -181,21 +176,6 @@ export function insertAgent(data: {
   );
 }
 
-export function getAgentExecLog(
-  agentId: string,
-  limit: number,
-  offset: number,
-) {
-  const totalRow = db
-    .prepare('SELECT COUNT(*) as count FROM agent_exec_log WHERE agent_id = ?')
-    .get(agentId) as { count: number };
-  const rows = db
-    .prepare(
-      'SELECT id, log, created_at FROM agent_exec_log WHERE agent_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?',
-    )
-    .all(agentId, limit, offset) as ExecLogRow[];
-  return { rows, total: totalRow.count };
-}
 
 export function updateAgent(data: {
   id: string;

--- a/backend/src/services/binance.ts
+++ b/backend/src/services/binance.ts
@@ -76,8 +76,6 @@ async function fetchSymbolData(symbol: string) {
     asks: [string, string][];
   };
   const yearJson = (await yearRes.json()) as unknown[];
-  const weekJson = yearJson.slice(-7);
-  const monthJson = yearJson.slice(-30);
   return {
     currentPrice: Number(priceJson.price),
     orderBook: {
@@ -85,8 +83,6 @@ async function fetchSymbolData(symbol: string) {
       asks: depthJson.asks.map(([p, q]) => [Number(p), Number(q)]),
     },
     day: await dayRes.json(),
-    week: weekJson,
-    month: monthJson,
     year: yearJson,
   };
 }

--- a/backend/src/services/binance.ts
+++ b/backend/src/services/binance.ts
@@ -51,28 +51,32 @@ export async function fetchTotalBalanceUsd(id: string) {
 
 export async function fetchPairData(tokenA: string, tokenB: string) {
   const symbol = `${tokenA}${tokenB}`.toUpperCase();
-  const [priceRes, depthRes, dayRes, weekRes, monthRes, yearRes] = await Promise.all([
+  const [priceRes, depthRes, dayRes, yearRes] = await Promise.all([
     fetch(`https://api.binance.com/api/v3/ticker/price?symbol=${symbol}`),
     fetch(`https://api.binance.com/api/v3/depth?symbol=${symbol}&limit=5`),
     fetch(`https://api.binance.com/api/v3/ticker/24hr?symbol=${symbol}`),
-    fetch(`https://api.binance.com/api/v3/klines?symbol=${symbol}&interval=1d&limit=7`),
-    fetch(`https://api.binance.com/api/v3/klines?symbol=${symbol}&interval=1d&limit=30`),
     fetch(`https://api.binance.com/api/v3/klines?symbol=${symbol}&interval=1d&limit=365`),
   ]);
-  if (
-    !priceRes.ok ||
-    !depthRes.ok ||
-    !dayRes.ok ||
-    !weekRes.ok ||
-    !monthRes.ok ||
-    !yearRes.ok
-  )
-    throw new Error('failed to fetch market data');
+  const responses = {
+    price: priceRes,
+    depth: depthRes,
+    day: dayRes,
+    year: yearRes,
+  } as const;
+  for (const [name, res] of Object.entries(responses)) {
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`failed to fetch ${name} data: ${res.status} ${body}`);
+    }
+  }
   const priceJson = (await priceRes.json()) as { price: string };
   const depthJson = (await depthRes.json()) as {
     bids: [string, string][];
     asks: [string, string][];
   };
+  const yearJson = (await yearRes.json()) as unknown[];
+  const weekJson = yearJson.slice(-7);
+  const monthJson = yearJson.slice(-30);
   return {
     currentPrice: Number(priceJson.price),
     orderBook: {
@@ -80,8 +84,8 @@ export async function fetchPairData(tokenA: string, tokenB: string) {
       asks: depthJson.asks.map(([p, q]) => [Number(p), Number(q)]),
     },
     day: await dayRes.json(),
-    week: await weekRes.json(),
-    month: await monthRes.json(),
-    year: await yearRes.json(),
+    week: weekJson,
+    month: monthJson,
+    year: yearJson,
   };
 }

--- a/backend/src/util/ai.ts
+++ b/backend/src/util/ai.ts
@@ -1,5 +1,5 @@
 const developerInstructions =
-  "You assist a real trader in taking decisions on a given tokens configuration. The user's comment may be found in the trading instructions field. Use the web search tool to find fresh news and prices and advise the user whether to rebalance or not. Fit report comment in 255 characters. If you suggest rebalancing, provide the new allocation in percentage (0-100) for the first token in the pair. If you don't suggest rebalancing, set rebalance to false and provide a short report comment. If you encounter an error, return an object with an error message.";
+  "You assist a real trader in taking decisions on a given tokens configuration. Users may deposit or withdraw funds between runs; if the current balance doesn't match previous executions, treat the session as new. The user's comment may be found in the trading instructions field. Use the web search tool to find fresh news and prices and advise the user whether to rebalance or not. Fit report comment in 255 characters. If you suggest rebalancing, provide the new allocation in percentage (0-100) for the first token in the pair. If you don't suggest rebalancing, set rebalance to false and provide a short report comment. If you encounter an error, return an object with an error message.";
 
 export async function callAi(
   model: string,

--- a/backend/src/util/parse-exec-log.ts
+++ b/backend/src/util/parse-exec-log.ts
@@ -27,6 +27,16 @@ export function parseExecLog(log: unknown): ParsedExecLog {
   }
 
   if (parsed && typeof parsed === 'object') {
+    if ('prompt' in parsed) {
+      if ('response' in parsed)
+        return parseExecLog((parsed as any).response);
+      if ('error' in parsed)
+        return {
+          text: '',
+          response: undefined,
+          error: { message: String((parsed as any).error) },
+        };
+    }
     // *** FIX: only treat as error if value is truthy, not when it's null ***
     if ('error' in parsed && parsed.error) {
       error = parsed.error as Record<string, unknown>;

--- a/backend/test/agentExecLog.test.ts
+++ b/backend/test/agentExecLog.test.ts
@@ -24,7 +24,7 @@ describe('agent exec log routes', () => {
 
     for (let i = 0; i < 3; i++) {
       db.prepare(
-        'INSERT INTO agent_exec_log (id, agent_id, response_json, created_at) VALUES (?, ?, ?, ?)',
+        'INSERT INTO agent_exec_log (id, agent_id, response, created_at) VALUES (?, ?, ?, ?)',
       ).run(`log${i}`, agentId, JSON.stringify(`log-${i}`), i);
       const parsed = parseExecLog(`log-${i}`);
       insertExecResult({
@@ -78,7 +78,7 @@ describe('agent exec log routes', () => {
     );
 
     db.prepare(
-      'INSERT INTO agent_exec_log (id, agent_id, response_json, created_at) VALUES (?, ?, ?, ?)',
+      'INSERT INTO agent_exec_log (id, agent_id, response, created_at) VALUES (?, ?, ?, ?)',
     ).run('log-new', agentId, aiLog, 0);
     const parsedAi = parseExecLog(aiLog);
     insertExecResult({
@@ -131,7 +131,7 @@ describe('agent exec log routes', () => {
     ).run(agentId, 'u5');
     const entry = JSON.stringify({ prompt: { instructions: 'inst' }, response: 'ok' });
     db.prepare(
-      'INSERT INTO agent_exec_log (id, agent_id, response_json, created_at) VALUES (?, ?, ?, ?)',
+      'INSERT INTO agent_exec_log (id, agent_id, response, created_at) VALUES (?, ?, ?, ?)',
     ).run('logp', agentId, entry, 0);
     const parsedP = parseExecLog(entry);
     insertExecResult({

--- a/backend/test/agentExecLog.test.ts
+++ b/backend/test/agentExecLog.test.ts
@@ -3,6 +3,8 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { db } from '../src/db/index.js';
 import buildServer from '../src/server.js';
+import { parseExecLog } from '../src/util/parse-exec-log.js';
+import { insertExecResult } from '../src/repos/agent-exec-result.js';
 
 function addUser(id: string) {
   db.prepare('INSERT INTO users (id) VALUES (?)').run(id);
@@ -24,6 +26,21 @@ describe('agent exec log routes', () => {
       db.prepare(
           'INSERT INTO agent_exec_log (id, agent_id, log, created_at) VALUES (?, ?, ?, ?)'
       ).run(`log${i}`, agentId, `log-${i}`, i);
+      const parsed = parseExecLog(`log-${i}`);
+      insertExecResult({
+        id: `log${i}`,
+        agentId,
+        log: parsed.text,
+        ...(parsed.response
+          ? {
+              rebalance: parsed.response.rebalance,
+              newAllocation: parsed.response.newAllocation,
+              shortReport: parsed.response.shortReport,
+            }
+          : {}),
+        ...(parsed.error ? { error: parsed.error } : {}),
+        createdAt: i,
+      });
     }
 
     let res = await app.inject({
@@ -63,6 +80,21 @@ describe('agent exec log routes', () => {
     db.prepare(
         'INSERT INTO agent_exec_log (id, agent_id, log, created_at) VALUES (?, ?, ?, ?)',
     ).run('log-new', agentId, aiLog, 0);
+    const parsedAi = parseExecLog(aiLog);
+    insertExecResult({
+      id: 'log-new',
+      agentId,
+      log: parsedAi.text,
+      ...(parsedAi.response
+        ? {
+            rebalance: parsedAi.response.rebalance,
+            newAllocation: parsedAi.response.newAllocation,
+            shortReport: parsedAi.response.shortReport,
+          }
+        : {}),
+      ...(parsedAi.error ? { error: parsedAi.error } : {}),
+      createdAt: 0,
+    });
 
     const res = await app.inject({
       method: 'GET',
@@ -86,6 +118,44 @@ describe('agent exec log routes', () => {
     expect(typeof body.items[0].response.shortReport).toBe('string');
     expect(body.items[0].response.shortReport.length).toBeGreaterThan(0);
 
+    await app.close();
+  });
+
+  it('handles exec log entries with prompt wrapper', async () => {
+    const app = await buildServer();
+    addUser('u5');
+    const agentId = 'a5';
+    db.prepare(
+        `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
+         VALUES (?, ?, 'gpt', 'active', 0, 'A', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`
+    ).run(agentId, 'u5');
+    const entry = JSON.stringify({ prompt: { instructions: 'inst' }, response: 'ok' });
+    db.prepare(
+        'INSERT INTO agent_exec_log (id, agent_id, log, created_at) VALUES (?, ?, ?, ?)',
+    ).run('logp', agentId, entry, 0);
+    const parsedP = parseExecLog(entry);
+    insertExecResult({
+      id: 'logp',
+      agentId,
+      log: parsedP.text,
+      ...(parsedP.response
+        ? {
+            rebalance: parsedP.response.rebalance,
+            newAllocation: parsedP.response.newAllocation,
+            shortReport: parsedP.response.shortReport,
+          }
+        : {}),
+      ...(parsedP.error ? { error: parsedP.error } : {}),
+      createdAt: 0,
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/agents/${agentId}/exec-log?page=1&pageSize=10`,
+      headers: { 'x-user-id': 'u5' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.items[0].log).toBe('ok');
     await app.close();
   });
 });

--- a/backend/test/agentExecLog.test.ts
+++ b/backend/test/agentExecLog.test.ts
@@ -24,8 +24,8 @@ describe('agent exec log routes', () => {
 
     for (let i = 0; i < 3; i++) {
       db.prepare(
-          'INSERT INTO agent_exec_log (id, agent_id, log, created_at) VALUES (?, ?, ?, ?)'
-      ).run(`log${i}`, agentId, `log-${i}`, i);
+        'INSERT INTO agent_exec_log (id, agent_id, response_json, created_at) VALUES (?, ?, ?, ?)',
+      ).run(`log${i}`, agentId, JSON.stringify(`log-${i}`), i);
       const parsed = parseExecLog(`log-${i}`);
       insertExecResult({
         id: `log${i}`,
@@ -78,7 +78,7 @@ describe('agent exec log routes', () => {
     );
 
     db.prepare(
-        'INSERT INTO agent_exec_log (id, agent_id, log, created_at) VALUES (?, ?, ?, ?)',
+      'INSERT INTO agent_exec_log (id, agent_id, response_json, created_at) VALUES (?, ?, ?, ?)',
     ).run('log-new', agentId, aiLog, 0);
     const parsedAi = parseExecLog(aiLog);
     insertExecResult({
@@ -131,7 +131,7 @@ describe('agent exec log routes', () => {
     ).run(agentId, 'u5');
     const entry = JSON.stringify({ prompt: { instructions: 'inst' }, response: 'ok' });
     db.prepare(
-        'INSERT INTO agent_exec_log (id, agent_id, log, created_at) VALUES (?, ?, ?, ?)',
+      'INSERT INTO agent_exec_log (id, agent_id, response_json, created_at) VALUES (?, ?, ?, ?)',
     ).run('logp', agentId, entry, 0);
     const parsedP = parseExecLog(entry);
     insertExecResult({

--- a/backend/test/binance.test.ts
+++ b/backend/test/binance.test.ts
@@ -6,7 +6,7 @@ describe('fetchPairData', () => {
     vi.restoreAllMocks();
   });
 
-  it('derives week and month from yearly klines', async () => {
+  it('fetches yearly klines and omits week/month slices', async () => {
     const yearData = Array.from({ length: 365 }, (_, i) => [i]);
     const fetchMock = vi
       .fn()
@@ -18,9 +18,9 @@ describe('fetchPairData', () => {
 
     const data = await fetchPairData('BTC', 'USDT');
     expect(fetchMock).toHaveBeenCalledTimes(4);
-    expect(data.week).toEqual(yearData.slice(-7));
-    expect(data.month).toEqual(yearData.slice(-30));
     expect(data.year).toEqual(yearData);
+    expect('week' in data).toBe(false);
+    expect('month' in data).toBe(false);
   });
 
   it('retries with reversed pair on invalid symbol', async () => {

--- a/backend/test/binance.test.ts
+++ b/backend/test/binance.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchPairData } from '../src/services/binance.js';
+
+describe('fetchPairData', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('derives week and month from yearly klines', async () => {
+    const yearData = Array.from({ length: 365 }, (_, i) => [i]);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ price: '1' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ bids: [], asks: [] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      .mockResolvedValueOnce({ ok: true, json: async () => yearData });
+    vi.stubGlobal('fetch', fetchMock as any);
+
+    const data = await fetchPairData('BTC', 'USDT');
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(data.week).toEqual(yearData.slice(-7));
+    expect(data.month).toEqual(yearData.slice(-30));
+    expect(data.year).toEqual(yearData);
+  });
+});

--- a/backend/test/reviewPortfolio.test.ts
+++ b/backend/test/reviewPortfolio.test.ts
@@ -41,7 +41,7 @@ describe('reviewPortfolio', () => {
     for (let i = 0; i < 6; i++) {
       db
         .prepare(
-          'INSERT INTO agent_exec_log (id, agent_id, response_json, created_at) VALUES (?, ?, ?, ?)',
+          'INSERT INTO agent_exec_log (id, agent_id, response, created_at) VALUES (?, ?, ?, ?)',
         )
         .run(`id${i}`, 'a1', JSON.stringify(`resp-${i}`), i);
     }
@@ -66,15 +66,15 @@ describe('reviewPortfolio', () => {
     const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
     await reviewPortfolio(log, 'a4');
     const rows = db
-      .prepare('SELECT prompt_json, response_json FROM agent_exec_log WHERE agent_id = ?')
-      .all('a4') as { prompt_json: string | null; response_json: string | null }[];
+      .prepare('SELECT prompt, response FROM agent_exec_log WHERE agent_id = ?')
+      .all('a4') as { prompt: string | null; response: string | null }[];
     expect(rows).toHaveLength(1);
-    expect(JSON.parse(rows[0].prompt_json!)).toMatchObject({
+    expect(JSON.parse(rows[0].prompt!)).toMatchObject({
       instructions: 'inst',
       tokenA: 'BTC',
       tokenB: 'ETH',
     });
-    const respEntry = JSON.parse(rows[0].response_json!);
+    const respEntry = JSON.parse(rows[0].response!);
     expect(typeof respEntry).toBe('string');
 
     const parsedRows = db
@@ -108,10 +108,10 @@ describe('reviewPortfolio', () => {
     await reviewPortfolio(log, 'a2');
     expect(callAi).not.toHaveBeenCalled();
     const rows = db
-      .prepare('SELECT response_json FROM agent_exec_log WHERE agent_id = ?')
-      .all('a2') as { response_json: string | null }[];
+      .prepare('SELECT response FROM agent_exec_log WHERE agent_id = ?')
+      .all('a2') as { response: string | null }[];
     expect(rows).toHaveLength(1);
-    const entry = JSON.parse(rows[0].response_json!);
+    const entry = JSON.parse(rows[0].response!);
     expect(entry.error).toContain('failed to fetch token balances');
     const parsedRows = db
       .prepare(
@@ -140,10 +140,10 @@ describe('reviewPortfolio', () => {
     await reviewPortfolio(log, 'a3');
     expect(callAi).not.toHaveBeenCalled();
     const rows = db
-      .prepare('SELECT response_json FROM agent_exec_log WHERE agent_id = ?')
-      .all('a3') as { response_json: string | null }[];
+      .prepare('SELECT response FROM agent_exec_log WHERE agent_id = ?')
+      .all('a3') as { response: string | null }[];
     expect(rows).toHaveLength(1);
-    const entry2 = JSON.parse(rows[0].response_json!);
+    const entry2 = JSON.parse(rows[0].response!);
     expect(entry2.error).toContain('failed to fetch market data');
     const parsedRows = db
       .prepare(


### PR DESCRIPTION
## Summary
- save full input prompts in exec logs for rebalancing runs
- persist structured exec results with dedicated table columns
- serve parsed exec results through the API
- guide the agent to restart if balances change due to withdrawals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7e681b43c832c8a8523ad6973c520