### PR TITLE
refactor: treat ids as strings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,12 @@ Tables:
 Environment variables: `DATABASE_URL`, `KEY_PASSWORD`, `GOOGLE_CLIENT_ID`.
 
 ### Testing
-- `npm test`
+- Backend tests require a running PostgreSQL instance.
+  - Check if `psql` exists or `pg_isready` succeeds before installing to avoid
+    clobbering an existing server.
+  - Ensure a database named `promptswap_test` is available on
+    `postgres://postgres:postgres@localhost:5432`.
+  - Run tests with `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`.
 - `npm run build`
 
 ### Guidelines

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -11,6 +11,13 @@ CREATE TABLE IF NOT EXISTS users(
   created_at TIMESTAMP NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC')
 );
 
+CREATE TABLE IF NOT EXISTS user_identities(
+  user_id BIGINT NOT NULL REFERENCES users(id),
+  provider TEXT NOT NULL,
+  sub TEXT NOT NULL,
+  UNIQUE(provider, sub)
+);
+
 CREATE TABLE IF NOT EXISTS agents(
   id BIGSERIAL PRIMARY KEY,
   user_id BIGINT NOT NULL REFERENCES users(id),

--- a/backend/src/jobs/review-portfolio.ts
+++ b/backend/src/jobs/review-portfolio.ts
@@ -30,7 +30,7 @@ type MarketTimeseries = Awaited<ReturnType<typeof fetchMarketTimeseries>>;
 /**
  * Agents currently under review. Used to avoid concurrent runs.
  */
-const runningAgents = new Set<number>();
+const runningAgents = new Set<string>();
 
 type PromptCache = {
   pairData: Map<string, { currentPrice: number }>;
@@ -40,7 +40,7 @@ type PromptCache = {
 
 export async function reviewAgentPortfolio(
   log: FastifyBaseLogger,
-  agentId: number,
+  agentId: string,
 ): Promise<void> {
   const agents = await getActiveAgents({ agentId });
   const { toRun, skipped } = filterRunningAgents(agents);

--- a/backend/src/repos/agent-exec-log.ts
+++ b/backend/src/repos/agent-exec-log.ts
@@ -1,12 +1,12 @@
 import { db } from '../db/index.js';
 
 export interface ExecLogInsert {
-  agentId: number;
+  agentId: string;
   prompt?: unknown;
   response: unknown;
 }
 
-export async function insertExecLog(entry: ExecLogInsert): Promise<number> {
+export async function insertExecLog(entry: ExecLogInsert): Promise<string> {
   const { rows } = await db.query(
     'INSERT INTO agent_exec_log (agent_id, prompt, response) VALUES ($1, $2, $3) RETURNING id',
     [
@@ -15,5 +15,5 @@ export async function insertExecLog(entry: ExecLogInsert): Promise<number> {
       JSON.stringify(entry.response),
     ],
   );
-  return Number(rows[0].id);
+  return rows[0].id as string;
 }

--- a/backend/src/repos/agent-exec-result.ts
+++ b/backend/src/repos/agent-exec-result.ts
@@ -1,7 +1,7 @@
 import { db } from '../db/index.js';
 
 export interface ExecResultInsert {
-  agentId: number;
+  agentId: string;
   log: string;
   rebalance?: boolean;
   newAllocation?: number;
@@ -9,7 +9,7 @@ export interface ExecResultInsert {
   error?: Record<string, unknown>;
 }
 
-export async function insertExecResult(entry: ExecResultInsert): Promise<number> {
+export async function insertExecResult(entry: ExecResultInsert): Promise<string> {
   const { rows } = await db.query(
     'INSERT INTO agent_exec_result (agent_id, log, rebalance, new_allocation, short_report, error) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id',
     [
@@ -21,10 +21,10 @@ export async function insertExecResult(entry: ExecResultInsert): Promise<number>
       entry.error ? JSON.stringify(entry.error) : null,
     ],
   );
-  return Number(rows[0].id);
+  return rows[0].id as string;
 }
 
-export async function getRecentExecResults(agentId: number, limit: number) {
+export async function getRecentExecResults(agentId: string, limit: number) {
   const { rows } = await db.query(
     'SELECT rebalance, new_allocation, short_report, error FROM agent_exec_result WHERE agent_id = $1 ORDER BY created_at DESC LIMIT $2',
     [agentId, limit],
@@ -42,7 +42,7 @@ export async function getRecentExecResults(agentId: number, limit: number) {
   }));
 }
 
-export async function getAgentExecResults(agentId: number, limit: number, offset: number) {
+export async function getAgentExecResults(agentId: string, limit: number, offset: number) {
   const totalRes = await db.query(
     'SELECT COUNT(*) as count FROM agent_exec_result WHERE agent_id = $1',
     [agentId],

--- a/backend/src/repos/agents.ts
+++ b/backend/src/repos/agents.ts
@@ -2,8 +2,8 @@ import { db } from '../db/index.js';
 import { AgentStatus } from '../util/agents.js';
 
 export interface AgentRow {
-  id: number;
-  user_id: number;
+  id: string;
+  user_id: string;
   model: string;
   status: string;
   created_at: string;
@@ -44,13 +44,13 @@ const baseSelect =
   'min_a_allocation, min_b_allocation, risk, review_interval, ' +
   'agent_instructions, manual_rebalance FROM agents';
 
-export async function getAgent(id: number): Promise<AgentRow | undefined> {
+export async function getAgent(id: string): Promise<AgentRow | undefined> {
   const { rows } = await db.query(`${baseSelect} WHERE id = $1`, [id]);
   return rows[0] as AgentRow | undefined;
 }
 
 export async function getAgentsPaginated(
-  userId: number,
+  userId: string,
   status: string | undefined,
   limit: number,
   offset: number,
@@ -69,7 +69,7 @@ export async function getAgentsPaginated(
 
 export async function findIdenticalDraftAgent(
   data: {
-    userId: number;
+    userId: string;
     model: string;
     name: string;
     tokenA: string;
@@ -81,7 +81,7 @@ export async function findIdenticalDraftAgent(
     agentInstructions: string;
     manualRebalance: boolean;
   },
-  excludeId?: number,
+  excludeId?: string,
 ) {
   const query = `SELECT id, name FROM agents
      WHERE user_id = $1 AND status = 'draft' AND ($2::bigint IS NULL OR id != $2) AND model = $3 AND name = $4
@@ -103,14 +103,14 @@ export async function findIdenticalDraftAgent(
     data.manualRebalance,
   ];
   const { rows } = await db.query(query, params as any[]);
-  return rows[0] as { id: number; name: string } | undefined;
+  return rows[0] as { id: string; name: string } | undefined;
 }
 
 export async function findActiveTokenConflicts(
-  userId: number,
+  userId: string,
   tokenA: string,
   tokenB: string,
-  excludeId?: number,
+  excludeId?: string,
 ) {
   const query = `SELECT id, name, token_a, token_b FROM agents
        WHERE user_id = $1 AND status = 'active' AND ($2::bigint IS NULL OR id != $2)
@@ -118,14 +118,14 @@ export async function findActiveTokenConflicts(
   const params: unknown[] = [userId, excludeId ?? null, tokenA, tokenB];
   const { rows } = await db.query(query, params as any[]);
   return rows as {
-    id: number;
+    id: string;
     name: string;
     token_a: string;
     token_b: string;
   }[];
 }
 
-export async function getUserApiKeys(userId: number) {
+export async function getUserApiKeys(userId: string) {
   const { rows } = await db.query(
     'SELECT ai_api_key_enc, binance_api_key_enc, binance_api_secret_enc FROM users WHERE id = $1',
     [userId],
@@ -140,7 +140,7 @@ export async function getUserApiKeys(userId: number) {
 }
 
 export async function insertAgent(data: {
-  userId: number;
+  userId: string;
   model: string;
   status: string;
   startBalance: number | null;
@@ -178,7 +178,7 @@ export async function insertAgent(data: {
 
 
 export async function updateAgent(data: {
-  id: number;
+  id: string;
   model: string;
   status: string;
   name: string;
@@ -212,11 +212,11 @@ export async function updateAgent(data: {
   );
 }
 
-export async function deleteAgent(id: number): Promise<void> {
+export async function deleteAgent(id: string): Promise<void> {
   await db.query('DELETE FROM agents WHERE id = $1', [id]);
 }
 
-export async function startAgent(id: number, startBalance: number): Promise<void> {
+export async function startAgent(id: string, startBalance: number): Promise<void> {
   await db.query('UPDATE agents SET status = $1, start_balance = $2 WHERE id = $3', [
     AgentStatus.Active,
     startBalance,
@@ -224,7 +224,7 @@ export async function startAgent(id: number, startBalance: number): Promise<void
   ]);
 }
 
-export async function stopAgent(id: number): Promise<void> {
+export async function stopAgent(id: string): Promise<void> {
   await db.query('UPDATE agents SET status = $1, start_balance = NULL WHERE id = $2', [
     AgentStatus.Inactive,
     id,
@@ -232,8 +232,8 @@ export async function stopAgent(id: number): Promise<void> {
 }
 
 export interface ActiveAgentRow {
-  id: number;
-  user_id: number;
+  id: string;
+  user_id: string;
   model: string;
   token_a: string;
   token_b: string;
@@ -247,7 +247,7 @@ export interface ActiveAgentRow {
 }
 
 export async function getActiveAgents(options?: {
-  agentId?: number;
+  agentId?: string;
   interval?: string;
 }): Promise<ActiveAgentRow[]> {
   const sql = `SELECT a.id, a.user_id, a.model,

--- a/backend/src/repos/api-keys.ts
+++ b/backend/src/repos/api-keys.ts
@@ -1,19 +1,19 @@
 import { db } from '../db/index.js';
 
-export async function getAiKeyRow(id: number) {
+export async function getAiKeyRow(id: string) {
   const { rows } = await db.query('SELECT ai_api_key_enc FROM users WHERE id = $1', [id]);
   return rows[0] as { ai_api_key_enc?: string } | undefined;
 }
 
-export async function setAiKey(id: number, enc: string) {
+export async function setAiKey(id: string, enc: string) {
   await db.query('UPDATE users SET ai_api_key_enc = $1 WHERE id = $2', [enc, id]);
 }
 
-export async function clearAiKey(id: number) {
+export async function clearAiKey(id: string) {
   await db.query('UPDATE users SET ai_api_key_enc = NULL WHERE id = $1', [id]);
 }
 
-export async function getBinanceKeyRow(id: number) {
+export async function getBinanceKeyRow(id: string) {
   const { rows } = await db.query(
     'SELECT binance_api_key_enc, binance_api_secret_enc FROM users WHERE id = $1',
     [id],
@@ -24,7 +24,7 @@ export async function getBinanceKeyRow(id: number) {
 }
 
 export async function setBinanceKey(
-  id: number,
+  id: string,
   keyEnc: string,
   secretEnc: string,
 ): Promise<void> {
@@ -34,7 +34,7 @@ export async function setBinanceKey(
   );
 }
 
-export async function clearBinanceKey(id: number): Promise<void> {
+export async function clearBinanceKey(id: string): Promise<void> {
   await db.query(
     'UPDATE users SET binance_api_key_enc = NULL, binance_api_secret_enc = NULL WHERE id = $1',
     [id],

--- a/backend/src/repos/executions.ts
+++ b/backend/src/repos/executions.ts
@@ -1,10 +1,10 @@
 import { db } from '../db/index.js';
 
 export interface ExecutionEntry {
-  userId: number;
+  userId: string;
   planned: Record<string, unknown>;
   status: string;
-  execResultId: number;
+  execResultId: string;
 }
 
 export async function insertExecution(entry: ExecutionEntry): Promise<void> {

--- a/backend/src/repos/user-identities.ts
+++ b/backend/src/repos/user-identities.ts
@@ -1,0 +1,46 @@
+import { db } from '../db/index.js';
+import { decrypt } from '../util/crypto.js';
+import { env } from '../util/env.js';
+
+export interface UserIdentityRow {
+  id: string;
+  role: string;
+  is_enabled: boolean;
+  totp_secret?: string;
+  is_totp_enabled?: boolean;
+}
+
+export async function findUserByIdentity(provider: string, sub: string) {
+  const { rows } = await db.query(
+    'SELECT u.id, u.role, u.is_enabled, u.totp_secret_enc, u.is_totp_enabled FROM user_identities ui JOIN users u ON ui.user_id = u.id WHERE ui.provider = $1 AND ui.sub = $2',
+    [provider, sub],
+  );
+  const row = rows[0] as {
+    id: string;
+    role: string;
+    is_enabled: boolean;
+    totp_secret_enc?: string;
+    is_totp_enabled?: boolean;
+  } | undefined;
+  if (!row) return undefined;
+  return {
+    id: row.id,
+    role: row.role,
+    is_enabled: row.is_enabled,
+    totp_secret: row.totp_secret_enc
+      ? decrypt(row.totp_secret_enc, env.KEY_PASSWORD)
+      : undefined,
+    is_totp_enabled: row.is_totp_enabled,
+  } as UserIdentityRow;
+}
+
+export async function insertUserIdentity(
+  userId: string,
+  provider: string,
+  sub: string,
+): Promise<void> {
+  await db.query(
+    'INSERT INTO user_identities (user_id, provider, sub) VALUES ($1, $2, $3)',
+    [userId, provider, sub],
+  );
+}

--- a/backend/src/repos/users.ts
+++ b/backend/src/repos/users.ts
@@ -9,7 +9,7 @@ export interface UserRow {
   is_enabled: boolean;
 }
 
-export async function getUser(id: number) {
+export async function getUser(id: string) {
   const { rows } = await db.query(
     'SELECT totp_secret_enc, is_totp_enabled, role, is_enabled FROM users WHERE id = $1',
     [id],
@@ -31,15 +31,15 @@ export async function getUser(id: number) {
   };
 }
 
-export async function insertUser(emailEnc: string | null): Promise<number> {
+export async function insertUser(emailEnc: string | null): Promise<string> {
   const { rows } = await db.query(
     "INSERT INTO users (role, is_enabled, email_enc) VALUES ('user', true, $1) RETURNING id",
     [emailEnc],
   );
-  return Number(rows[0].id);
+  return rows[0].id as string;
 }
 
-export async function setUserEmail(id: number, emailEnc: string): Promise<void> {
+export async function setUserEmail(id: string, emailEnc: string): Promise<void> {
   await db.query('UPDATE users SET email_enc = $1 WHERE id = $2', [emailEnc, id]);
 }
 
@@ -48,7 +48,7 @@ export async function listUsers() {
     'SELECT id, role, is_enabled, email_enc, created_at FROM users',
   );
   return rows as {
-    id: number;
+    id: string;
     role: string;
     is_enabled: boolean;
     email_enc?: string;
@@ -56,11 +56,11 @@ export async function listUsers() {
   }[];
 }
 
-export async function setUserEnabled(id: number, enabled: boolean): Promise<void> {
+export async function setUserEnabled(id: string, enabled: boolean): Promise<void> {
   await db.query('UPDATE users SET is_enabled = $1 WHERE id = $2', [enabled, id]);
 }
 
-export async function getUserTotpStatus(id: number) {
+export async function getUserTotpStatus(id: string) {
   const { rows } = await db.query(
     'SELECT is_totp_enabled FROM users WHERE id = $1',
     [id],
@@ -69,7 +69,7 @@ export async function getUserTotpStatus(id: number) {
   return !!row?.is_totp_enabled;
 }
 
-export async function setUserTotpSecret(id: number, secret: string): Promise<void> {
+export async function setUserTotpSecret(id: string, secret: string): Promise<void> {
   const enc = encrypt(secret, env.KEY_PASSWORD);
   await db.query(
     'UPDATE users SET totp_secret_enc = $1, is_totp_enabled = true WHERE id = $2',
@@ -77,7 +77,7 @@ export async function setUserTotpSecret(id: number, secret: string): Promise<voi
   );
 }
 
-export async function getUserTotpSecret(id: number) {
+export async function getUserTotpSecret(id: string) {
   const { rows } = await db.query(
     'SELECT totp_secret_enc FROM users WHERE id = $1',
     [id],
@@ -87,7 +87,7 @@ export async function getUserTotpSecret(id: number) {
   return decrypt(row.totp_secret_enc, env.KEY_PASSWORD);
 }
 
-export async function clearUserTotp(id: number): Promise<void> {
+export async function clearUserTotp(id: string): Promise<void> {
   await db.query(
     'UPDATE users SET totp_secret_enc = NULL, is_totp_enabled = false WHERE id = $1',
     [id],
@@ -100,7 +100,7 @@ export async function findUserByEmail(emailEnc: string) {
     [emailEnc],
   );
   const row = rows[0] as {
-    id: number;
+    id: string;
     role: string;
     is_enabled: boolean;
     totp_secret_enc?: string;

--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -28,10 +28,10 @@ import {
 async function getAgentForRequest(
   req: FastifyRequest,
   reply: FastifyReply,
-): Promise<{ userId: number; id: number; log: Logger; agent: any } | undefined> {
+): Promise<{ userId: string; id: string; log: Logger; agent: any } | undefined> {
   const userId = requireUserId(req, reply);
   if (!userId) return;
-  const id = Number((req.params as any).id);
+  const id = (req.params as any).id as string;
   const log = req.log.child({ userId, agentId: id }) as unknown as Logger;
   const agent = await getAgent(id);
   if (!agent) {

--- a/backend/src/routes/api-keys.ts
+++ b/backend/src/routes/api-keys.ts
@@ -24,7 +24,7 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
     '/users/:id/ai-key',
     { config: { rateLimit: RATE_LIMITS.TIGHT } },
     async (req, reply) => {
-      const id = Number((req.params as any).id);
+      const id = (req.params as any).id as string;
       const { key } = req.body as { key: string };
       const row = await getAiKeyRow(id);
       let err = ensureUser(row);
@@ -43,7 +43,7 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
     '/users/:id/ai-key',
     { config: { rateLimit: RATE_LIMITS.MODERATE } },
     async (req, reply) => {
-      const id = Number((req.params as any).id);
+      const id = (req.params as any).id as string;
       const row = await getAiKeyRow(id);
       const err = ensureKeyPresent(row, ['ai_api_key_enc']);
       if (err) return reply.code(err.code).send(err.body);
@@ -56,7 +56,7 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
     '/users/:id/ai-key',
     { config: { rateLimit: RATE_LIMITS.TIGHT } },
     async (req, reply) => {
-      const id = Number((req.params as any).id);
+      const id = (req.params as any).id as string;
       const { key } = req.body as { key: string };
       const row = await getAiKeyRow(id);
       const err = ensureKeyPresent(row, ['ai_api_key_enc']);
@@ -73,7 +73,7 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
     '/users/:id/ai-key',
     { config: { rateLimit: RATE_LIMITS.VERY_TIGHT } },
     async (req, reply) => {
-      const id = Number((req.params as any).id);
+      const id = (req.params as any).id as string;
       const row = await getAiKeyRow(id);
       const err = ensureKeyPresent(row, ['ai_api_key_enc']);
       if (err) return reply.code(err.code).send(err.body);
@@ -86,7 +86,7 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
     '/users/:id/binance-key',
     { config: { rateLimit: RATE_LIMITS.TIGHT } },
     async (req, reply) => {
-      const id = Number((req.params as any).id);
+      const id = (req.params as any).id as string;
       const { key, secret } = req.body as { key: string; secret: string };
       const row = await getBinanceKeyRow(id);
       let err = ensureUser(row);
@@ -106,7 +106,7 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
     '/users/:id/binance-key',
     { config: { rateLimit: RATE_LIMITS.MODERATE } },
     async (req, reply) => {
-      const id = Number((req.params as any).id);
+      const id = (req.params as any).id as string;
       const row = await getBinanceKeyRow(id);
       const err = ensureKeyPresent(row, [
         'binance_api_key_enc',
@@ -123,7 +123,7 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
     '/users/:id/binance-key',
     { config: { rateLimit: RATE_LIMITS.TIGHT } },
     async (req, reply) => {
-      const id = Number((req.params as any).id);
+      const id = (req.params as any).id as string;
       const { key, secret } = req.body as { key: string; secret: string };
       const row = await getBinanceKeyRow(id);
       const err = ensureKeyPresent(row, [
@@ -144,7 +144,7 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
     '/users/:id/binance-key',
     { config: { rateLimit: RATE_LIMITS.VERY_TIGHT } },
     async (req, reply) => {
-      const id = (req.params as any).id;
+      const id = (req.params as any).id as string;
       const row = await getBinanceKeyRow(id);
       const err = ensureKeyPresent(row, [
         'binance_api_key_enc',

--- a/backend/src/routes/binance-balance.ts
+++ b/backend/src/routes/binance-balance.ts
@@ -9,7 +9,7 @@ export default async function binanceBalanceRoutes(app: FastifyInstance) {
     '/users/:id/binance-balance',
     { config: { rateLimit: RATE_LIMITS.MODERATE } },
     async (req, reply) => {
-      const id = Number((req.params as any).id);
+      const id = (req.params as any).id as string;
       if (!requireUserIdMatch(req, reply, id)) return;
     let total;
     try {
@@ -30,7 +30,7 @@ export default async function binanceBalanceRoutes(app: FastifyInstance) {
     { config: { rateLimit: RATE_LIMITS.RELAXED } },
     async (req, reply) => {
       const { id, token } = req.params as any;
-      const userId = Number(id);
+      const userId = id as string;
       if (!requireUserIdMatch(req, reply, userId)) return;
       let account;
       try {

--- a/backend/src/routes/models.ts
+++ b/backend/src/routes/models.ts
@@ -28,7 +28,7 @@ export default async function modelsRoutes(app: FastifyInstance) {
     '/users/:id/models',
     { config: { rateLimit: RATE_LIMITS.MODERATE } },
     async (req, reply) => {
-      const id = Number((req.params as any).id);
+      const id = (req.params as any).id as string;
       if (!requireUserIdMatch(req, reply, id)) return;
     const row = await getAiKeyRow(id);
     if (!row?.ai_api_key_enc)

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -31,7 +31,7 @@ export default async function usersRoutes(app: FastifyInstance) {
       const adminId = await requireAdmin(req, reply);
       if (!adminId) return;
       const { id } = req.params as { id: string };
-      const userId = Number(id);
+      const userId = id;
       const row = await getUser(userId);
       if (!row) return reply.code(404).send(errorResponse('user not found'));
       await setUserEnabled(userId, true);
@@ -46,7 +46,7 @@ export default async function usersRoutes(app: FastifyInstance) {
       const adminId = await requireAdmin(req, reply);
       if (!adminId) return;
       const { id } = req.params as { id: string };
-      const userId = Number(id);
+      const userId = id;
       const row = await getUser(userId);
       if (!row) return reply.code(404).send(errorResponse('user not found'));
       await setUserEnabled(userId, false);

--- a/backend/src/services/binance.ts
+++ b/backend/src/services/binance.ts
@@ -5,7 +5,7 @@ import { getBinanceKeyRow } from '../repos/api-keys.js';
 
 type UserCreds = { key: string; secret: string };
 
-async function getUserCreds(id: number): Promise<UserCreds | null> {
+async function getUserCreds(id: string): Promise<UserCreds | null> {
   const row = await getBinanceKeyRow(id);
   if (!row?.binance_api_key_enc || !row.binance_api_secret_enc) return null;
   const key = decrypt(row.binance_api_key_enc, env.KEY_PASSWORD);
@@ -13,7 +13,7 @@ async function getUserCreds(id: number): Promise<UserCreds | null> {
   return { key, secret };
 }
 
-export async function fetchAccount(id: number) {
+export async function fetchAccount(id: string) {
   const creds = await getUserCreds(id);
   if (!creds) return null;
   const timestamp = Date.now();
@@ -29,7 +29,7 @@ export async function fetchAccount(id: number) {
   };
 }
 
-export async function fetchTotalBalanceUsd(id: number) {
+export async function fetchTotalBalanceUsd(id: string) {
   const account = await fetchAccount(id);
   if (!account) return null;
   let total = 0;
@@ -50,7 +50,7 @@ export async function fetchTotalBalanceUsd(id: number) {
   return total;
 }
 
-export async function fetchTokensBalanceUsd(id: number, tokens: string[]) {
+export async function fetchTokensBalanceUsd(id: string, tokens: string[]) {
   const account = await fetchAccount(id);
   if (!account) return null;
   const wanted = new Set(tokens.map((t) => t.toUpperCase()));
@@ -74,7 +74,7 @@ export async function fetchTokensBalanceUsd(id: number, tokens: string[]) {
 }
 
 export async function createLimitOrder(
-  id: number,
+  id: string,
   opts: { symbol: string; side: 'BUY' | 'SELL'; quantity: number; price: number }
 ) {
   const creds = await getUserCreds(id);
@@ -109,7 +109,7 @@ export async function createLimitOrder(
 }
 
 export async function cancelOrder(
-  id: number,
+  id: string,
   opts: { symbol: string; orderId: number }
 ) {
   const creds = await getUserCreds(id);

--- a/backend/src/services/rebalance.ts
+++ b/backend/src/services/rebalance.ts
@@ -3,12 +3,12 @@ import { insertExecution } from '../repos/executions.js';
 import { fetchPairData, createLimitOrder } from './binance.js';
 
 export async function createRebalanceLimitOrder(opts: {
-  userId: number;
+  userId: string;
   tokenA: string;
   tokenB: string;
   positions: { sym: string; value_usdt: number }[];
   newAllocation: number;
-  execResultId: number;
+  execResultId: string;
   log: FastifyBaseLogger;
 }) {
   const { userId, tokenA, tokenB, positions, newAllocation, execResultId, log } = opts;

--- a/backend/src/util/agents.ts
+++ b/backend/src/util/agents.ts
@@ -19,7 +19,7 @@ export enum AgentStatus {
 }
 
 export interface AgentInput {
-  userId: number;
+  userId: string;
   model: string;
   name: string;
   tokenA: string;
@@ -40,14 +40,14 @@ export interface ValidationErr {
 
 export async function validateTokenConflicts(
   log: Logger,
-  userId: number,
+  userId: string,
   tokenA: string,
   tokenB: string,
-  id?: number,
+  id?: string,
 ): Promise<ValidationErr | null> {
   const dupRows = await findActiveTokenConflicts(userId, tokenA, tokenB, id);
   if (!dupRows.length) return null;
-  const conflicts: { token: string; id: number; name: string }[] = [];
+  const conflicts: { token: string; id: string; name: string }[] = [];
   for (const row of dupRows) {
     if (row.token_a === tokenA || row.token_b === tokenA)
       conflicts.push({ token: tokenA, id: row.id, name: row.name });
@@ -62,9 +62,9 @@ export async function validateTokenConflicts(
 
 async function validateAgentInput(
   log: Logger,
-  userId: number,
+  userId: string,
   body: AgentInput,
-  id?: number,
+  id?: string,
 ): Promise<ValidationErr | null> {
   if (body.userId !== userId) {
     log.error('user mismatch');
@@ -120,7 +120,7 @@ async function validateAgentInput(
 
 export async function ensureApiKeys(
   log: Logger,
-  userId: number,
+  userId: string,
 ): Promise<ValidationErr | null> {
   const userRow = await getUserApiKeys(userId);
   if (
@@ -136,7 +136,7 @@ export async function ensureApiKeys(
 
 export async function getStartBalance(
   log: Logger,
-  userId: number,
+  userId: string,
   tokenA: string,
   tokenB: string,
 ): Promise<number | ValidationErr> {
@@ -155,9 +155,9 @@ export async function getStartBalance(
 
 export async function prepareAgentForUpsert(
   log: Logger,
-  userId: number,
+  userId: string,
   body: AgentInput,
-  id?: number,
+  id?: string,
 ): Promise<{ body: AgentInput; startBalance: number | null } | ValidationErr> {
   let norm;
   try {

--- a/backend/src/util/auth.ts
+++ b/backend/src/util/auth.ts
@@ -4,25 +4,20 @@ import { getUser } from '../repos/users.js';
 
 export function requireUserId(
   req: FastifyRequest,
-  reply: FastifyReply
-): number | null {
+  reply: FastifyReply,
+): string | null {
   const userIdHeader = req.headers['x-user-id'] as string | undefined;
   if (!userIdHeader) {
     reply.code(403).send(errorResponse(ERROR_MESSAGES.forbidden));
     return null;
   }
-  const userId = Number(userIdHeader);
-  if (!Number.isFinite(userId)) {
-    reply.code(403).send(errorResponse(ERROR_MESSAGES.forbidden));
-    return null;
-  }
-  return userId;
+  return userIdHeader;
 }
 
 export async function requireAdmin(
   req: FastifyRequest,
-  reply: FastifyReply
-): Promise<number | null> {
+  reply: FastifyReply,
+): Promise<string | null> {
   const userId = requireUserId(req, reply);
   if (!userId) return null;
   const row = await getUser(userId);
@@ -36,8 +31,8 @@ export async function requireAdmin(
 export function requireUserIdMatch(
   req: FastifyRequest,
   reply: FastifyReply,
-  id: number,
-): number | null {
+  id: string,
+): string | null {
   const userId = requireUserId(req, reply);
   if (!userId) return null;
   if (userId !== id) {

--- a/backend/test/adminUsers.test.ts
+++ b/backend/test/adminUsers.test.ts
@@ -8,24 +8,24 @@ import { getUser } from '../src/repos/users.js';
 describe('admin user routes', () => {
   it('lists users for admin only', async () => {
     const app = await buildServer();
-    insertAdminUser('admin1', encrypt('admin@example.com', env.KEY_PASSWORD));
-    insertUser('user1', encrypt('user1@example.com', env.KEY_PASSWORD));
+    const adminId = await insertAdminUser('admin1', encrypt('admin@example.com', env.KEY_PASSWORD));
+    const userId = await insertUser('1', encrypt('user1@example.com', env.KEY_PASSWORD));
 
     const resForbidden = await app.inject({
       method: 'GET',
       url: '/api/users',
-      headers: { 'x-user-id': 'user1' },
+      headers: { 'x-user-id': userId },
     });
     expect(resForbidden.statusCode).toBe(403);
 
     const res = await app.inject({
       method: 'GET',
       url: '/api/users',
-      headers: { 'x-user-id': 'admin1' },
+      headers: { 'x-user-id': adminId },
     });
     expect(res.statusCode).toBe(200);
     const body = res.json() as any[];
-    const user = body.find((u) => u.id === 'user1');
+    const user = body.find((u) => u.id === userId);
     expect(user.email).toBe('user1@example.com');
     expect(typeof user.createdAt).toBe('string');
     await app.close();
@@ -33,25 +33,25 @@ describe('admin user routes', () => {
 
   it('enables and disables users', async () => {
     const app = await buildServer();
-    insertAdminUser('admin2');
-    insertUser('user2');
+    const adminId = await insertAdminUser('admin2');
+    const userId = await insertUser('2');
 
     const resDisable = await app.inject({
       method: 'POST',
-      url: '/api/users/user2/disable',
-      headers: { 'x-user-id': 'admin2' },
+      url: `/api/users/${userId}/disable`,
+      headers: { 'x-user-id': adminId },
     });
     expect(resDisable.statusCode).toBe(200);
-    let row = getUser('user2');
+    let row = await getUser(userId);
     expect(row?.is_enabled).toBe(false);
 
     const resEnable = await app.inject({
       method: 'POST',
-      url: '/api/users/user2/enable',
-      headers: { 'x-user-id': 'admin2' },
+      url: `/api/users/${userId}/enable`,
+      headers: { 'x-user-id': adminId },
     });
     expect(resEnable.statusCode).toBe(200);
-    row = getUser('user2');
+    row = await getUser(userId);
     expect(row?.is_enabled).toBe(true);
 
     await app.close();

--- a/backend/test/agentCreateAsync.test.ts
+++ b/backend/test/agentCreateAsync.test.ts
@@ -12,19 +12,20 @@ vi.mock('../src/jobs/review-portfolio.js', () => ({
 import buildServer from '../src/server.js';
 import { encrypt } from '../src/util/crypto.js';
 
-function addUser(id: string) {
+async function addUser(id: string) {
   const ai = encrypt('aikey', process.env.KEY_PASSWORD!);
   const bk = encrypt('bkey', process.env.KEY_PASSWORD!);
   const bs = encrypt('skey', process.env.KEY_PASSWORD!);
-  insertUser(id, null);
-  setAiKey(id, ai);
-  setBinanceKey(id, bk, bs);
+  const userId = await insertUser(id, null);
+  await setAiKey(userId, ai);
+  await setBinanceKey(userId, bk, bs);
+  return userId;
 }
 
 describe('agent creation', () => {
   it('does not await initial review', async () => {
     const app = await buildServer();
-    addUser('u1');
+    const userId = await addUser('1');
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({
@@ -48,7 +49,7 @@ describe('agent creation', () => {
     (globalThis as any).fetch = fetchMock;
 
     const payload = {
-      userId: 'u1',
+      userId,
       model: 'm',
       name: 'Draft',
       tokenA: 'BTC',
@@ -64,7 +65,7 @@ describe('agent creation', () => {
     const createPromise = app.inject({
       method: 'POST',
       url: '/api/agents',
-      headers: { 'x-user-id': 'u1' },
+      headers: { 'x-user-id': userId },
       payload,
     });
     const res = await Promise.race([

--- a/backend/test/agentManualReview.test.ts
+++ b/backend/test/agentManualReview.test.ts
@@ -14,14 +14,11 @@ vi.mock('../src/jobs/review-portfolio.js', () => ({
 describe('manual review endpoint', () => {
   it('triggers portfolio review', async () => {
     const app = await buildServer();
-    await insertUser('u1');
-    const agentId = 'a1';
-    await insertAgent({
-      id: agentId,
-      userId: 'u1',
+    const userId = await insertUser('1');
+    const agent = await insertAgent({
+      userId,
       model: 'gpt',
       status: 'active',
-      createdAt: 0,
       startBalance: null,
       name: 'A',
       tokenA: 'BTC',
@@ -33,11 +30,12 @@ describe('manual review endpoint', () => {
       agentInstructions: 'inst',
       manualRebalance: false,
     });
+    const agentId = agent.id;
 
     const res = await app.inject({
       method: 'POST',
       url: `/api/agents/${agentId}/review`,
-      headers: { 'x-user-id': 'u1' },
+      headers: { 'x-user-id': userId },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ ok: true });
@@ -48,14 +46,11 @@ describe('manual review endpoint', () => {
 
   it('returns error when agent is already reviewing', async () => {
     const app = await buildServer();
-    await insertUser('u2');
-    const agentId = 'b1';
-    await insertAgent({
-      id: agentId,
-      userId: 'u2',
+    const userId = await insertUser('2');
+    const agent = await insertAgent({
+      userId,
       model: 'gpt',
       status: 'active',
-      createdAt: 0,
       startBalance: null,
       name: 'A2',
       tokenA: 'BTC',
@@ -67,13 +62,14 @@ describe('manual review endpoint', () => {
       agentInstructions: 'inst',
       manualRebalance: false,
     });
+    const agentId = agent.id;
     reviewAgentPortfolioMock.mockRejectedValueOnce(
       new Error('Agent is already reviewing portfolio'),
     );
     const res = await app.inject({
       method: 'POST',
       url: `/api/agents/${agentId}/review`,
-      headers: { 'x-user-id': 'u2' },
+      headers: { 'x-user-id': userId },
     });
     expect(res.statusCode).toBe(400);
     expect(res.json()).toEqual({ error: 'Agent is already reviewing portfolio' });

--- a/backend/test/agents.test.ts
+++ b/backend/test/agents.test.ts
@@ -10,23 +10,25 @@ vi.mock('../src/jobs/review-portfolio.js', () => ({
   reviewAgentPortfolio: vi.fn(() => Promise.resolve()),
 }));
 
-function addUser(id: string) {
+async function addUser(id: string) {
   const ai = encrypt('aikey', process.env.KEY_PASSWORD!);
   const bk = encrypt('bkey', process.env.KEY_PASSWORD!);
   const bs = encrypt('skey', process.env.KEY_PASSWORD!);
-  insertUser(id, null);
-  setAiKey(id, ai);
-  setBinanceKey(id, bk, bs);
+  const userId = await insertUser(id, null);
+  await setAiKey(userId, ai);
+  await setBinanceKey(userId, bk, bs);
+  return userId;
 }
 
-function addUserNoKeys(id: string) {
-  insertUser(id);
+async function addUserNoKeys(id: string) {
+  const userId = await insertUser(id);
+  return userId;
 }
 
 describe('agent routes', () => {
   it('performs CRUD operations', async () => {
     const app = await buildServer();
-    addUser('user1');
+    const userId = await addUser('1');
 
     const fetchMock = vi.fn();
     fetchMock
@@ -65,7 +67,7 @@ describe('agent routes', () => {
     (globalThis as any).fetch = fetchMock;
 
     const payload = {
-      userId: 'user1',
+      userId,
       model: 'gpt-5',
       name: 'A1',
       tokenA: 'BTC',
@@ -81,7 +83,7 @@ describe('agent routes', () => {
     let res = await app.inject({
       method: 'POST',
       url: '/api/agents',
-      headers: { 'x-user-id': 'user1' },
+      headers: { 'x-user-id': userId },
       payload,
     });
     expect(res.statusCode).toBe(200);
@@ -92,7 +94,7 @@ describe('agent routes', () => {
     res = await app.inject({
       method: 'GET',
       url: `/api/agents/${id}`,
-      headers: { 'x-user-id': 'user1' },
+      headers: { 'x-user-id': userId },
     });
     expect(res.statusCode).toBe(200);
       expect(res.json()).toMatchObject({ id, ...payload, startBalanceUsd: 100 });
@@ -100,7 +102,7 @@ describe('agent routes', () => {
     res = await app.inject({
       method: 'GET',
       url: '/api/agents/paginated?page=1&pageSize=10',
-      headers: { 'x-user-id': 'user1' },
+      headers: { 'x-user-id': userId },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ total: 1, page: 1, pageSize: 10 });
@@ -109,7 +111,7 @@ describe('agent routes', () => {
     res = await app.inject({
       method: 'GET',
       url: '/api/agents/paginated?page=1&pageSize=10&status=active',
-      headers: { 'x-user-id': 'user1' },
+      headers: { 'x-user-id': userId },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ total: 1, page: 1, pageSize: 10 });
@@ -119,7 +121,7 @@ describe('agent routes', () => {
     res = await app.inject({
       method: 'PUT',
       url: `/api/agents/${id}`,
-      headers: { 'x-user-id': 'user1' },
+      headers: { 'x-user-id': userId },
       payload: update,
     });
     expect(res.statusCode).toBe(200);
@@ -128,7 +130,7 @@ describe('agent routes', () => {
     res = await app.inject({
       method: 'GET',
       url: '/api/agents/paginated?page=1&pageSize=10&status=active',
-      headers: { 'x-user-id': 'user1' },
+      headers: { 'x-user-id': userId },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ total: 0, page: 1, pageSize: 10 });
@@ -137,7 +139,7 @@ describe('agent routes', () => {
     res = await app.inject({
       method: 'GET',
       url: '/api/agents/paginated?page=1&pageSize=10&status=draft',
-      headers: { 'x-user-id': 'user1' },
+      headers: { 'x-user-id': userId },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ total: 1, page: 1, pageSize: 10 });
@@ -146,22 +148,22 @@ describe('agent routes', () => {
     res = await app.inject({
       method: 'DELETE',
       url: `/api/agents/${id}`,
-      headers: { 'x-user-id': 'user1' },
+      headers: { 'x-user-id': userId },
     });
     expect(res.statusCode).toBe(200);
 
     res = await app.inject({
       method: 'GET',
       url: `/api/agents/${id}`,
-      headers: { 'x-user-id': 'user1' },
+      headers: { 'x-user-id': userId },
     });
     expect(res.statusCode).toBe(404);
 
     res = await app.inject({
       method: 'POST',
       url: '/api/agents',
-      headers: { 'x-user-id': 'user2' },
-      payload: { ...payload, userId: 'user3', name: 'A2' },
+      headers: { 'x-user-id': '999' },
+      payload: { ...payload, userId, name: 'A2' },
     });
     expect(res.statusCode).toBe(403);
 
@@ -171,9 +173,9 @@ describe('agent routes', () => {
 
   it('starts and stops agent', async () => {
     const app = await buildServer();
-    addUser('starter');
+    const starterId = await addUser('starter');
     const draftPayload = {
-      userId: 'starter',
+      userId: starterId,
       model: 'm',
       name: 'Draft',
       tokenA: 'BTC',
@@ -188,7 +190,7 @@ describe('agent routes', () => {
     const resCreate = await app.inject({
       method: 'POST',
       url: '/api/agents',
-      headers: { 'x-user-id': 'starter' },
+      headers: { 'x-user-id': starterId },
       payload: draftPayload,
     });
     const id = resCreate.json().id as string;
@@ -223,7 +225,7 @@ describe('agent routes', () => {
     let res = await app.inject({
       method: 'POST',
       url: `/api/agents/${id}/start`,
-      headers: { 'x-user-id': 'starter' },
+      headers: { 'x-user-id': starterId },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ status: 'active' });
@@ -233,7 +235,7 @@ describe('agent routes', () => {
     res = await app.inject({
       method: 'POST',
       url: `/api/agents/${id}/stop`,
-      headers: { 'x-user-id': 'starter' },
+      headers: { 'x-user-id': starterId },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ status: 'inactive' });
@@ -245,7 +247,7 @@ describe('agent routes', () => {
 
   it('updates running agent and refreshes start balance', async () => {
     const app = await buildServer();
-    addUser('update-user');
+    const updateUserId = await addUser('update-user');
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({
@@ -295,7 +297,7 @@ describe('agent routes', () => {
     (globalThis as any).fetch = fetchMock;
 
     const createPayload = {
-      userId: 'update-user',
+      userId: updateUserId,
       model: 'm',
       name: 'A',
       tokenA: 'BTC',
@@ -311,7 +313,7 @@ describe('agent routes', () => {
     const resCreate = await app.inject({
       method: 'POST',
       url: '/api/agents',
-      headers: { 'x-user-id': 'update-user' },
+      headers: { 'x-user-id': updateUserId },
       payload: createPayload,
     });
     expect(resCreate.statusCode).toBe(200);
@@ -321,7 +323,7 @@ describe('agent routes', () => {
     const resUpdate = await app.inject({
       method: 'PUT',
       url: `/api/agents/${id}`,
-      headers: { 'x-user-id': 'update-user' },
+      headers: { 'x-user-id': updateUserId },
       payload: updatePayload,
     });
     expect(resUpdate.statusCode).toBe(200);
@@ -335,10 +337,10 @@ describe('agent routes', () => {
 
   it('handles drafts and api key validation', async () => {
     const app = await buildServer();
-    addUserNoKeys('u1');
+    const u1Id = await addUserNoKeys('1');
 
     const basePayload = {
-      userId: 'u1',
+      userId: u1Id,
       model: 'm',
       name: 'Draft1',
       tokenA: 'BTC',
@@ -353,7 +355,7 @@ describe('agent routes', () => {
     let res = await app.inject({
       method: 'POST',
       url: '/api/agents',
-      headers: { 'x-user-id': 'u1' },
+      headers: { 'x-user-id': u1Id },
       payload: { ...basePayload, status: 'active' },
     });
     expect(res.statusCode).toBe(400);
@@ -361,13 +363,13 @@ describe('agent routes', () => {
     res = await app.inject({
       method: 'POST',
       url: '/api/agents',
-      headers: { 'x-user-id': 'u1' },
+      headers: { 'x-user-id': u1Id },
       payload: { ...basePayload, status: 'draft' },
     });
     expect(res.statusCode).toBe(200);
     const draftId = res.json().id as string;
 
-    addUser('u2');
+    const u2Id = await addUser('2');
     const fetchMock = vi.fn();
     fetchMock
       .mockResolvedValueOnce({
@@ -398,8 +400,8 @@ describe('agent routes', () => {
     res = await app.inject({
       method: 'POST',
       url: '/api/agents',
-      headers: { 'x-user-id': 'u2' },
-      payload: { ...basePayload, userId: 'u2', name: 'Active', status: 'active' },
+      headers: { 'x-user-id': u2Id },
+      payload: { ...basePayload, userId: u2Id, name: 'Active', status: 'active' },
     });
     expect(res.statusCode).toBe(200);
     const activeId = res.json().id as string;
@@ -407,8 +409,8 @@ describe('agent routes', () => {
     const resDraft2 = await app.inject({
       method: 'POST',
       url: '/api/agents',
-      headers: { 'x-user-id': 'u2' },
-      payload: { ...basePayload, userId: 'u2', name: 'Draft2', status: 'draft' },
+      headers: { 'x-user-id': u2Id },
+      payload: { ...basePayload, userId: u2Id, name: 'Draft2', status: 'draft' },
     });
     const draft2Id = resDraft2.json().id as string;
 
@@ -423,7 +425,7 @@ describe('agent routes', () => {
 
   it('checks duplicates based on status and tokens', async () => {
     const app = await buildServer();
-    addUser('dupUser');
+    const dupId = await addUser('dupUser');
     const fetchMock = vi.fn();
     fetchMock
       .mockResolvedValueOnce({
@@ -453,7 +455,7 @@ describe('agent routes', () => {
     (globalThis as any).fetch = fetchMock;
 
     const base = {
-      userId: 'dupUser',
+      userId: dupId,
       model: 'm',
       name: 'A1',
       tokenA: 'BTC',
@@ -469,7 +471,7 @@ describe('agent routes', () => {
     const res1 = await app.inject({
       method: 'POST',
       url: '/api/agents',
-      headers: { 'x-user-id': 'dupUser' },
+      headers: { 'x-user-id': dupId },
       payload: base,
     });
     const existingId = res1.json().id as string;
@@ -477,7 +479,7 @@ describe('agent routes', () => {
     const resDup = await app.inject({
       method: 'POST',
       url: '/api/agents',
-      headers: { 'x-user-id': 'dupUser' },
+      headers: { 'x-user-id': dupId },
       payload: { ...base, name: 'B1', tokenA: 'BTC', tokenB: 'SOL' },
     });
     expect(resDup.statusCode).toBe(400);
@@ -490,7 +492,7 @@ describe('agent routes', () => {
     const resOk = await app.inject({
       method: 'POST',
       url: '/api/agents',
-      headers: { 'x-user-id': 'dupUser' },
+      headers: { 'x-user-id': dupId },
       payload: { ...base, name: 'B2', tokenA: 'BTC', tokenB: 'SOL' },
     });
     expect(resOk.statusCode).toBe(200);
@@ -501,10 +503,10 @@ describe('agent routes', () => {
 
   it('detects identical drafts', async () => {
     const app = await buildServer();
-    addUserNoKeys('draftUser');
+    const draftUserId = await addUserNoKeys('draftUser');
 
     const draftPayload = {
-      userId: 'draftUser',
+      userId: draftUserId,
       model: 'm',
       name: 'Draft',
       tokenA: 'BTC',
@@ -520,7 +522,7 @@ describe('agent routes', () => {
     const res1 = await app.inject({
       method: 'POST',
       url: '/api/agents',
-      headers: { 'x-user-id': 'draftUser' },
+      headers: { 'x-user-id': draftUserId },
       payload: draftPayload,
     });
     const draftId = res1.json().id as string;
@@ -528,7 +530,7 @@ describe('agent routes', () => {
     const resDup = await app.inject({
       method: 'POST',
       url: '/api/agents',
-      headers: { 'x-user-id': 'draftUser' },
+      headers: { 'x-user-id': draftUserId },
       payload: draftPayload,
     });
     expect(resDup.statusCode).toBe(400);
@@ -538,7 +540,7 @@ describe('agent routes', () => {
     const resOk = await app.inject({
       method: 'POST',
       url: '/api/agents',
-      headers: { 'x-user-id': 'draftUser' },
+      headers: { 'x-user-id': draftUserId },
       payload: { ...draftPayload, name: 'Draft2' },
     });
     expect(resOk.statusCode).toBe(200);
@@ -548,10 +550,10 @@ describe('agent routes', () => {
 
   it('rejects duplicate draft updates', async () => {
     const app = await buildServer();
-    addUserNoKeys('updUser');
+    const updId = await addUserNoKeys('updUser');
 
     const base = {
-      userId: 'updUser',
+      userId: updId,
       model: 'm1',
       name: 'Draft1',
       tokenA: 'BTC',
@@ -567,7 +569,7 @@ describe('agent routes', () => {
     const res1 = await app.inject({
       method: 'POST',
       url: '/api/agents',
-      headers: { 'x-user-id': 'updUser' },
+      headers: { 'x-user-id': updId },
       payload: base,
     });
     const draft1 = res1.json().id as string;
@@ -575,7 +577,7 @@ describe('agent routes', () => {
     const res2 = await app.inject({
       method: 'POST',
       url: '/api/agents',
-      headers: { 'x-user-id': 'updUser' },
+      headers: { 'x-user-id': updId },
       payload: { ...base, name: 'Draft2', tokenB: 'SOL' },
     });
     const draft2 = res2.json().id as string;
@@ -583,7 +585,7 @@ describe('agent routes', () => {
     const resUpd = await app.inject({
       method: 'PUT',
       url: `/api/agents/${draft2}`,
-      headers: { 'x-user-id': 'updUser' },
+      headers: { 'x-user-id': updId },
       payload: { ...base },
     });
     expect(resUpd.statusCode).toBe(400);
@@ -595,9 +597,9 @@ describe('agent routes', () => {
 
   it('fails to start agent without model', async () => {
     const app = await buildServer();
-    addUser('nomodel');
+    const nomodelId = await addUser('nomodel');
     const payload = {
-      userId: 'nomodel',
+      userId: nomodelId,
       model: '',
       name: 'Draft',
       tokenA: 'BTC',
@@ -612,14 +614,14 @@ describe('agent routes', () => {
     const resCreate = await app.inject({
       method: 'POST',
       url: '/api/agents',
-      headers: { 'x-user-id': 'nomodel' },
+      headers: { 'x-user-id': nomodelId },
       payload,
     });
     const id = resCreate.json().id as string;
     const resStart = await app.inject({
       method: 'POST',
       url: `/api/agents/${id}/start`,
-      headers: { 'x-user-id': 'nomodel' },
+      headers: { 'x-user-id': nomodelId },
     });
     expect(resStart.statusCode).toBe(400);
     expect(resStart.json().error).toContain('model');
@@ -628,9 +630,9 @@ describe('agent routes', () => {
 
   it('rejects allocations exceeding 95%', async () => {
     const app = await buildServer();
-    addUserNoKeys('allocUser');
+    const allocId = await addUserNoKeys('allocUser');
     const payload = {
-      userId: 'allocUser',
+      userId: allocId,
       model: 'm',
       name: 'Bad',
       tokenA: 'BTC',
@@ -645,7 +647,7 @@ describe('agent routes', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/agents',
-      headers: { 'x-user-id': 'allocUser' },
+      headers: { 'x-user-id': allocId },
       payload,
     });
     expect(res.statusCode).toBe(400);

--- a/backend/test/apiKeys.test.ts
+++ b/backend/test/apiKeys.test.ts
@@ -6,7 +6,7 @@ import { getAiKeyRow, getBinanceKeyRow } from '../src/repos/api-keys.js';
 describe('AI API key routes', () => {
   it('performs CRUD operations', async () => {
     const app = await buildServer();
-    insertUser('user1');
+    const userId = await insertUser('1');
 
     const fetchMock = vi.fn();
     const originalFetch = globalThis.fetch;
@@ -18,32 +18,32 @@ describe('AI API key routes', () => {
     fetchMock.mockResolvedValueOnce({ ok: false } as any);
     let res = await app.inject({
       method: 'POST',
-      url: '/api/users/user1/ai-key',
+      url: `/api/users/${userId}/ai-key`,
       payload: { key: 'bad' },
     });
     expect(res.statusCode).toBe(400);
     expect(res.json()).toMatchObject({ error: 'verification failed' });
-    let row = getAiKeyRow('user1');
+    let row = getAiKeyRow(userId);
     expect(row!.ai_api_key_enc).toBeNull();
 
     fetchMock.mockResolvedValueOnce({ ok: true } as any);
     res = await app.inject({
       method: 'POST',
-      url: '/api/users/user1/ai-key',
+      url: `/api/users/${userId}/ai-key`,
       payload: { key: key1 },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ key: 'aike...7890' });
-    row = getAiKeyRow('user1');
+    row = getAiKeyRow(userId);
     expect(row!.ai_api_key_enc).not.toBe(key1);
 
-    res = await app.inject({ method: 'GET', url: '/api/users/user1/ai-key' });
+    res = await app.inject({ method: 'GET', url: `/api/users/${userId}/ai-key` });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ key: 'aike...7890' });
 
     res = await app.inject({
       method: 'POST',
-      url: '/api/users/user1/ai-key',
+      url: `/api/users/${userId}/ai-key`,
       payload: { key: 'dup' },
     });
     expect(res.statusCode).toBe(400);
@@ -51,27 +51,27 @@ describe('AI API key routes', () => {
     fetchMock.mockResolvedValueOnce({ ok: false } as any);
     res = await app.inject({
       method: 'PUT',
-      url: '/api/users/user1/ai-key',
+      url: `/api/users/${userId}/ai-key`,
       payload: { key: 'bad2' },
     });
     expect(res.statusCode).toBe(400);
     expect(res.json()).toMatchObject({ error: 'verification failed' });
-    res = await app.inject({ method: 'GET', url: '/api/users/user1/ai-key' });
+    res = await app.inject({ method: 'GET', url: `/api/users/${userId}/ai-key` });
     expect(res.json()).toMatchObject({ key: 'aike...7890' });
 
     fetchMock.mockResolvedValueOnce({ ok: true } as any);
     res = await app.inject({
       method: 'PUT',
-      url: '/api/users/user1/ai-key',
+      url: `/api/users/${userId}/ai-key`,
       payload: { key: key2 },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ key: 'aike...ghij' });
 
-    res = await app.inject({ method: 'DELETE', url: '/api/users/user1/ai-key' });
+    res = await app.inject({ method: 'DELETE', url: `/api/users/${userId}/ai-key` });
     expect(res.statusCode).toBe(200);
 
-    res = await app.inject({ method: 'GET', url: '/api/users/user1/ai-key' });
+    res = await app.inject({ method: 'GET', url: `/api/users/${userId}/ai-key` });
     expect(res.statusCode).toBe(404);
 
     await app.close();
@@ -82,7 +82,7 @@ describe('AI API key routes', () => {
 describe('Binance API key routes', () => {
   it('performs CRUD operations', async () => {
     const app = await buildServer();
-    insertUser('user2');
+    const userId = await insertUser('2');
 
     const fetchMock = vi.fn();
     const originalFetch = globalThis.fetch;
@@ -96,19 +96,19 @@ describe('Binance API key routes', () => {
     fetchMock.mockResolvedValueOnce({ ok: false } as any);
     let res = await app.inject({
       method: 'POST',
-      url: '/api/users/user2/binance-key',
+      url: `/api/users/${userId}/binance-key`,
       payload: { key: 'bad', secret: 'bad' },
     });
     expect(res.statusCode).toBe(400);
     expect(res.json()).toMatchObject({ error: 'verification failed' });
-    let row = getBinanceKeyRow('user2');
+    let row = getBinanceKeyRow(userId);
     expect(row!.binance_api_key_enc).toBeNull();
     expect(row!.binance_api_secret_enc).toBeNull();
 
     fetchMock.mockResolvedValueOnce({ ok: true } as any);
     res = await app.inject({
       method: 'POST',
-      url: '/api/users/user2/binance-key',
+      url: `/api/users/${userId}/binance-key`,
       payload: { key: key1, secret: secret1 },
     });
     expect(res.statusCode).toBe(200);
@@ -116,11 +116,11 @@ describe('Binance API key routes', () => {
       key: 'bkey...7890',
       secret: 'bsec...7890',
     });
-    row = getBinanceKeyRow('user2');
+    row = getBinanceKeyRow(userId);
     expect(row!.binance_api_key_enc).not.toBe(key1);
     expect(row!.binance_api_secret_enc).not.toBe(secret1);
 
-    res = await app.inject({ method: 'GET', url: '/api/users/user2/binance-key' });
+    res = await app.inject({ method: 'GET', url: `/api/users/${userId}/binance-key` });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({
       key: 'bkey...7890',
@@ -129,7 +129,7 @@ describe('Binance API key routes', () => {
 
     res = await app.inject({
       method: 'POST',
-      url: '/api/users/user2/binance-key',
+      url: `/api/users/${userId}/binance-key`,
       payload: { key: 'dup', secret: 'dup' },
     });
     expect(res.statusCode).toBe(400);
@@ -137,12 +137,12 @@ describe('Binance API key routes', () => {
     fetchMock.mockResolvedValueOnce({ ok: false } as any);
     res = await app.inject({
       method: 'PUT',
-      url: '/api/users/user2/binance-key',
+      url: `/api/users/${userId}/binance-key`,
       payload: { key: 'bad2', secret: 'bad2' },
     });
     expect(res.statusCode).toBe(400);
     expect(res.json()).toMatchObject({ error: 'verification failed' });
-    res = await app.inject({ method: 'GET', url: '/api/users/user2/binance-key' });
+    res = await app.inject({ method: 'GET', url: `/api/users/${userId}/binance-key` });
     expect(res.json()).toMatchObject({
       key: 'bkey...7890',
       secret: 'bsec...7890',
@@ -151,7 +151,7 @@ describe('Binance API key routes', () => {
     fetchMock.mockResolvedValueOnce({ ok: true } as any);
     res = await app.inject({
       method: 'PUT',
-      url: '/api/users/user2/binance-key',
+      url: `/api/users/${userId}/binance-key`,
       payload: { key: key2, secret: secret2 },
     });
     expect(res.statusCode).toBe(200);
@@ -160,10 +160,10 @@ describe('Binance API key routes', () => {
       secret: 'bsec...ghij',
     });
 
-    res = await app.inject({ method: 'DELETE', url: '/api/users/user2/binance-key' });
+    res = await app.inject({ method: 'DELETE', url: `/api/users/${userId}/binance-key` });
     expect(res.statusCode).toBe(200);
 
-    res = await app.inject({ method: 'GET', url: '/api/users/user2/binance-key' });
+    res = await app.inject({ method: 'GET', url: `/api/users/${userId}/binance-key` });
     expect(res.statusCode).toBe(404);
 
     await app.close();

--- a/backend/test/binanceBalance.test.ts
+++ b/backend/test/binanceBalance.test.ts
@@ -11,8 +11,8 @@ describe('binance balance route', () => {
     const secret = 'binSecret123456';
     const encKey = encrypt(key, process.env.KEY_PASSWORD!);
     const encSecret = encrypt(secret, process.env.KEY_PASSWORD!);
-    insertUser('user1');
-    setBinanceKey('user1', encKey, encSecret);
+    const userId = await insertUser('1');
+    await setBinanceKey(userId, encKey, encSecret);
 
     const fetchMock = vi.fn();
     const originalFetch = globalThis.fetch;
@@ -33,8 +33,8 @@ describe('binance balance route', () => {
 
     const res = await app.inject({
       method: 'GET',
-      url: '/api/users/user1/binance-balance',
-      headers: { 'x-user-id': 'user1' },
+      url: `/api/users/${userId}/binance-balance`,
+      headers: { 'x-user-id': userId },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ totalUsd: 20100 });
@@ -49,8 +49,8 @@ describe('binance balance route', () => {
     const secret = 'binSecret123456';
     const encKey = encrypt(key, process.env.KEY_PASSWORD!);
     const encSecret = encrypt(secret, process.env.KEY_PASSWORD!);
-    insertUser('user2');
-    setBinanceKey('user2', encKey, encSecret);
+    const userId = await insertUser('2');
+    await setBinanceKey(userId, encKey, encSecret);
 
     const fetchMock = vi.fn();
     const originalFetch = globalThis.fetch;
@@ -64,8 +64,8 @@ describe('binance balance route', () => {
 
     const res = await app.inject({
       method: 'GET',
-      url: '/api/users/user2/binance-balance/BTC',
-      headers: { 'x-user-id': 'user2' },
+      url: `/api/users/${userId}/binance-balance/BTC`,
+      headers: { 'x-user-id': userId },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ asset: 'BTC', free: 1.5, locked: 0.5 });
@@ -78,8 +78,8 @@ describe('binance balance route', () => {
     const app = await buildServer();
     const res = await app.inject({
       method: 'GET',
-      url: '/api/users/other/binance-balance',
-      headers: { 'x-user-id': 'user1' },
+      url: '/api/users/999/binance-balance',
+      headers: { 'x-user-id': '1' },
     });
     expect(res.statusCode).toBe(403);
     await app.close();

--- a/backend/test/binanceOrders.test.ts
+++ b/backend/test/binanceOrders.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { encrypt } from '../src/util/crypto.js';
-import { insertUser, clearUsers } from './repos/users.js';
+import { insertUser } from './repos/users.js';
 import { setBinanceKey } from '../src/repos/api-keys.js';
 import { createHmac } from 'node:crypto';
 import {
@@ -11,7 +11,6 @@ import {
 describe('binance order helpers', () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    clearUsers();
   });
 
   it('creates a signed limit order', async () => {

--- a/backend/test/binanceOrders.test.ts
+++ b/backend/test/binanceOrders.test.ts
@@ -19,15 +19,15 @@ describe('binance order helpers', () => {
     const secret = 'binSecret123456';
     const encKey = encrypt(key, process.env.KEY_PASSWORD!);
     const encSecret = encrypt(secret, process.env.KEY_PASSWORD!);
-    insertUser('user1');
-    setBinanceKey('user1', encKey, encSecret);
+    const id1 = await insertUser('1');
+    await setBinanceKey(id1, encKey, encSecret);
 
     const fetchMock = vi
       .fn()
       .mockResolvedValue({ ok: true, json: async () => ({ orderId: 1 }) });
     vi.stubGlobal('fetch', fetchMock as any);
 
-    await createLimitOrder('user1', {
+    await createLimitOrder(id1, {
       symbol: 'BTCUSDT',
       side: 'BUY',
       quantity: 0.1,
@@ -53,15 +53,15 @@ describe('binance order helpers', () => {
     const secret = 'binSecret654321';
     const encKey = encrypt(key, process.env.KEY_PASSWORD!);
     const encSecret = encrypt(secret, process.env.KEY_PASSWORD!);
-    insertUser('user2');
-    setBinanceKey('user2', encKey, encSecret);
+    const id2 = await insertUser('2');
+    await setBinanceKey(id2, encKey, encSecret);
 
     const fetchMock = vi
       .fn()
       .mockResolvedValue({ ok: true, json: async () => ({ status: 'canceled' }) });
     vi.stubGlobal('fetch', fetchMock as any);
 
-    await cancelOrder('user2', { symbol: 'BTCUSDT', orderId: 42 });
+    await cancelOrder(id2, { symbol: 'BTCUSDT', orderId: 42 });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, options] = fetchMock.mock.calls[0];

--- a/backend/test/rateLimit.test.ts
+++ b/backend/test/rateLimit.test.ts
@@ -22,19 +22,19 @@ const endpoints: Endpoint[] = [
     setup: async () => {
       const { OAuth2Client } = await import('google-auth-library');
       vi.spyOn(OAuth2Client.prototype, 'verifyIdToken').mockResolvedValue({
-        getPayload: () => ({ sub: 'user1', email: 'user@example.com' }),
+        getPayload: () => ({ sub: '1', email: 'user@example.com' }),
       } as any);
     },
   },
   { name: 'agents', method: 'GET', url: '/api/agents/paginated', limit: RATE_LIMITS.RELAXED.max },
-  { name: 'api-keys', method: 'GET', url: '/api/users/u1/ai-key', limit: RATE_LIMITS.MODERATE.max },
+  { name: 'api-keys', method: 'GET', url: '/api/users/1/ai-key', limit: RATE_LIMITS.MODERATE.max },
   {
     name: 'binance-balance',
     method: 'GET',
-    url: '/api/users/u1/binance-balance',
+    url: '/api/users/1/binance-balance',
     limit: RATE_LIMITS.MODERATE.max,
   },
-  { name: 'models', method: 'GET', url: '/api/users/u1/models', limit: RATE_LIMITS.MODERATE.max },
+  { name: 'models', method: 'GET', url: '/api/users/1/models', limit: RATE_LIMITS.MODERATE.max },
   { name: 'twofa-status', method: 'GET', url: '/api/2fa/status', limit: RATE_LIMITS.MODERATE.max },
   { name: 'twofa-setup', method: 'GET', url: '/api/2fa/setup', limit: RATE_LIMITS.TIGHT.max },
 ];

--- a/backend/test/rebalance.test.ts
+++ b/backend/test/rebalance.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { FastifyBaseLogger } from 'fastify';
-import { clearExecutions, getExecutions } from './repos/executions.js';
+import { getExecutions } from './repos/executions.js';
 import { insertUser } from './repos/users.js';
 import { insertAgent } from './repos/agents.js';
 import { insertExecResult } from './repos/agent-exec-result.js';
@@ -16,7 +16,6 @@ import { createLimitOrder } from '../src/services/binance.js';
 describe('createRebalanceLimitOrder', () => {
   it('saves execution with status and exec result', async () => {
     const log = { info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
-    clearExecutions();
     const userId = await insertUser('1');
     const agent = await insertAgent({
       userId,
@@ -47,7 +46,7 @@ describe('createRebalanceLimitOrder', () => {
       execResultId,
     });
 
-    const row = getExecutions()[0];
+    const row = (await getExecutions())[0];
 
     expect(row.user_id).toBe(userId);
     expect(JSON.parse(row.planned_json)).toMatchObject({

--- a/backend/test/rebalance.test.ts
+++ b/backend/test/rebalance.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { FastifyBaseLogger } from 'fastify';
 import { clearExecutions, getExecutions } from './repos/executions.js';
+import { insertUser } from './repos/users.js';
+import { insertAgent } from './repos/agents.js';
+import { insertExecResult } from './repos/agent-exec-result.js';
 
 vi.mock('../src/services/binance.js', () => ({
   fetchPairData: vi.fn().mockResolvedValue({ currentPrice: 100 }),
@@ -14,8 +17,25 @@ describe('createRebalanceLimitOrder', () => {
   it('saves execution with status and exec result', async () => {
     const log = { info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
     clearExecutions();
+    const userId = await insertUser('1');
+    const agent = await insertAgent({
+      userId,
+      model: 'm',
+      status: 'active',
+      startBalance: null,
+      name: 'A',
+      tokenA: 'BTC',
+      tokenB: 'ETH',
+      minTokenAAllocation: 10,
+      minTokenBAllocation: 20,
+      risk: 'low',
+      reviewInterval: '1h',
+      agentInstructions: 'inst',
+      manualRebalance: false,
+    });
+    const execResultId = await insertExecResult({ agentId: agent.id, log: '' });
     await createRebalanceLimitOrder({
-      userId: 'user1',
+      userId,
       tokenA: 'BTC',
       tokenB: 'ETH',
       positions: [
@@ -24,12 +44,12 @@ describe('createRebalanceLimitOrder', () => {
       ],
       newAllocation: 50,
       log,
-      execResultId: 'res1',
+      execResultId,
     });
 
     const row = getExecutions()[0];
 
-    expect(row.user_id).toBe('user1');
+    expect(row.user_id).toBe(userId);
     expect(JSON.parse(row.planned_json)).toMatchObject({
       symbol: 'BTCETH',
       side: 'BUY',
@@ -37,8 +57,8 @@ describe('createRebalanceLimitOrder', () => {
       price: 100,
     });
     expect(row.status).toBe('pending');
-    expect(row.exec_result_id).toBe('res1');
-    expect(createLimitOrder).toHaveBeenCalledWith('user1', {
+    expect(row.exec_result_id).toBe(execResultId);
+    expect(createLimitOrder).toHaveBeenCalledWith(userId, {
       symbol: 'BTCETH',
       side: 'BUY',
       quantity: 0.5,

--- a/backend/test/repos/agent-exec-log.ts
+++ b/backend/test/repos/agent-exec-log.ts
@@ -9,10 +9,6 @@ export function insertExecLog(entry: any) {
   });
 }
 
-export async function clearAgentExecLog() {
-  await db.query('DELETE FROM agent_exec_log');
-}
-
 export async function getAgentExecResponses(agentId: string) {
   const { rows } = await db.query(
     'SELECT response FROM agent_exec_log WHERE agent_id = $1',

--- a/backend/test/repos/agent-exec-result.ts
+++ b/backend/test/repos/agent-exec-result.ts
@@ -11,7 +11,3 @@ export function insertExecResult(entry: any) {
     error: entry.error,
   });
 }
-
-export async function clearAgentExecResult() {
-  await db.query('DELETE FROM agent_exec_result');
-}

--- a/backend/test/repos/agents.ts
+++ b/backend/test/repos/agents.ts
@@ -9,10 +9,6 @@ import {
 export const insertAgent = insertAgentProd;
 export { startAgent, stopAgent, deleteAgent };
 
-export async function clearAgents() {
-  await db.query('DELETE FROM agents');
-}
-
 export async function setAgentStatus(id: string, status: string) {
   await db.query('UPDATE agents SET status = $1 WHERE id = $2', [status, id]);
 }

--- a/backend/test/repos/executions.ts
+++ b/backend/test/repos/executions.ts
@@ -1,9 +1,5 @@
 import { db } from '../../src/db/index.js';
 
-export async function clearExecutions() {
-  await db.query('DELETE FROM executions');
-}
-
 export async function getExecutions() {
   const { rows } = await db.query(
     'SELECT user_id, planned_json, status, exec_result_id FROM executions',

--- a/backend/test/repos/users.ts
+++ b/backend/test/repos/users.ts
@@ -23,10 +23,6 @@ export async function insertAdminUser(sub?: string, emailEnc?: string | null) {
   return id;
 }
 
-export async function clearUsers() {
-  await db.query('DELETE FROM users');
-}
-
 export async function getUserEmailEnc(id: string) {
   const { rows } = await db.query('SELECT email_enc FROM users WHERE id = $1', [id]);
   return rows[0] as { email_enc?: string } | undefined;

--- a/backend/test/repos/users.ts
+++ b/backend/test/repos/users.ts
@@ -4,25 +4,30 @@ import {
   setUserEmail,
   setUserEnabled,
 } from '../../src/repos/users.js';
+import { insertUserIdentity } from '../../src/repos/user-identities.js';
 
-export async function insertUser(_id?: string, emailEnc?: string | null) {
-  return insertUserProd(emailEnc ?? null);
+export async function insertUser(sub?: string, emailEnc?: string | null) {
+  const id = await insertUserProd(emailEnc ?? null);
+  if (sub) await insertUserIdentity(id, 'google', sub);
+  return id;
 }
 export { setUserEmail, setUserEnabled };
 
-export async function insertAdminUser(_id?: string, emailEnc?: string | null) {
+export async function insertAdminUser(sub?: string, emailEnc?: string | null) {
   const { rows } = await db.query(
     "INSERT INTO users (role, is_enabled, email_enc) VALUES ('admin', true, $1) RETURNING id",
     [emailEnc ?? null],
   );
-  return Number(rows[0].id);
+  const id = rows[0].id as string;
+  if (sub) await insertUserIdentity(id, 'google', sub);
+  return id;
 }
 
 export async function clearUsers() {
   await db.query('DELETE FROM users');
 }
 
-export async function getUserEmailEnc(id: number) {
+export async function getUserEmailEnc(id: string) {
   const { rows } = await db.query('SELECT email_enc FROM users WHERE id = $1', [id]);
   return rows[0] as { email_enc?: string } | undefined;
 }

--- a/backend/test/reviewPortfolio.test.ts
+++ b/backend/test/reviewPortfolio.test.ts
@@ -73,22 +73,22 @@ beforeAll(async () => {
 describe('reviewPortfolio', () => {
   it('passes last five responses to callRebalancingAgent', async () => {
     await db.query('INSERT INTO users (id, ai_api_key_enc) VALUES ($1, $2)', [
-      'u1',
+      '1',
       'enc',
     ]);
     await db.query(
       `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
        VALUES ($1, $2, 'gpt', 'active', 0, 'Agent', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
-      ['a1', 'u1'],
+      ['1', '1'],
     );
     for (let i = 0; i < 6; i++) {
       await db.query(
-        'INSERT INTO agent_exec_result (id, agent_id, log, rebalance, new_allocation, short_report, created_at) VALUES ($1, $2, $3, $4, $5, $6, $7)',
-        [`id${i}`, 'a1', 'ignore', 1, i, `short-${i}`, i],
+        'INSERT INTO agent_exec_result (agent_id, log, rebalance, new_allocation, short_report, created_at) VALUES ($1, $2, $3, $4, $5, $6)',
+        ['1', 'ignore', 1, i, `short-${i}`, i],
       );
     }
     const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
-    await reviewAgentPortfolio(log, 'a1');
+    await reviewAgentPortfolio(log, '1');
     expect(callRebalancingAgent).toHaveBeenCalledTimes(1);
     const args = (callRebalancingAgent as any).mock.calls[0];
     const prev = args[1].previous_responses.map((s: string) => JSON.parse(s));
@@ -123,19 +123,19 @@ describe('reviewPortfolio', () => {
     vi.mocked(callRebalancingAgent).mockClear();
     vi.mocked(callRebalancingAgent).mockResolvedValueOnce('ok');
     await db.query('INSERT INTO users (id, ai_api_key_enc) VALUES ($1, $2)', [
-      'u4',
+      '4',
       'enc',
     ]);
     await db.query(
       `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
        VALUES ($1, $2, 'gpt', 'active', 0, 'Agent4', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
-      ['a4', 'u4'],
+      ['4', '4'],
     );
     const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
-    await reviewAgentPortfolio(log, 'a4');
+    await reviewAgentPortfolio(log, '4');
     const { rows } = await db.query(
       'SELECT prompt, response FROM agent_exec_log WHERE agent_id = $1',
-      ['a4'],
+      ['4'],
     );
     const rowsTyped = rows as { prompt: string | null; response: string | null }[];
     expect(rowsTyped).toHaveLength(1);
@@ -156,7 +156,7 @@ describe('reviewPortfolio', () => {
 
     const { rows: parsedRowsRaw } = await db.query(
       'SELECT log, rebalance, new_allocation, short_report, error FROM agent_exec_result WHERE agent_id = $1',
-      ['a4'],
+      ['4'],
     );
     const parsedRows = parsedRowsRaw as {
       log: string;
@@ -196,19 +196,19 @@ describe('reviewPortfolio', () => {
     await db.query('DELETE FROM agent_exec_log');
     await db.query('DELETE FROM agent_exec_result');
     await db.query('INSERT INTO users (id, ai_api_key_enc) VALUES ($1, $2)', [
-      'u11',
+      '11',
       'enc',
     ]);
     await db.query(
       `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
        VALUES ($1, $2, 'gpt', 'active', 0, 'Agent11', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
-      ['a11', 'u11'],
+      ['11', '11'],
     );
     const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
-    await reviewAgentPortfolio(log, 'a11');
+    await reviewAgentPortfolio(log, '11');
     expect(createRebalanceLimitOrder).toHaveBeenCalledTimes(1);
     const args = vi.mocked(createRebalanceLimitOrder).mock.calls[0][0];
-    expect(args.userId).toBe('u11');
+    expect(args.userId).toBe('11');
     expect(args.tokenA).toBe('BTC');
     expect(args.tokenB).toBe('ETH');
     expect(args.newAllocation).toBe(60);
@@ -240,16 +240,16 @@ describe('reviewPortfolio', () => {
     await db.query('DELETE FROM agent_exec_log');
     await db.query('DELETE FROM agent_exec_result');
     await db.query('INSERT INTO users (id, ai_api_key_enc) VALUES ($1, $2)', [
-      'u12',
+      '12',
       'enc',
     ]);
     await db.query(
       `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions, manual_rebalance)
        VALUES ($1, $2, 'gpt', 'active', 0, 'Agent12', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst', 1)`,
-      ['a12', 'u12'],
+      ['12', '12'],
     );
     const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
-    await reviewAgentPortfolio(log, 'a12');
+    await reviewAgentPortfolio(log, '12');
     expect(createRebalanceLimitOrder).not.toHaveBeenCalled();
   });
 
@@ -264,16 +264,16 @@ describe('reviewPortfolio', () => {
       ],
     });
     await db.query('INSERT INTO users (id, ai_api_key_enc) VALUES ($1, $2)', [
-      'u5',
+      '5',
       'enc',
     ]);
     await db.query(
       `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
        VALUES ($1, $2, 'gpt', 'active', 0, 'Agent5', 'USDT', 'ETH', 10, 20, 'low', '1h', 'inst')`,
-      ['a5', 'u5'],
+      ['5', '5'],
     );
     const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
-    await reviewAgentPortfolio(log, 'a5');
+    await reviewAgentPortfolio(log, '5');
     expect(callRebalancingAgent).toHaveBeenCalledTimes(1);
     const args = (callRebalancingAgent as any).mock.calls[0];
     expect(args[1].marketData).toEqual({
@@ -293,20 +293,20 @@ describe('reviewPortfolio', () => {
       balances: [{ asset: 'BTC', free: '1', locked: '0' }],
     });
     await db.query('INSERT INTO users (id, ai_api_key_enc) VALUES ($1, $2)', [
-      'u2',
+      '2',
       'enc',
     ]);
     await db.query(
       `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
        VALUES ($1, $2, 'gpt', 'active', 0, 'Agent2', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
-      ['a2', 'u2'],
+      ['2', '2'],
     );
     const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
-    await reviewAgentPortfolio(log, 'a2');
+    await reviewAgentPortfolio(log, '2');
     expect(callRebalancingAgent).not.toHaveBeenCalled();
     const { rows } = await db.query(
       'SELECT response FROM agent_exec_log WHERE agent_id = $1',
-      ['a2'],
+      ['2'],
     );
     const rowsTyped = rows as { response: string | null }[];
     expect(rowsTyped).toHaveLength(1);
@@ -314,7 +314,7 @@ describe('reviewPortfolio', () => {
     expect(entry.error).toContain('failed to fetch token balances');
     const { rows: parsedRowsRaw } = await db.query(
       'SELECT log, error FROM agent_exec_result WHERE agent_id = $1',
-      ['a2'],
+      ['2'],
     );
     const parsedRows = parsedRowsRaw as { log: string; error: string | null }[];
     expect(parsedRows).toHaveLength(1);
@@ -331,20 +331,20 @@ describe('reviewPortfolio', () => {
     });
     vi.mocked(fetchPairData).mockRejectedValueOnce(new Error('fail'));
     await db.query('INSERT INTO users (id, ai_api_key_enc) VALUES ($1, $2)', [
-      'u3',
+      '3',
       'enc',
     ]);
     await db.query(
       `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
        VALUES ($1, $2, 'gpt', 'active', 0, 'Agent3', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
-      ['a3', 'u3'],
+      ['3', '3'],
     );
     const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
-    await reviewAgentPortfolio(log, 'a3');
+    await reviewAgentPortfolio(log, '3');
     expect(callRebalancingAgent).not.toHaveBeenCalled();
     const { rows } = await db.query(
       'SELECT response FROM agent_exec_log WHERE agent_id = $1',
-      ['a3'],
+      ['3'],
     );
     const rowsTyped = rows as { response: string | null }[];
     expect(rowsTyped).toHaveLength(1);
@@ -352,7 +352,7 @@ describe('reviewPortfolio', () => {
     expect(entry2.error).toContain('failed to fetch market data');
     const { rows: parsedRowsRaw } = await db.query(
       'SELECT log, error FROM agent_exec_result WHERE agent_id = $1',
-      ['a3'],
+      ['3'],
     );
     const parsedRows = parsedRowsRaw as { log: string; error: string | null }[];
     expect(parsedRows).toHaveLength(1);
@@ -367,18 +367,18 @@ describe('reviewPortfolio', () => {
     await db.query('DELETE FROM agents');
     await db.query('DELETE FROM users');
     await db.query('INSERT INTO users (id, ai_api_key_enc) VALUES ($1, $2)', [
-      'u6',
+      '6',
       'enc',
     ]);
     await db.query(
       `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
        VALUES ($1, $2, 'gpt', 'active', 0, 'Agent6', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
-      ['a6', 'u6'],
+      ['6', '6'],
     );
     await db.query(
       `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
        VALUES ($1, $2, 'gpt', 'active', 0, 'Agent7', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
-      ['a7', 'u6'],
+      ['7', '6'],
     );
     const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
     await reviewPortfolios(log, '1h'); // run for all 1h agents
@@ -395,18 +395,18 @@ describe('reviewPortfolio', () => {
     await db.query('DELETE FROM agent_exec_log');
     await db.query('DELETE FROM agent_exec_result');
     await db.query('INSERT INTO users (id, ai_api_key_enc) VALUES ($1, $2)', [
-      'u8',
+      '8',
       'enc',
     ]);
     await db.query(
       `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
        VALUES ($1, $2, 'gpt', 'active', 0, 'Agent9', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
-      ['a9', 'u8'],
+      ['9', '8'],
     );
     await db.query(
       `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
        VALUES ($1, $2, 'gpt', 'active', 0, 'Agent10', 'BTC', 'ETH', 10, 20, 'low', '3h', 'inst')`,
-      ['a10', 'u8'],
+      ['10', '8'],
     );
     const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
     await reviewPortfolios(log, '3h');
@@ -414,7 +414,7 @@ describe('reviewPortfolio', () => {
     const { rows } = await db.query('SELECT agent_id FROM agent_exec_log');
     const rowsTyped = rows as { agent_id: string }[];
     expect(rowsTyped).toHaveLength(1);
-    expect(rowsTyped[0].agent_id).toBe('a10');
+    expect(rowsTyped[0].agent_id).toBe('10');
   });
 
   it('prevents concurrent runs for same agent', async () => {
@@ -429,18 +429,18 @@ describe('reviewPortfolio', () => {
         }),
     );
     await db.query('INSERT INTO users (id, ai_api_key_enc) VALUES ($1, $2)', [
-      'u7',
+      '7',
       'enc',
     ]);
     await db.query(
       `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
        VALUES ($1, $2, 'gpt', 'active', 0, 'Agent8', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
-      ['a8', 'u7'],
+      ['8', '7'],
     );
     const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
-    const p1 = reviewAgentPortfolio(log, 'a8');
+    const p1 = reviewAgentPortfolio(log, '8');
     await new Promise((r) => setImmediate(r));
-    await expect(reviewAgentPortfolio(log, 'a8')).rejects.toThrow(
+    await expect(reviewAgentPortfolio(log, '8')).rejects.toThrow(
       'Agent is already reviewing portfolio',
     );
     resolveFn('ok');

--- a/backend/test/reviewPortfolio.test.ts
+++ b/backend/test/reviewPortfolio.test.ts
@@ -192,10 +192,6 @@ describe('reviewPortfolio', () => {
         ],
       }),
     );
-    await db.query('DELETE FROM agents');
-    await db.query('DELETE FROM users');
-    await db.query('DELETE FROM agent_exec_log');
-    await db.query('DELETE FROM agent_exec_result');
     await db.query('INSERT INTO users (id, ai_api_key_enc) VALUES ($1, $2)', [
       '11',
       'enc',
@@ -236,17 +232,13 @@ describe('reviewPortfolio', () => {
         ],
       }),
     );
-    await db.query('DELETE FROM agents');
-    await db.query('DELETE FROM users');
-    await db.query('DELETE FROM agent_exec_log');
-    await db.query('DELETE FROM agent_exec_result');
     await db.query('INSERT INTO users (id, ai_api_key_enc) VALUES ($1, $2)', [
       '12',
       'enc',
     ]);
     await db.query(
       `INSERT INTO agents (id, user_id, model, status, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions, manual_rebalance)
-       VALUES ($1, $2, 'gpt', 'active', 'Agent12', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst', 1)`,
+       VALUES ($1, $2, 'gpt', 'active', 'Agent12', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst', TRUE)`,
       ['12', '12'],
     );
     const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
@@ -365,8 +357,6 @@ describe('reviewPortfolio', () => {
     vi.mocked(fetchPairData).mockClear();
     vi.mocked(fetchTokenIndicators).mockClear();
     vi.mocked(fetchMarketTimeseries).mockClear();
-    await db.query('DELETE FROM agents');
-    await db.query('DELETE FROM users');
     await db.query('INSERT INTO users (id, ai_api_key_enc) VALUES ($1, $2)', [
       '6',
       'enc',
@@ -391,10 +381,6 @@ describe('reviewPortfolio', () => {
 
   it('runs only agents matching interval', async () => {
     vi.mocked(callRebalancingAgent).mockClear();
-    await db.query('DELETE FROM agents');
-    await db.query('DELETE FROM users');
-    await db.query('DELETE FROM agent_exec_log');
-    await db.query('DELETE FROM agent_exec_result');
     await db.query('INSERT INTO users (id, ai_api_key_enc) VALUES ($1, $2)', [
       '8',
       'enc',
@@ -420,8 +406,6 @@ describe('reviewPortfolio', () => {
 
   it('prevents concurrent runs for same agent', async () => {
     vi.mocked(callRebalancingAgent).mockClear();
-    await db.query('DELETE FROM agents');
-    await db.query('DELETE FROM users');
     let resolveFn!: (v: unknown) => void;
     vi.mocked(callRebalancingAgent).mockImplementation(
       () =>

--- a/backend/test/reviewPortfolio.test.ts
+++ b/backend/test/reviewPortfolio.test.ts
@@ -77,14 +77,15 @@ describe('reviewPortfolio', () => {
       'enc',
     ]);
     await db.query(
-      `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
-       VALUES ($1, $2, 'gpt', 'active', 0, 'Agent', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
+      `INSERT INTO agents (id, user_id, model, status, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
+       VALUES ($1, $2, 'gpt', 'active', 'Agent', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
       ['1', '1'],
     );
+    const base = new Date('2023-01-01T00:00:00Z');
     for (let i = 0; i < 6; i++) {
       await db.query(
         'INSERT INTO agent_exec_result (agent_id, log, rebalance, new_allocation, short_report, created_at) VALUES ($1, $2, $3, $4, $5, $6)',
-        ['1', 'ignore', 1, i, `short-${i}`, i],
+        ['1', 'ignore', 1, i, `short-${i}`, new Date(base.getTime() + i * 1000)],
       );
     }
     const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
@@ -127,8 +128,8 @@ describe('reviewPortfolio', () => {
       'enc',
     ]);
     await db.query(
-      `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
-       VALUES ($1, $2, 'gpt', 'active', 0, 'Agent4', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
+      `INSERT INTO agents (id, user_id, model, status, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
+       VALUES ($1, $2, 'gpt', 'active', 'Agent4', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
       ['4', '4'],
     );
     const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
@@ -200,8 +201,8 @@ describe('reviewPortfolio', () => {
       'enc',
     ]);
     await db.query(
-      `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
-       VALUES ($1, $2, 'gpt', 'active', 0, 'Agent11', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
+      `INSERT INTO agents (id, user_id, model, status, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
+       VALUES ($1, $2, 'gpt', 'active', 'Agent11', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
       ['11', '11'],
     );
     const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
@@ -244,8 +245,8 @@ describe('reviewPortfolio', () => {
       'enc',
     ]);
     await db.query(
-      `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions, manual_rebalance)
-       VALUES ($1, $2, 'gpt', 'active', 0, 'Agent12', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst', 1)`,
+      `INSERT INTO agents (id, user_id, model, status, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions, manual_rebalance)
+       VALUES ($1, $2, 'gpt', 'active', 'Agent12', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst', 1)`,
       ['12', '12'],
     );
     const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
@@ -268,8 +269,8 @@ describe('reviewPortfolio', () => {
       'enc',
     ]);
     await db.query(
-      `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
-       VALUES ($1, $2, 'gpt', 'active', 0, 'Agent5', 'USDT', 'ETH', 10, 20, 'low', '1h', 'inst')`,
+      `INSERT INTO agents (id, user_id, model, status, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
+       VALUES ($1, $2, 'gpt', 'active', 'Agent5', 'USDT', 'ETH', 10, 20, 'low', '1h', 'inst')`,
       ['5', '5'],
     );
     const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
@@ -297,8 +298,8 @@ describe('reviewPortfolio', () => {
       'enc',
     ]);
     await db.query(
-      `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
-       VALUES ($1, $2, 'gpt', 'active', 0, 'Agent2', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
+      `INSERT INTO agents (id, user_id, model, status, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
+       VALUES ($1, $2, 'gpt', 'active', 'Agent2', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
       ['2', '2'],
     );
     const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
@@ -335,8 +336,8 @@ describe('reviewPortfolio', () => {
       'enc',
     ]);
     await db.query(
-      `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
-       VALUES ($1, $2, 'gpt', 'active', 0, 'Agent3', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
+      `INSERT INTO agents (id, user_id, model, status, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
+       VALUES ($1, $2, 'gpt', 'active', 'Agent3', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
       ['3', '3'],
     );
     const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
@@ -371,13 +372,13 @@ describe('reviewPortfolio', () => {
       'enc',
     ]);
     await db.query(
-      `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
-       VALUES ($1, $2, 'gpt', 'active', 0, 'Agent6', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
+      `INSERT INTO agents (id, user_id, model, status, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
+       VALUES ($1, $2, 'gpt', 'active', 'Agent6', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
       ['6', '6'],
     );
     await db.query(
-      `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
-       VALUES ($1, $2, 'gpt', 'active', 0, 'Agent7', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
+      `INSERT INTO agents (id, user_id, model, status, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
+       VALUES ($1, $2, 'gpt', 'active', 'Agent7', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
       ['7', '6'],
     );
     const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
@@ -399,13 +400,13 @@ describe('reviewPortfolio', () => {
       'enc',
     ]);
     await db.query(
-      `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
-       VALUES ($1, $2, 'gpt', 'active', 0, 'Agent9', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
+      `INSERT INTO agents (id, user_id, model, status, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
+       VALUES ($1, $2, 'gpt', 'active', 'Agent9', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
       ['9', '8'],
     );
     await db.query(
-      `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
-       VALUES ($1, $2, 'gpt', 'active', 0, 'Agent10', 'BTC', 'ETH', 10, 20, 'low', '3h', 'inst')`,
+      `INSERT INTO agents (id, user_id, model, status, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
+       VALUES ($1, $2, 'gpt', 'active', 'Agent10', 'BTC', 'ETH', 10, 20, 'low', '3h', 'inst')`,
       ['10', '8'],
     );
     const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
@@ -433,8 +434,8 @@ describe('reviewPortfolio', () => {
       'enc',
     ]);
     await db.query(
-      `INSERT INTO agents (id, user_id, model, status, created_at, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
-       VALUES ($1, $2, 'gpt', 'active', 0, 'Agent8', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
+      `INSERT INTO agents (id, user_id, model, status, name, token_a, token_b, min_a_allocation, min_b_allocation, risk, review_interval, agent_instructions)
+       VALUES ($1, $2, 'gpt', 'active', 'Agent8', 'BTC', 'ETH', 10, 20, 'low', '1h', 'inst')`,
       ['8', '7'],
     );
     const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;

--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -1,8 +1,14 @@
-import { beforeEach, afterAll } from 'vitest';
+import { beforeAll, beforeEach, afterAll } from 'vitest';
 import { db, migrate } from '../src/db/index.js';
 
-beforeEach(async () => {
+beforeAll(async () => {
   await migrate();
+});
+
+beforeEach(async () => {
+  await db.query(
+    'TRUNCATE TABLE agent_exec_log, agent_exec_result, executions, agents, user_identities, users RESTART IDENTITY CASCADE',
+  );
 });
 
 afterAll(async () => {

--- a/backend/test/twofa.test.ts
+++ b/backend/test/twofa.test.ts
@@ -5,13 +5,13 @@ import { insertUser } from './repos/users.js';
 
 describe('2fa routes', () => {
   it('enables and disables 2fa', async () => {
-    insertUser('user1');
+    const userId = await insertUser('1');
     const app = await buildServer();
 
     const setupRes = await app.inject({
       method: 'GET',
       url: '/api/2fa/setup',
-      headers: { 'x-user-id': 'user1' },
+      headers: { 'x-user-id': userId },
     });
     expect(setupRes.statusCode).toBe(200);
     const { secret } = setupRes.json() as { secret: string };
@@ -20,7 +20,7 @@ describe('2fa routes', () => {
     const enableRes = await app.inject({
       method: 'POST',
       url: '/api/2fa/enable',
-      headers: { 'x-user-id': 'user1' },
+      headers: { 'x-user-id': userId },
       payload: { token, secret },
     });
     expect(enableRes.statusCode).toBe(200);
@@ -28,14 +28,14 @@ describe('2fa routes', () => {
     const statusRes = await app.inject({
       method: 'GET',
       url: '/api/2fa/status',
-      headers: { 'x-user-id': 'user1' },
+      headers: { 'x-user-id': userId },
     });
     expect(statusRes.json()).toEqual({ enabled: true });
 
     const disableRes = await app.inject({
       method: 'POST',
       url: '/api/2fa/disable',
-      headers: { 'x-user-id': 'user1' },
+      headers: { 'x-user-id': userId },
       payload: { token: authenticator.generate(secret) },
     });
     expect(disableRes.statusCode).toBe(200);
@@ -43,7 +43,7 @@ describe('2fa routes', () => {
     const statusRes2 = await app.inject({
       method: 'GET',
       url: '/api/2fa/status',
-      headers: { 'x-user-id': 'user1' },
+      headers: { 'x-user-id': userId },
     });
     expect(statusRes2.json()).toEqual({ enabled: false });
 

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -9,5 +9,8 @@ export default defineConfig({
     environment: 'node',
     exclude: ['frontend/**', 'node_modules/**', 'dist/**'],
     setupFiles: ['test/setup.ts'],
+    // Tests share a single PostgreSQL instance; run sequentially to avoid
+    // cross-test state leaks.
+    fileParallelism: false,
   },
 });


### PR DESCRIPTION
## Summary
- add user_identities table for external provider identities
- treat IDs as strings throughout backend and tests
- adjust login and auth to use user identities
- replace old sqlite-style dummy IDs in tests with numeric strings

## Testing
- `npm test` *(fails: Cannot find package 'pg')*
- `npm run build` *(fails: Cannot find module 'pg')*


------
https://chatgpt.com/codex/tasks/task_e_68afc78ad1b8832ca29234edb5d586fd