### PR TITLE
style: improve mobile navigation

### DIFF
--- a/frontend/src/components/GoogleLoginButton.tsx
+++ b/frontend/src/components/GoogleLoginButton.tsx
@@ -70,7 +70,8 @@ export default function GoogleLoginButton() {
   if (user)
     return (
       <div className="h-5 flex items-center text-sm gap-2">
-        <span>{user.email}</span>
+        <span className="hidden md:inline">{user.email}</span>
+        <span className="md:hidden">{user.email.split('@')[0]}</span>
         <Button
           type="button"
           variant="link"

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -30,7 +30,9 @@ export default function AppShell() {
       <header className="fixed top-0 left-0 right-0 bg-gray-800 text-white p-4 flex justify-between z-10">
         <span className="font-bold">PromptSwap</span>
         <div className="flex items-center gap-4">
-          <ApiStatus />
+          <span className="hidden md:inline">
+            <ApiStatus />
+          </span>
           <GoogleLoginButton />
         </div>
       </header>
@@ -111,7 +113,7 @@ export default function AppShell() {
           Privacy
         </Link>
       </footer>
-      <nav className="md:hidden fixed bottom-0 left-0 right-0 bg-gray-100 border-t flex justify-around py-2">
+      <nav className="md:hidden fixed bottom-0 left-0 right-0 bg-gray-100 border-t flex justify-around py-4">
         <Link to="/settings" className="text-gray-700 hover:text-gray-900" aria-label="Settings">
           <SettingsIcon className="w-6 h-6" />
         </Link>


### PR DESCRIPTION
## Summary
- hide API status and shorten user email in mobile header
- increase padding in mobile bottom navigation bar for easier tapping

## Testing
- `npm test`
- `npm run build`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa69b170f8832c9c39f109cab11352