### PR TITLE
refactor: replace native dialogs

### DIFF
--- a/frontend/src/components/AgentStartButton.tsx
+++ b/frontend/src/components/AgentStartButton.tsx
@@ -6,6 +6,7 @@ import api from '../lib/axios';
 import { useUser } from '../lib/useUser';
 import { useToast } from '../lib/useToast';
 import Button from './ui/Button';
+import ConfirmDialog from './ui/ConfirmDialog';
 
 interface AgentPreviewDetails {
   name: string;
@@ -42,10 +43,10 @@ export default function AgentStartButton({
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [isCreating, setIsCreating] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
-  async function handleStart() {
+  async function startAgent() {
     if (!user) return;
-    if (!window.confirm('Start agent with current settings?')) return;
     setIsCreating(true);
     try {
       if (draft) {
@@ -81,9 +82,24 @@ export default function AgentStartButton({
   }
 
   return (
-    <Button disabled={disabled || isCreating} loading={isCreating} onClick={handleStart}>
-      Start Agent
-    </Button>
+    <>
+      <Button
+        disabled={disabled || isCreating}
+        loading={isCreating}
+        onClick={() => setConfirmOpen(true)}
+      >
+        Start Agent
+      </Button>
+      <ConfirmDialog
+        open={confirmOpen}
+        message="Start agent with current settings?"
+        onCancel={() => setConfirmOpen(false)}
+        onConfirm={() => {
+          setConfirmOpen(false);
+          startAgent();
+        }}
+      />
+    </>
   );
 }
 

--- a/frontend/src/components/AgentUpdateModal.tsx
+++ b/frontend/src/components/AgentUpdateModal.tsx
@@ -6,6 +6,7 @@ import type { Agent } from '../lib/useAgentData';
 import { useToast } from '../lib/useToast';
 import Button from './ui/Button';
 import Modal from './ui/Modal';
+import ConfirmDialog from './ui/ConfirmDialog';
 import StrategyForm from './StrategyForm';
 import AgentInstructions from './AgentInstructions';
 import { normalizeAllocations } from '../lib/allocations';
@@ -19,6 +20,7 @@ interface Props {
 
 export default function AgentUpdateModal({ agent, open, onClose, onUpdated }: Props) {
   const toast = useToast();
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const [data, setData] = useState({
     tokenA: agent.tokenA,
     tokenB: agent.tokenB,
@@ -67,11 +69,12 @@ export default function AgentUpdateModal({ agent, open, onClose, onUpdated }: Pr
   });
 
   return (
-    <Modal open={open} onClose={onClose}>
-      <h2 className="text-xl font-bold mb-2">Update Agent</h2>
-      <div className="max-w-2xl">
-        <StrategyForm
-          data={data}
+    <>
+      <Modal open={open} onClose={onClose}>
+        <h2 className="text-xl font-bold mb-2">Update Agent</h2>
+        <div className="max-w-2xl">
+          <StrategyForm
+            data={data}
           onChange={(key, value) =>
             setData((d) => {
               const updated = { ...d, [key]: value } as typeof data;
@@ -88,19 +91,27 @@ export default function AgentUpdateModal({ agent, open, onClose, onUpdated }: Pr
         value={data.agentInstructions}
         onChange={(v) => setData((d) => ({ ...d, agentInstructions: v }))}
       />
-      <div className="mt-4 flex justify-end gap-2">
-        <Button onClick={onClose}>Cancel</Button>
-        <Button
-          disabled={updateMut.isPending}
-          loading={updateMut.isPending}
-          onClick={() => {
-            if (window.confirm('Update running agent?')) updateMut.mutate();
-          }}
-        >
-          Confirm
-        </Button>
-      </div>
-    </Modal>
+        <div className="mt-4 flex justify-end gap-2">
+          <Button onClick={onClose}>Cancel</Button>
+          <Button
+            disabled={updateMut.isPending}
+            loading={updateMut.isPending}
+            onClick={() => setConfirmOpen(true)}
+          >
+            Confirm
+          </Button>
+        </div>
+      </Modal>
+      <ConfirmDialog
+        open={confirmOpen}
+        message="Update running agent?"
+        onCancel={() => setConfirmOpen(false)}
+        onConfirm={() => {
+          setConfirmOpen(false);
+          updateMut.mutate();
+        }}
+      />
+    </>
   );
 }
 

--- a/frontend/src/components/GoogleLoginButton.tsx
+++ b/frontend/src/components/GoogleLoginButton.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { LogOut } from 'lucide-react';
 import axios from 'axios';
 import api from '../lib/axios';
 import { useUser } from '../lib/useUser';
+import { useToast } from '../lib/useToast';
 import Button from './ui/Button';
+import PromptDialog from './ui/PromptDialog';
 
 type CredentialResponse = { credential: string };
 
@@ -30,6 +32,27 @@ declare global {
 export default function GoogleLoginButton() {
   const btnRef = useRef<HTMLDivElement>(null);
   const { user, setUser } = useUser();
+  const toast = useToast();
+  const [otpOpen, setOtpOpen] = useState(false);
+  const [pendingCred, setPendingCred] = useState<string | null>(null);
+
+  const handleOtpSubmit = async (otp: string) => {
+    if (!pendingCred) return;
+    try {
+      const res2 = await api.post('/login', { token: pendingCred, otp });
+      setUser(res2.data);
+      if (btnRef.current) btnRef.current.innerHTML = '';
+    } catch (err) {
+      if (axios.isAxiosError(err) && err.response?.data?.error) {
+        toast.show(err.response.data.error);
+      } else {
+        toast.show('Login failed');
+      }
+    } finally {
+      setOtpOpen(false);
+      setPendingCred(null);
+    }
+  };
 
   useEffect(() => {
     const google = window.google;
@@ -47,15 +70,8 @@ export default function GoogleLoginButton() {
             axios.isAxiosError(err) &&
             err.response?.data?.error === 'otp required'
           ) {
-            const otp = window.prompt('Enter 2FA code');
-            if (otp) {
-              const res2 = await api.post('/login', {
-                token: resp.credential,
-                otp,
-              });
-              setUser(res2.data);
-              if (btnRef.current) btnRef.current.innerHTML = '';
-            }
+            setPendingCred(resp.credential);
+            setOtpOpen(true);
           }
         }
       },
@@ -67,26 +83,40 @@ export default function GoogleLoginButton() {
     });
   }, [user, setUser]);
 
-  if (user) {
-    const email = user.email ?? '';
-    return (
-      <div className="h-5 flex items-center text-sm gap-2">
-        <span className="hidden md:inline">{email}</span>
-        <span className="md:hidden">{email.split('@')[0]}</span>
-        <Button
-          type="button"
-          variant="link"
-          className="text-xs flex items-center gap-1"
-          onClick={() => {
-            const google = window.google;
-            google?.accounts.id.disableAutoSelect?.();
-            setUser(null);
-          }}
-        >
-          <LogOut className="w-4 h-4" />
-        </Button>
-      </div>
-    );
-  }
-  return <div ref={btnRef} className="h-5 capitalize" />;
+  const handleOtpCancel = () => {
+    setOtpOpen(false);
+    setPendingCred(null);
+  };
+
+  const email = user?.email ?? '';
+  return (
+    <>
+      {user ? (
+        <div className="h-5 flex items-center text-sm gap-2">
+          <span className="hidden md:inline">{email}</span>
+          <span className="md:hidden">{email.split('@')[0]}</span>
+          <Button
+            type="button"
+            variant="link"
+            className="text-xs flex items-center gap-1"
+            onClick={() => {
+              const google = window.google;
+              google?.accounts.id.disableAutoSelect?.();
+              setUser(null);
+            }}
+          >
+            <LogOut className="w-4 h-4" />
+          </Button>
+        </div>
+      ) : (
+        <div ref={btnRef} className="h-5 capitalize" />
+      )}
+      <PromptDialog
+        open={otpOpen}
+        message="Enter 2FA code"
+        onSubmit={handleOtpSubmit}
+        onCancel={handleOtpCancel}
+      />
+    </>
+  );
 }

--- a/frontend/src/components/forms/ApiKeySection.tsx
+++ b/frontend/src/components/forms/ApiKeySection.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation } from '@tanstack/react-query';
 import axios from 'axios';
 import api from '../../lib/axios';
 import { useUser } from '../../lib/useUser';
+import { useToast } from '../../lib/useToast';
 import Button from '../ui/Button';
 
 interface Field {
@@ -36,6 +37,7 @@ export default function ApiKeySection({
   getBalancePath,
 }: ApiKeySectionProps) {
   const { user } = useUser();
+  const toast = useToast();
   const defaultValues = useMemo(
     () =>
       Object.fromEntries(fields.map((f) => [f.name, ''])) as Record<string, string>,
@@ -84,7 +86,7 @@ export default function ApiKeySection({
         axios.isAxiosError(err) &&
         err.response?.data?.error === 'verification failed'
       ) {
-        alert('Key verification failed');
+        toast.show('Key verification failed');
       }
     },
   });

--- a/frontend/src/components/ui/ConfirmDialog.tsx
+++ b/frontend/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,21 @@
+import Button from './Button';
+import Modal from './Modal';
+
+interface Props {
+  open: boolean;
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function ConfirmDialog({ open, message, onConfirm, onCancel }: Props) {
+  return (
+    <Modal open={open} onClose={onCancel}>
+      <p className="mb-4">{message}</p>
+      <div className="flex justify-end gap-2">
+        <Button onClick={onCancel}>Cancel</Button>
+        <Button onClick={onConfirm}>Confirm</Button>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/ui/PromptDialog.tsx
+++ b/frontend/src/components/ui/PromptDialog.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import Button from './Button';
+import Modal from './Modal';
+
+interface Props {
+  open: boolean;
+  message: string;
+  onSubmit: (value: string) => void;
+  onCancel: () => void;
+}
+
+export default function PromptDialog({ open, message, onSubmit, onCancel }: Props) {
+  const [value, setValue] = useState('');
+  useEffect(() => {
+    if (open) setValue('');
+  }, [open]);
+  return (
+    <Modal open={open} onClose={onCancel}>
+      <p className="mb-2">{message}</p>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        className="border p-2 w-full mb-4"
+      />
+      <div className="flex justify-end gap-2">
+        <Button onClick={onCancel}>Cancel</Button>
+        <Button onClick={() => onSubmit(value)}>Submit</Button>
+      </div>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable confirm and prompt dialogs
- switch agent actions and OTP flow from browser dialogs to custom modals

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac1c19fea8832c92d7be33b64363f7