### PR TITLE
Clarify floor config as percentages

### DIFF
--- a/backend/src/jobs/review-portfolio.ts
+++ b/backend/src/jobs/review-portfolio.ts
@@ -178,7 +178,7 @@ async function buildPrompt(
       tsA,
       tsB,
     } = await fetchPromptData(row, cache);
-    const { floors, positions, weights } = computePortfolioValues(
+    const { floorPercents, positions, weights } = computePortfolioValues(
       row,
       balances,
       priceA,
@@ -187,7 +187,7 @@ async function buildPrompt(
     return {
       instructions: row.agent_instructions,
       config: {
-        policy: { floors },
+        policy: { floorPercents },
         portfolio: {
           ts: new Date().toISOString(),
           positions,
@@ -280,9 +280,9 @@ function computePortfolioValues(
   const valueA = balances.tokenABalance * priceA;
   const valueB = balances.tokenBBalance * priceB;
   const totalValue = valueA + valueB;
-  const floors: Record<string, number> = {
-    [row.token_a]: row.min_a_allocation / 100,
-    [row.token_b]: row.min_b_allocation / 100,
+  const floorPercents: Record<string, number> = {
+    [row.token_a]: row.min_a_allocation,
+    [row.token_b]: row.min_b_allocation,
   };
   const positions = [
     {
@@ -302,7 +302,7 @@ function computePortfolioValues(
     [row.token_a]: totalValue ? valueA / totalValue : 0,
     [row.token_b]: totalValue ? valueB / totalValue : 0,
   };
-  return { floors, positions, weights };
+  return { floorPercents, positions, weights };
 }
 
 function assembleMarketData(

--- a/backend/src/util/ai.ts
+++ b/backend/src/util/ai.ts
@@ -19,7 +19,7 @@ export interface RebalancePosition {
 export interface RebalancePrompt {
   instructions: string;
   config: {
-    policy: { floors: Record<string, number> };
+    policy: { floorPercents: Record<string, number> };
     portfolio: {
       ts: string;
       positions: RebalancePosition[];

--- a/backend/test/callRebalancingAgent.test.ts
+++ b/backend/test/callRebalancingAgent.test.ts
@@ -10,7 +10,7 @@ describe('callRebalancingAgent structured output', () => {
     const prompt: RebalancePrompt = {
       instructions: 'inst',
       config: {
-        policy: { floors: { USDT: 0.2 } },
+        policy: { floorPercents: { USDT: 20 } },
         portfolio: {
           ts: new Date().toISOString(),
           positions: [

--- a/backend/test/reviewPortfolio.test.ts
+++ b/backend/test/reviewPortfolio.test.ts
@@ -105,7 +105,7 @@ describe('reviewPortfolio', () => {
     const ethPos = cfg.portfolio.positions.find((p: any) => p.sym === 'ETH');
     expect(btcPos.qty).toBe(1.5);
     expect(ethPos.qty).toBe(2);
-    expect(cfg.policy.floors).toEqual({ BTC: 0.1, ETH: 0.2 });
+    expect(cfg.policy.floorPercents).toEqual({ BTC: 10, ETH: 20 });
     expect(cfg.portfolio.weights.BTC).toBeCloseTo(150 / 350);
     expect(cfg.portfolio.weights.ETH).toBeCloseTo(200 / 350);
     expect(args[1].marketData).toEqual({
@@ -143,7 +143,7 @@ describe('reviewPortfolio', () => {
     expect(JSON.parse(rowsTyped[0].prompt!)).toMatchObject({
       instructions: 'inst',
       config: {
-        policy: { floors: { BTC: 0.1, ETH: 0.2 } },
+        policy: { floorPercents: { BTC: 10, ETH: 20 } },
         portfolio: {
           positions: [
             expect.objectContaining({ sym: 'BTC', qty: 1.5 }),


### PR DESCRIPTION
## Summary
- rename `floors` config to `floorPercents` to make units explicit
- send policy floors as whole percentages instead of decimals
- adjust tests to reflect new naming and values

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b053133844832ca9521c22e07c7213