### PR TITLE
feat: add mobile nav and hide chart

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
+        "@types/node": "^24.3.0",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
@@ -1507,6 +1508,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.1.10",
@@ -4576,6 +4587,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,12 +18,13 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.62.0",
+    "react-qr-code": "^2.0.13",
     "react-router-dom": "^7.8.0",
-    "zod": "^4.0.17",
-    "react-qr-code": "^2.0.13"
+    "zod": "^4.0.17"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@types/node": "^24.3.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -34,9 +34,9 @@ export default function AppShell() {
           <GoogleLoginButton />
         </div>
       </header>
-      <div className="flex flex-1 pt-16 pb-8 overflow-hidden">
+      <div className="flex flex-1 pt-16 pb-16 md:pb-8 overflow-hidden">
         <nav
-          className={`${navCollapsed ? 'w-20' : 'w-32'} bg-gray-100 p-4 transition-all duration-300 flex flex-col`}
+          className={`${navCollapsed ? 'w-20' : 'w-32'} bg-gray-100 p-4 transition-all duration-300 hidden md:flex md:flex-col`}
         >
           <div
             className={`flex flex-col flex-1 overflow-y-auto ${
@@ -103,7 +103,7 @@ export default function AppShell() {
           <Outlet />
         </main>
       </div>
-      <footer className="fixed bottom-0 left-0 right-0 bg-gray-100 text-xs text-center py-1 border-t">
+      <footer className="hidden md:block fixed bottom-0 left-0 right-0 bg-gray-100 text-xs text-center py-1 border-t">
         <Link to="/terms" className="mx-2 hover:text-gray-900">
           Terms
         </Link>
@@ -111,6 +111,17 @@ export default function AppShell() {
           Privacy
         </Link>
       </footer>
+      <nav className="md:hidden fixed bottom-0 left-0 right-0 bg-gray-100 border-t flex justify-around py-2">
+        <Link to="/settings" className="text-gray-700 hover:text-gray-900" aria-label="Settings">
+          <SettingsIcon className="w-6 h-6" />
+        </Link>
+        <Link to="/" className="text-gray-700 hover:text-gray-900" aria-label="Agents">
+          <Bot className="w-6 h-6" />
+        </Link>
+        <Link to="/keys" className="text-gray-700 hover:text-gray-900" aria-label="Keys">
+          <Key className="w-6 h-6" />
+        </Link>
+      </nav>
     </div>
   );
 }

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -161,10 +161,12 @@ export default function Dashboard() {
 
   return (
     <div className="flex flex-col gap-3 w-full">
-      <div className="flex gap-3 items-stretch">
-        <ErrorBoundary>
-          <PriceChart tokenA={tokens.tokenA} tokenB={tokens.tokenB} />
-        </ErrorBoundary>
+      <div className="flex flex-col md:flex-row gap-3 items-stretch">
+        <div className="hidden md:flex flex-1">
+          <ErrorBoundary>
+            <PriceChart tokenA={tokens.tokenA} tokenB={tokens.tokenB} />
+          </ErrorBoundary>
+        </div>
         <CreateAgentForm onTokensChange={handleTokensChange} />
       </div>
       <ErrorBoundary>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   server: {


### PR DESCRIPTION
## Summary
- hide price chart and terms/privacy footer on mobile
- move key nav icons into a new mobile bottom bar

## Testing
- `npm test`
- `npm run build`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa59a07ab8832cb92529d498a67313