### PR TITLE
chore(ci): cache dependencies for faster deploy pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,16 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'npm'
+          cache-dependency-path: |
+            backend/package-lock.json
+            frontend/package-lock.json
 
-      - name: Install backend dependencies
-        run: npm --prefix backend ci
-
-      - name: Install frontend dependencies
-        run: npm --prefix frontend ci
+      - name: Install dependencies
+        run: |
+          npm --prefix backend ci &
+          npm --prefix frontend ci &
+          wait
 
       - name: Lint frontend
         run: npm --prefix frontend run lint


### PR DESCRIPTION
## Summary
- cache npm dependencies and install backend/frontend in parallel
- speed up CI while preserving build, test, and lint safeguards

## Testing
- `npm --prefix frontend run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa568d3df4832c9e9ffd032b4086e2