### PR TITLE
feat(ui): unify agent timestamps

### DIFF
--- a/frontend/src/components/ui/FormattedDate.tsx
+++ b/frontend/src/components/ui/FormattedDate.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  date: string | number | Date;
+}
+
+export default function FormattedDate({ date }: Props) {
+  const d = new Date(date);
+  const short = new Intl.DateTimeFormat(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  })
+    .format(d)
+    .replace(/,\s*/g, " ");
+  const full = new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  })
+    .format(d)
+    .replace(", ", " ");
+  return <span title={full}>{short}</span>;
+}

--- a/frontend/src/routes/AgentView.tsx
+++ b/frontend/src/routes/AgentView.tsx
@@ -16,6 +16,7 @@ import ExecLogItem, { type ExecLog } from '../components/ExecLogItem';
 import Modal from '../components/ui/Modal';
 import AgentInstructions from '../components/AgentInstructions';
 import { normalizeAllocations } from '../lib/allocations';
+import FormattedDate from '../components/ui/FormattedDate';
 
 interface Agent {
   id: string;
@@ -149,7 +150,7 @@ export default function AgentView() {
           <span>Agent:</span> <span>{data.name}</span>
         </h1>
         <p className="mt-2">
-          <strong>Created:</strong> {new Date(data.createdAt).toLocaleString()}
+          <strong>Created:</strong> <FormattedDate date={data.createdAt} />
         </p>
         <p className="mt-2">
           <strong>Status:</strong> <AgentStatusLabel status={data.status}/>
@@ -257,7 +258,7 @@ export default function AgentView() {
                       {logData.items.map((log) => (
                           <tr key={log.id}>
                             <td className="align-top pr-2">
-                              {new Date(log.createdAt).toLocaleString()}
+                              <FormattedDate date={log.createdAt} />
                             </td>
                             <td>
                               <ExecLogItem log={log}/>


### PR DESCRIPTION
## Summary
- add `FormattedDate` component for consistent timestamp display
- use new component in agent details and execution log entries

## Testing
- `npm test`
- `npm --prefix frontend run lint` *(fails: Unexpected any / react-refresh restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68a80a0209b8832c9dda3ed7c9ce176d