### PR TITLE
Use agent_exec_result for prompt history

### DIFF
--- a/backend/src/jobs/review-portfolio.ts
+++ b/backend/src/jobs/review-portfolio.ts
@@ -3,8 +3,8 @@ import { randomUUID } from 'node:crypto';
 import { env } from '../util/env.js';
 import { decrypt } from '../util/crypto.js';
 import { getActiveAgents } from '../repos/agents.js';
-import { insertExecLog, getRecentExecLogs } from '../repos/agent-exec-log.js';
-import { insertExecResult } from '../repos/agent-exec-result.js';
+import { insertExecLog } from '../repos/agent-exec-log.js';
+import { insertExecResult, getRecentExecResults } from '../repos/agent-exec-result.js';
 import { parseExecLog } from '../util/parse-exec-log.js';
 import { callAi } from '../util/ai.js';
 import { fetchAccount, fetchPairData } from '../services/binance.js';
@@ -109,17 +109,10 @@ export default async function reviewPortfolio(
           reviewInterval: row.review_interval,
           marketData,
         };
-        const prevRows = getRecentExecLogs(row.id, 5);
+        const prevRows = getRecentExecResults(row.id, 5);
         const previousResponses = prevRows.map((r) => {
-          if (!r.response) return '';
-          try {
-            const parsed = JSON.parse(r.response);
-            return typeof parsed === 'string'
-              ? parsed
-              : JSON.stringify(parsed);
-          } catch {
-            return r.response as string;
-          }
+          const str = JSON.stringify(r);
+          return str === '{}' ? '' : str;
         });
         const text = await callAi(row.model, prompt, key, previousResponses);
         const createdAt = Date.now();

--- a/backend/src/repos/agent-exec-result.ts
+++ b/backend/src/repos/agent-exec-result.ts
@@ -26,6 +26,25 @@ export function insertExecResult(entry: ExecResultEntry): void {
   );
 }
 
+export function getRecentExecResults(agentId: string, limit: number) {
+  const rows = db
+    .prepare(
+      'SELECT rebalance, new_allocation, short_report, error FROM agent_exec_result WHERE agent_id = ? ORDER BY created_at DESC LIMIT ?',
+    )
+    .all(agentId, limit) as {
+      rebalance: number | null;
+      new_allocation: number | null;
+      short_report: string | null;
+      error: string | null;
+    }[];
+  return rows.map((r) => ({
+    ...(r.rebalance !== null ? { rebalance: !!r.rebalance } : {}),
+    ...(r.new_allocation !== null ? { newAllocation: r.new_allocation } : {}),
+    ...(r.short_report !== null ? { shortReport: r.short_report } : {}),
+    ...(r.error !== null ? { error: JSON.parse(r.error) } : {}),
+  }));
+}
+
 export function getAgentExecResults(agentId: string, limit: number, offset: number) {
   const totalRow = db
     .prepare('SELECT COUNT(*) as count FROM agent_exec_result WHERE agent_id = ?')


### PR DESCRIPTION
## Summary
- derive prior AI responses from `agent_exec_result` instead of `agent_exec_log`
- include recent execution results (without id or log) when constructing prompts
- update tests to reflect new source for previous responses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a81b630b88832c8990e2834cae9ec8