### PR TITLE
feat: make header logo link to agents

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -28,7 +28,9 @@ export default function AppShell() {
   return (
     <div className="h-screen flex flex-col">
       <header className="fixed top-0 left-0 right-0 bg-gray-800 text-white p-4 flex justify-between z-10">
-        <span className="font-bold">PromptSwap</span>
+        <Link to="/" className="font-bold">
+          PromptSwap
+        </Link>
         <div className="flex items-center gap-4">
           <span className="hidden md:inline">
             <ApiStatus />


### PR DESCRIPTION
## Summary
- link PromptSwap header text to the agents dashboard

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa76f092e4832cbe248f1a562db73c