### PR TITLE
feat: add binance order helpers

### DIFF
--- a/backend/test/binanceOrders.test.ts
+++ b/backend/test/binanceOrders.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { db } from '../src/db/index.js';
+import { encrypt } from '../src/util/crypto.js';
+import { createHmac } from 'node:crypto';
+import {
+  createLimitOrder,
+  cancelOrder,
+} from '../src/services/binance.js';
+
+describe('binance order helpers', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    db.prepare('DELETE FROM users').run();
+  });
+
+  it('creates a signed limit order', async () => {
+    const key = 'binKey123456';
+    const secret = 'binSecret123456';
+    const encKey = encrypt(key, process.env.KEY_PASSWORD!);
+    const encSecret = encrypt(secret, process.env.KEY_PASSWORD!);
+    db.prepare(
+      'INSERT INTO users (id, binance_api_key_enc, binance_api_secret_enc) VALUES (?, ?, ?)'
+    ).run('user1', encKey, encSecret);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ orderId: 1 }) });
+    vi.stubGlobal('fetch', fetchMock as any);
+
+    await createLimitOrder('user1', {
+      symbol: 'BTCUSDT',
+      side: 'BUY',
+      quantity: 0.1,
+      price: 20000,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.binance.com/api/v3/order');
+    expect(options.method).toBe('POST');
+    expect(options.headers['X-MBX-APIKEY']).toBe(key);
+
+    const params = new URLSearchParams(options.body as string);
+    const query = (options.body as string).split('&signature=')[0];
+    const expectedSig = createHmac('sha256', secret)
+      .update(query)
+      .digest('hex');
+    expect(params.get('signature')).toBe(expectedSig);
+  });
+
+  it('cancels a signed order', async () => {
+    const key = 'binKey654321';
+    const secret = 'binSecret654321';
+    const encKey = encrypt(key, process.env.KEY_PASSWORD!);
+    const encSecret = encrypt(secret, process.env.KEY_PASSWORD!);
+    db.prepare(
+      'INSERT INTO users (id, binance_api_key_enc, binance_api_secret_enc) VALUES (?, ?, ?)'
+    ).run('user2', encKey, encSecret);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ status: 'canceled' }) });
+    vi.stubGlobal('fetch', fetchMock as any);
+
+    await cancelOrder('user2', { symbol: 'BTCUSDT', orderId: 42 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0];
+    const parsedUrl = new URL(url);
+    expect(parsedUrl.origin + parsedUrl.pathname).toBe(
+      'https://api.binance.com/api/v3/order'
+    );
+    expect(options.method).toBe('DELETE');
+    expect(options.headers['X-MBX-APIKEY']).toBe(key);
+
+    const query = parsedUrl.search.slice(1).split('&signature=')[0];
+    const signature = parsedUrl.searchParams.get('signature');
+    const expectedSig = createHmac('sha256', secret)
+      .update(query)
+      .digest('hex');
+    expect(signature).toBe(expectedSig);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add helper to create and cancel signed Binance limit orders
- cover Binance order helpers with unit tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac143b8830832cb0b7f3639497ab2a