### PR TITLE
Refactor tests to centralize SQL in repository helpers

### DIFF
--- a/backend/src/services/binance.ts
+++ b/backend/src/services/binance.ts
@@ -1,18 +1,12 @@
-import { db } from '../db/index.js';
 import { env } from '../util/env.js';
 import { decrypt } from '../util/crypto.js';
 import { createHmac } from 'node:crypto';
+import { getBinanceKeyRow } from '../repos/api-keys.js';
 
 type UserCreds = { key: string; secret: string };
 
 function getUserCreds(id: string): UserCreds | null {
-  const row = db
-    .prepare(
-      'SELECT binance_api_key_enc, binance_api_secret_enc FROM users WHERE id = ?'
-    )
-    .get(id) as
-    | { binance_api_key_enc?: string; binance_api_secret_enc?: string }
-    | undefined;
+  const row = getBinanceKeyRow(id);
   if (!row?.binance_api_key_enc || !row.binance_api_secret_enc) return null;
   const key = decrypt(row.binance_api_key_enc, env.KEY_PASSWORD);
   const secret = decrypt(row.binance_api_secret_enc, env.KEY_PASSWORD);

--- a/backend/test/agentCreateAsync.test.ts
+++ b/backend/test/agentCreateAsync.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { db } from '../src/db/index.js';
+import { insertUser } from './repos/users.js';
+import { setAiKey, setBinanceKey } from '../src/repos/api-keys.js';
 
 const reviewAgentPortfolioMock = vi.fn<
   (log: unknown, agentId: string) => Promise<unknown>
@@ -15,9 +16,9 @@ function addUser(id: string) {
   const ai = encrypt('aikey', process.env.KEY_PASSWORD!);
   const bk = encrypt('bkey', process.env.KEY_PASSWORD!);
   const bs = encrypt('skey', process.env.KEY_PASSWORD!);
-  db.prepare(
-    'INSERT INTO users (id, ai_api_key_enc, binance_api_key_enc, binance_api_secret_enc) VALUES (?, ?, ?, ?)'
-  ).run(id, ai, bk, bs);
+  insertUser(id, null);
+  setAiKey(id, ai);
+  setBinanceKey(id, bk, bs);
 }
 
 describe('agent creation', () => {

--- a/backend/test/agentExecLog.test.ts
+++ b/backend/test/agentExecLog.test.ts
@@ -1,31 +1,45 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { db } from '../src/db/index.js';
 import buildServer from '../src/server.js';
 import { parseExecLog } from '../src/util/parse-exec-log.js';
 import { insertExecResult } from '../src/repos/agent-exec-result.js';
-
-function addUser(id: string) {
-  db.prepare('INSERT INTO users (id) VALUES (?)').run(id);
-}
+import { insertUser } from './repos/users.js';
+import { insertAgent } from './repos/agents.js';
+import { insertExecLog } from './repos/agent-exec-log.js';
 
 describe('agent exec log routes', () => {
   it('returns paginated logs and enforces ownership', async () => {
     const app = await buildServer();
-    addUser('u1');
-    addUser('u2');
+    insertUser('u1');
+    insertUser('u2');
 
     const agentId = 'a1';
-    db.prepare(
-        `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
-         VALUES (?, ?, 'gpt', 'active', 0, 'A', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`
-    ).run(agentId, 'u1');
+    insertAgent({
+      id: agentId,
+      userId: 'u1',
+      model: 'gpt',
+      status: 'active',
+      createdAt: 0,
+      startBalance: null,
+      name: 'A',
+      tokenA: 'BTC',
+      tokenB: 'ETH',
+      minTokenAAllocation: 10,
+      minTokenBAllocation: 20,
+      risk: 'low',
+      reviewInterval: '1h',
+      agentInstructions: 'inst',
+      manualRebalance: false,
+    });
 
     for (let i = 0; i < 3; i++) {
-      db.prepare(
-        'INSERT INTO agent_exec_log (id, agent_id, response, created_at) VALUES (?, ?, ?, ?)',
-      ).run(`log${i}`, agentId, JSON.stringify(`log-${i}`), i);
+      insertExecLog({
+        id: `log${i}`,
+        agentId,
+        response: `log-${i}`,
+        createdAt: i,
+      });
       const parsed = parseExecLog(`log-${i}`);
       insertExecResult({
         id: `log${i}`,
@@ -64,22 +78,33 @@ describe('agent exec log routes', () => {
 
   it('parses OpenAI response content JSON into {response}', async () => {
     const app = await buildServer();
-    addUser('u3');
+    insertUser('u3');
 
     const agentId = 'a2';
-    db.prepare(
-        `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
-         VALUES (?, ?, 'gpt', 'active', 0, 'A', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`
-    ).run(agentId, 'u3');
+    insertAgent({
+      id: agentId,
+      userId: 'u3',
+      model: 'gpt',
+      status: 'active',
+      createdAt: 0,
+      startBalance: null,
+      name: 'A',
+      tokenA: 'BTC',
+      tokenB: 'ETH',
+      minTokenAAllocation: 10,
+      minTokenBAllocation: 20,
+      risk: 'low',
+      reviewInterval: '1h',
+      agentInstructions: 'inst',
+      manualRebalance: false,
+    });
 
     const aiLog = readFileSync(
-        join(__dirname, 'fixtures/real-openai-log.json'),
-        'utf8',
+      join(__dirname, 'fixtures/real-openai-log.json'),
+      'utf8',
     );
 
-    db.prepare(
-      'INSERT INTO agent_exec_log (id, agent_id, response, created_at) VALUES (?, ?, ?, ?)',
-    ).run('log-new', agentId, aiLog, 0);
+    insertExecLog({ id: 'log-new', agentId, response: aiLog, createdAt: 0 });
     const parsedAi = parseExecLog(aiLog);
     insertExecResult({
       id: 'log-new',
@@ -105,12 +130,10 @@ describe('agent exec log routes', () => {
     expect(res.statusCode).toBe(200);
     const body = res.json();
 
-    // The parser should put the assistant message's JSON string into `log`
     expect(typeof body.items[0].log).toBe('string');
     expect(body.items[0].log).toContain('"result"');
     expect(body.items[0].log).toContain('"rebalance"');
 
-    // And it should normalize `response`
     expect(body.items[0].response).toMatchObject({
       rebalance: true,
       newAllocation: 70, // matches the provided fixture
@@ -123,16 +146,27 @@ describe('agent exec log routes', () => {
 
   it('handles exec log entries with prompt wrapper', async () => {
     const app = await buildServer();
-    addUser('u5');
+    insertUser('u5');
     const agentId = 'a5';
-    db.prepare(
-        `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
-         VALUES (?, ?, 'gpt', 'active', 0, 'A', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`
-    ).run(agentId, 'u5');
+    insertAgent({
+      id: agentId,
+      userId: 'u5',
+      model: 'gpt',
+      status: 'active',
+      createdAt: 0,
+      startBalance: null,
+      name: 'A',
+      tokenA: 'BTC',
+      tokenB: 'ETH',
+      minTokenAAllocation: 10,
+      minTokenBAllocation: 20,
+      risk: 'low',
+      reviewInterval: '1h',
+      agentInstructions: 'inst',
+      manualRebalance: false,
+    });
     const entry = JSON.stringify({ prompt: { instructions: 'inst' }, response: 'ok' });
-    db.prepare(
-      'INSERT INTO agent_exec_log (id, agent_id, response, created_at) VALUES (?, ?, ?, ?)',
-    ).run('logp', agentId, entry, 0);
+    insertExecLog({ id: 'logp', agentId, response: entry, createdAt: 0 });
     const parsedP = parseExecLog(entry);
     insertExecResult({
       id: 'logp',

--- a/backend/test/agentStartAsync.test.ts
+++ b/backend/test/agentStartAsync.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { db } from '../src/db/index.js';
+import { insertUser } from './repos/users.js';
+import { setAiKey, setBinanceKey } from '../src/repos/api-keys.js';
 
 const reviewAgentPortfolioMock = vi.fn<
   (log: unknown, agentId: string) => Promise<unknown>
@@ -15,9 +16,9 @@ function addUser(id: string) {
   const ai = encrypt('aikey', process.env.KEY_PASSWORD!);
   const bk = encrypt('bkey', process.env.KEY_PASSWORD!);
   const bs = encrypt('skey', process.env.KEY_PASSWORD!);
-  db.prepare(
-    'INSERT INTO users (id, ai_api_key_enc, binance_api_key_enc, binance_api_secret_enc) VALUES (?, ?, ?, ?)'
-  ).run(id, ai, bk, bs);
+  insertUser(id, null);
+  setAiKey(id, ai);
+  setBinanceKey(id, bk, bs);
 }
 
 describe('agent start', () => {

--- a/backend/test/binanceBalance.test.ts
+++ b/backend/test/binanceBalance.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
-import { db } from '../src/db/index.js';
 import buildServer from '../src/server.js';
 import { encrypt } from '../src/util/crypto.js';
+import { insertUser } from './repos/users.js';
+import { setBinanceKey } from '../src/repos/api-keys.js';
 
 describe('binance balance route', () => {
   it('returns aggregated balance for user', async () => {
@@ -10,9 +11,8 @@ describe('binance balance route', () => {
     const secret = 'binSecret123456';
     const encKey = encrypt(key, process.env.KEY_PASSWORD!);
     const encSecret = encrypt(secret, process.env.KEY_PASSWORD!);
-    db.prepare(
-      'INSERT INTO users (id, binance_api_key_enc, binance_api_secret_enc) VALUES (?, ?, ?)'
-    ).run('user1', encKey, encSecret);
+    insertUser('user1');
+    setBinanceKey('user1', encKey, encSecret);
 
     const fetchMock = vi.fn();
     const originalFetch = globalThis.fetch;
@@ -49,9 +49,8 @@ describe('binance balance route', () => {
     const secret = 'binSecret123456';
     const encKey = encrypt(key, process.env.KEY_PASSWORD!);
     const encSecret = encrypt(secret, process.env.KEY_PASSWORD!);
-    db.prepare(
-      'INSERT INTO users (id, binance_api_key_enc, binance_api_secret_enc) VALUES (?, ?, ?)'
-    ).run('user2', encKey, encSecret);
+    insertUser('user2');
+    setBinanceKey('user2', encKey, encSecret);
 
     const fetchMock = vi.fn();
     const originalFetch = globalThis.fetch;

--- a/backend/test/binanceOrders.test.ts
+++ b/backend/test/binanceOrders.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { db } from '../src/db/index.js';
 import { encrypt } from '../src/util/crypto.js';
+import { insertUser, clearUsers } from './repos/users.js';
+import { setBinanceKey } from '../src/repos/api-keys.js';
 import { createHmac } from 'node:crypto';
 import {
   createLimitOrder,
@@ -10,7 +11,7 @@ import {
 describe('binance order helpers', () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    db.prepare('DELETE FROM users').run();
+    clearUsers();
   });
 
   it('creates a signed limit order', async () => {
@@ -18,9 +19,8 @@ describe('binance order helpers', () => {
     const secret = 'binSecret123456';
     const encKey = encrypt(key, process.env.KEY_PASSWORD!);
     const encSecret = encrypt(secret, process.env.KEY_PASSWORD!);
-    db.prepare(
-      'INSERT INTO users (id, binance_api_key_enc, binance_api_secret_enc) VALUES (?, ?, ?)'
-    ).run('user1', encKey, encSecret);
+    insertUser('user1');
+    setBinanceKey('user1', encKey, encSecret);
 
     const fetchMock = vi
       .fn()
@@ -53,9 +53,8 @@ describe('binance order helpers', () => {
     const secret = 'binSecret654321';
     const encKey = encrypt(key, process.env.KEY_PASSWORD!);
     const encSecret = encrypt(secret, process.env.KEY_PASSWORD!);
-    db.prepare(
-      'INSERT INTO users (id, binance_api_key_enc, binance_api_secret_enc) VALUES (?, ?, ?)'
-    ).run('user2', encKey, encSecret);
+    insertUser('user2');
+    setBinanceKey('user2', encKey, encSecret);
 
     const fetchMock = vi
       .fn()

--- a/backend/test/models.test.ts
+++ b/backend/test/models.test.ts
@@ -1,17 +1,16 @@
 import { describe, it, expect, vi } from 'vitest';
-import { db } from '../src/db/index.js';
 import buildServer from '../src/server.js';
 import { encrypt } from '../src/util/crypto.js';
+import { insertUser } from './repos/users.js';
+import { setAiKey } from '../src/repos/api-keys.js';
 
 describe('model routes', () => {
   it('returns filtered models', async () => {
     const app = await buildServer();
     const key = 'aikey1234567890';
     const enc = encrypt(key, process.env.KEY_PASSWORD!);
-    db.prepare('INSERT INTO users (id, ai_api_key_enc) VALUES (?, ?)').run(
-      'user1',
-      enc,
-    );
+    insertUser('user1', null);
+    setAiKey('user1', enc);
 
     const fetchMock = vi.fn();
     const originalFetch = globalThis.fetch;
@@ -42,7 +41,7 @@ describe('model routes', () => {
 
   it('requires a key', async () => {
     const app = await buildServer();
-    db.prepare('INSERT INTO users (id) VALUES (?)').run('user2');
+    insertUser('user2');
     const res = await app.inject({
       method: 'GET',
       url: '/api/users/user2/models',
@@ -56,10 +55,8 @@ describe('model routes', () => {
     const app = await buildServer();
     const key = 'aikey9999999999';
     const enc = encrypt(key, process.env.KEY_PASSWORD!);
-    db.prepare('INSERT INTO users (id, ai_api_key_enc) VALUES (?, ?)').run(
-      'user3',
-      enc,
-    );
+    insertUser('user3', null);
+    setAiKey('user3', enc);
 
     const fetchMock = vi.fn();
     const originalFetch = globalThis.fetch;

--- a/backend/test/rebalance.test.ts
+++ b/backend/test/rebalance.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { FastifyBaseLogger } from 'fastify';
-import { db } from '../src/db/index.js';
+import { clearExecutions, getExecutions } from './repos/executions.js';
 
 vi.mock('../src/services/binance.js', () => ({
   fetchPairData: vi.fn().mockResolvedValue({ currentPrice: 100 }),
@@ -13,7 +13,7 @@ import { createLimitOrder } from '../src/services/binance.js';
 describe('createRebalanceLimitOrder', () => {
   it('saves execution with status and exec result', async () => {
     const log = { info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
-    db.prepare('DELETE FROM executions').run();
+    clearExecutions();
     await createRebalanceLimitOrder({
       userId: 'user1',
       tokenA: 'BTC',
@@ -27,9 +27,7 @@ describe('createRebalanceLimitOrder', () => {
       execResultId: 'res1',
     });
 
-    const row = db
-      .prepare('SELECT user_id, planned_json, status, exec_result_id FROM executions')
-      .get() as any;
+    const row = getExecutions()[0];
 
     expect(row.user_id).toBe('user1');
     expect(JSON.parse(row.planned_json)).toMatchObject({

--- a/backend/test/repos/agent-exec-log.ts
+++ b/backend/test/repos/agent-exec-log.ts
@@ -1,0 +1,20 @@
+import { db } from '../../src/db/index.js';
+import { insertExecLog as insertExecLogProd } from '../../src/repos/agent-exec-log.js';
+
+export const insertExecLog = insertExecLogProd;
+
+export function clearAgentExecLog() {
+  db.prepare('DELETE FROM agent_exec_log').run();
+}
+
+export function getAgentExecResponses(agentId: string) {
+  return db
+    .prepare('SELECT response FROM agent_exec_log WHERE agent_id = ?')
+    .all(agentId) as { response: string | null }[];
+}
+
+export function getAgentExecPromptsResponses(agentId: string) {
+  return db
+    .prepare('SELECT prompt, response FROM agent_exec_log WHERE agent_id = ?')
+    .all(agentId) as { prompt: string | null; response: string | null }[];
+}

--- a/backend/test/repos/agent-exec-result.ts
+++ b/backend/test/repos/agent-exec-result.ts
@@ -1,0 +1,8 @@
+import { db } from '../../src/db/index.js';
+import { insertExecResult as insertExecResultProd } from '../../src/repos/agent-exec-result.js';
+
+export const insertExecResult = insertExecResultProd;
+
+export function clearAgentExecResult() {
+  db.prepare('DELETE FROM agent_exec_result').run();
+}

--- a/backend/test/repos/agents.ts
+++ b/backend/test/repos/agents.ts
@@ -1,0 +1,18 @@
+import { db } from '../../src/db/index.js';
+import {
+  insertAgent as insertAgentProd,
+  startAgent,
+  stopAgent,
+  deleteAgent,
+} from '../../src/repos/agents.js';
+
+export const insertAgent = insertAgentProd;
+export { startAgent, stopAgent, deleteAgent };
+
+export function clearAgents() {
+  db.prepare('DELETE FROM agents').run();
+}
+
+export function setAgentStatus(id: string, status: string) {
+  db.prepare('UPDATE agents SET status = ? WHERE id = ?').run(status, id);
+}

--- a/backend/test/repos/executions.ts
+++ b/backend/test/repos/executions.ts
@@ -1,0 +1,11 @@
+import { db } from '../../src/db/index.js';
+
+export function clearExecutions() {
+  db.prepare('DELETE FROM executions').run();
+}
+
+export function getExecutions() {
+  return db
+    .prepare('SELECT user_id, planned_json, status, exec_result_id FROM executions')
+    .all() as { user_id: string; planned_json: string; status: string; exec_result_id: string }[];
+}

--- a/backend/test/repos/users.ts
+++ b/backend/test/repos/users.ts
@@ -1,0 +1,27 @@
+import { db } from '../../src/db/index.js';
+import {
+  insertUser as insertUserProd,
+  setUserEmail,
+  setUserEnabled,
+} from '../../src/repos/users.js';
+
+export function insertUser(id: string, emailEnc?: string | null) {
+  insertUserProd(id, emailEnc ?? null);
+}
+export { setUserEmail, setUserEnabled };
+
+export function insertAdminUser(id: string, emailEnc?: string | null) {
+  db.prepare(
+    "INSERT INTO users (id, is_auto_enabled, role, is_enabled, email_enc) VALUES (?, 0, 'admin', 1, ?)"
+  ).run(id, emailEnc ?? null);
+}
+
+export function clearUsers() {
+  db.prepare('DELETE FROM users').run();
+}
+
+export function getUserEmailEnc(id: string) {
+  return db
+    .prepare('SELECT email_enc FROM users WHERE id = ?')
+    .get(id) as { email_enc?: string } | undefined;
+}

--- a/backend/test/twofa.test.ts
+++ b/backend/test/twofa.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { db } from '../src/db/index.js';
 import buildServer from '../src/server.js';
 import { authenticator } from 'otplib';
+import { insertUser } from './repos/users.js';
 
 describe('2fa routes', () => {
   it('enables and disables 2fa', async () => {
-    db.prepare('INSERT INTO users (id, is_auto_enabled) VALUES (?,0)').run('user1');
+    insertUser('user1');
     const app = await buildServer();
 
     const setupRes = await app.inject({


### PR DESCRIPTION
## Summary
- centralize user credential lookup in `api-keys` repo for binance service
- add test repository utilities for users, agents, execution logs, and executions
- update backend tests to use repository helpers instead of inline SQL

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad7a09d1b4832c9bc037751ce9c5f0