### PR TITLE
Refactor mobile agents and logs layout

### DIFF
--- a/frontend/src/routes/AgentView.tsx
+++ b/frontend/src/routes/AgentView.tsx
@@ -174,7 +174,7 @@ export default function AgentView() {
                   <p>No logs yet.</p>
               ) : (
                   <>
-                    <table className="w-full mb-2 table-fixed">
+                    <table className="w-full mb-2 table-fixed hidden md:table">
                       <colgroup>
                         <col className="w-40" />
                         <col />
@@ -198,6 +198,16 @@ export default function AgentView() {
                         ))}
                       </tbody>
                     </table>
+                    <div className="md:hidden mb-2">
+                      {logData.items.map((log) => (
+                        <div key={log.id} className="mb-2">
+                          <div className="text-xs text-gray-500 mb-1">
+                            <FormattedDate date={log.createdAt} />
+                          </div>
+                          <ExecLogItem log={log} />
+                        </div>
+                      ))}
+                    </div>
                     <div className="flex items-center gap-2">
                       <Button
                           disabled={logPage === 1}


### PR DESCRIPTION
## Summary
- Show agents as stacked blocks on mobile with tokens, balance, PnL, model, status, and actions
- Remove time column from mobile execution log and show timestamp above each entry

## Testing
- `npm test`
- `npm run build`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa71cdd1d4832c915f78dec859d9e0