### PR TITLE
refactor: split agent view components

### DIFF
--- a/frontend/src/components/AgentDetailsDesktop.tsx
+++ b/frontend/src/components/AgentDetailsDesktop.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import { Eye, EyeOff, ChevronDown, ChevronRight } from 'lucide-react';
+import AgentStatusLabel from './AgentStatusLabel';
+import TokenDisplay from './TokenDisplay';
+import StrategyForm from './StrategyForm';
+import AgentPnl from './AgentPnl';
+import FormattedDate from './ui/FormattedDate';
+import type { Agent } from '../lib/useAgentData';
+
+interface Props {
+  agent: Agent;
+}
+
+export default function AgentDetailsDesktop({ agent }: Props) {
+  const [showStrategy, setShowStrategy] = useState(false);
+  const [showPrompt, setShowPrompt] = useState(false);
+
+  const strategyData = {
+    tokenA: agent.tokenA,
+    tokenB: agent.tokenB,
+    minTokenAAllocation: agent.minTokenAAllocation,
+    minTokenBAllocation: agent.minTokenBAllocation,
+    risk: agent.risk,
+    reviewInterval: agent.reviewInterval,
+  };
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-2 flex items-center gap-2">
+        <span>Agent:</span> <span>{agent.name}</span>
+      </h1>
+      <p className="mt-2">
+        <strong>Created:</strong> <FormattedDate date={agent.createdAt} />
+      </p>
+      <p className="mt-2">
+        <strong>Status:</strong> <AgentStatusLabel status={agent.status} />
+      </p>
+      <p className="flex items-center gap-1 mt-2">
+        <strong>Tokens:</strong>
+        <TokenDisplay token={agent.tokenA} />
+        <span>/</span>
+        <TokenDisplay token={agent.tokenB} />
+      </p>
+      <div className="mt-2">
+        <div
+          className="flex items-center gap-1 cursor-pointer"
+          onClick={() => setShowStrategy((s) => !s)}
+        >
+          <h2 className="text-l font-bold">Strategy</h2>
+          {showStrategy ? (
+            <ChevronDown className="w-4 h-4" />
+          ) : (
+            <ChevronRight className="w-4 h-4" />
+          )}
+        </div>
+        {showStrategy && (
+          <div className="mt-2 max-w-2xl">
+            <StrategyForm data={strategyData} onChange={() => {}} disabled />
+          </div>
+        )}
+      </div>
+      <div className="mt-2">
+        <div className="flex items-center gap-1">
+          <h2 className="text-l font-bold">Trading Instructions</h2>
+          {showPrompt ? (
+            <EyeOff
+              className="w-4 h-4 cursor-pointer"
+              onClick={() => setShowPrompt(false)}
+            />
+          ) : (
+            <Eye
+              className="w-4 h-4 cursor-pointer"
+              onClick={() => setShowPrompt(true)}
+            />
+          )}
+        </div>
+        {showPrompt && (
+          <pre className="whitespace-pre-wrap mt-2">
+            {agent.agentInstructions}
+          </pre>
+        )}
+      </div>
+      <AgentPnl
+        tokenA={agent.tokenA}
+        tokenB={agent.tokenB}
+        startBalanceUsd={agent.startBalanceUsd}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/AgentDetailsMobile.tsx
+++ b/frontend/src/components/AgentDetailsMobile.tsx
@@ -1,0 +1,33 @@
+import AgentStatusLabel from './AgentStatusLabel';
+import TokenDisplay from './TokenDisplay';
+import AgentPnlMobile from './AgentPnlMobile';
+import FormattedDate from './ui/FormattedDate';
+import type { Agent } from '../lib/useAgentData';
+
+interface Props {
+  agent: Agent;
+}
+
+export default function AgentDetailsMobile({ agent }: Props) {
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between">
+        <h1 className="text-2xl font-bold truncate flex-1">Agent: {agent.name}</h1>
+        <AgentStatusLabel status={agent.status} />
+      </div>
+      <p className="text-sm text-gray-500">
+        <FormattedDate date={agent.createdAt} />
+      </p>
+      <p className="flex items-center gap-1 mt-2">
+        <TokenDisplay token={agent.tokenA} />
+        <span>/</span>
+        <TokenDisplay token={agent.tokenB} />
+      </p>
+      <AgentPnlMobile
+        tokenA={agent.tokenA}
+        tokenB={agent.tokenB}
+        startBalanceUsd={agent.startBalanceUsd}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/AgentPnlMobile.tsx
+++ b/frontend/src/components/AgentPnlMobile.tsx
@@ -1,0 +1,46 @@
+import { useAgentBalanceUsd } from '../lib/useAgentBalanceUsd';
+
+interface Props {
+  tokenA: string;
+  tokenB: string;
+  startBalanceUsd: number | null;
+}
+
+export default function AgentPnlMobile({ tokenA, tokenB, startBalanceUsd }: Props) {
+  const { balance, isLoading } = useAgentBalanceUsd(tokenA, tokenB);
+  const balanceText =
+    balance === null ? '-' : isLoading ? 'Loading...' : `$${balance.toFixed(2)}`;
+  const pnl =
+    balance !== null && startBalanceUsd != null ? balance - startBalanceUsd : null;
+  const pnlText =
+    pnl === null
+      ? '-'
+      : isLoading
+      ? 'Loading...'
+      : `${pnl > 0 ? '+' : pnl < 0 ? '-' : ''}$${Math.abs(pnl).toFixed(2)}`;
+  const pnlClass =
+    pnl === null || isLoading
+      ? ''
+      : pnl <= -0.03
+      ? 'text-red-600'
+      : pnl >= 0.03
+      ? 'text-green-600'
+      : 'text-gray-600';
+  const pnlTooltip =
+    pnl === null || isLoading
+      ? undefined
+      : `PnL = $${balance!.toFixed(2)} - $${startBalanceUsd!.toFixed(2)} = ${
+          pnl > 0 ? '+' : pnl < 0 ? '-' : ''
+        }$${Math.abs(pnl).toFixed(2)}`;
+  return (
+    <p className="mt-2">
+      <strong>Balance:</strong> {balanceText}
+      <span className="ml-4">
+        <strong>PnL:</strong>{' '}
+        <span className={pnlClass} title={pnlTooltip}>
+          {pnlText}
+        </span>
+      </span>
+    </p>
+  );
+}

--- a/frontend/src/routes/AgentView.tsx
+++ b/frontend/src/routes/AgentView.tsx
@@ -6,17 +6,14 @@ import { useUser } from '../lib/useUser';
 import { useAgentData } from '../lib/useAgentData';
 import { useAgentActions } from '../lib/useAgentActions';
 import api from '../lib/axios';
-import AgentStatusLabel from '../components/AgentStatusLabel';
-import TokenDisplay from '../components/TokenDisplay';
-import StrategyForm from '../components/StrategyForm';
 import Button from '../components/ui/Button';
 import { useToast } from '../lib/useToast';
 import AgentPreview from './AgentPreview';
-import { Eye, EyeOff, ChevronDown, ChevronRight } from 'lucide-react';
 import ExecLogItem, { type ExecLog } from '../components/ExecLogItem';
 import FormattedDate from '../components/ui/FormattedDate';
-import AgentPnl from '../components/AgentPnl';
 import AgentUpdateModal from '../components/AgentUpdateModal';
+import AgentDetailsDesktop from '../components/AgentDetailsDesktop';
+import AgentDetailsMobile from '../components/AgentDetailsMobile';
 
 export default function AgentView() {
   const { id } = useParams();
@@ -41,8 +38,6 @@ export default function AgentView() {
     },
   });
 
-  const [showStrategy, setShowStrategy] = useState(false);
-  const [showPrompt, setShowPrompt] = useState(false);
   const [showUpdate, setShowUpdate] = useState(false);
 
   const [logPage, setLogPage] = useState(1);
@@ -66,77 +61,14 @@ export default function AgentView() {
   if (data.status === 'draft') return <AgentPreview draft={data} />;
 
   const isActive = data.status === 'active';
-  const strategyData = {
-    tokenA: data.tokenA,
-    tokenB: data.tokenB,
-    minTokenAAllocation: data.minTokenAAllocation,
-    minTokenBAllocation: data.minTokenBAllocation,
-    risk: data.risk,
-    reviewInterval: data.reviewInterval,
-  };
-
   return (
       <div className="p-4">
-        <h1 className="text-2xl font-bold mb-2 flex items-center gap-2">
-          <span>Agent:</span> <span>{data.name}</span>
-        </h1>
-        <p className="mt-2">
-          <strong>Created:</strong> <FormattedDate date={data.createdAt} />
-        </p>
-        <p className="mt-2">
-          <strong>Status:</strong> <AgentStatusLabel status={data.status}/>
-        </p>
-        <p className="flex items-center gap-1 mt-2">
-          <strong>Tokens:</strong>
-          <TokenDisplay token={data.tokenA}/>
-          <span>/</span>
-          <TokenDisplay token={data.tokenB}/>
-        </p>
-        <div className="mt-2">
-          <div
-              className="flex items-center gap-1 cursor-pointer"
-              onClick={() => setShowStrategy((s) => !s)}
-          >
-            <h2 className="text-l font-bold">Strategy</h2>
-            {showStrategy ? (
-                <ChevronDown className="w-4 h-4"/>
-            ) : (
-                <ChevronRight className="w-4 h-4"/>
-            )}
-          </div>
-          {showStrategy && (
-              <div className="mt-2 max-w-2xl">
-                <StrategyForm data={strategyData} onChange={() => {
-                }} disabled/>
-              </div>
-          )}
+        <div className="hidden md:block">
+          <AgentDetailsDesktop agent={data} />
         </div>
-        <div className="mt-2">
-          <div className="flex items-center gap-1">
-            <h2 className="text-l font-bold">Trading Instructions</h2>
-            {showPrompt ? (
-                <EyeOff
-                    className="w-4 h-4 cursor-pointer"
-                    onClick={() => setShowPrompt(false)}
-                />
-            ) : (
-                <Eye
-                    className="w-4 h-4 cursor-pointer"
-                    onClick={() => setShowPrompt(true)}
-                />
-            )}
-          </div>
-          {showPrompt && (
-              <pre className="whitespace-pre-wrap mt-2">
-            {data.agentInstructions}
-          </pre>
-          )}
+        <div className="md:hidden">
+          <AgentDetailsMobile agent={data} />
         </div>
-        <AgentPnl
-          tokenA={data.tokenA}
-          tokenB={data.tokenB}
-          startBalanceUsd={data.startBalanceUsd}
-        />
         {isActive ? (
             <div className="mt-4 flex gap-2">
               <Button onClick={() => setShowUpdate(true)}>


### PR DESCRIPTION
## Summary
- extract desktop and mobile AgentDetails components
- restore USD labels for desktop PnL and add mobile variant without them
- simplify AgentView by rendering dedicated components per breakpoint

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa815b004c832cafecc51cb1ebc26c