### PR TITLE
feat: add responsive create agent form

### DIFF
--- a/frontend/src/components/forms/CreateAgentForm.tsx
+++ b/frontend/src/components/forms/CreateAgentForm.tsx
@@ -1,4 +1,4 @@
-import {useEffect} from 'react';
+import {useEffect, useState} from 'react';
 import {useNavigate} from 'react-router-dom';
 import {Controller, useForm} from 'react-hook-form';
 import {zodResolver} from '@hookform/resolvers/zod';
@@ -54,6 +54,7 @@ export default function CreateAgentForm({
     );
 
     const navigate = useNavigate();
+    const [mobileOpen, setMobileOpen] = useState(false);
 
     const onSubmit = handleSubmit(async (values) => {
         if (!user) return;
@@ -72,11 +73,20 @@ export default function CreateAgentForm({
 
     return (
         <>
+            {!mobileOpen && (
+                <Button
+                    type="button"
+                    className="w-full md:hidden"
+                    onClick={() => setMobileOpen(true)}
+                >
+                    Create Agent
+                </Button>
+            )}
             <form
                 onSubmit={onSubmit}
-                className="bg-white shadow-md border border-gray-200 rounded p-6 space-y-4 w-full max-w-[30rem]"
+                className={`bg-white shadow-md border border-gray-200 rounded p-6 space-y-4 w-full max-w-[30rem] ${mobileOpen ? '' : 'hidden'} md:block`}
             >
-                <h2 className="text-xl font-bold">Create Agent</h2>
+                <h2 className="text-lg md:text-xl font-bold">Create Agent</h2>
                 <div className="grid grid-cols-2 gap-4">
                     <FormField label="Token A" htmlFor="tokenA">
                         <Controller

--- a/frontend/src/components/forms/FormField.tsx
+++ b/frontend/src/components/forms/FormField.tsx
@@ -19,7 +19,10 @@ export default function FormField({
   return (
     <div className={className}>
       {label && (
-        <label className="block text-sm font-medium mb-1" htmlFor={htmlFor}>
+        <label
+          className="block text-xs md:text-sm font-medium mb-1"
+          htmlFor={htmlFor}
+        >
           <span className="inline-flex items-center">
             {label}
             {tooltip && <InfoTooltip>{tooltip}</InfoTooltip>}


### PR DESCRIPTION
## Summary
- Collapse Create Agent form on mobile behind a button and add responsive header sizing
- Reduce form label size on small screens for consistency with mobile tables

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa783f653c832cb531168b9680705d