### PR TITLE
feat: add rebalance filter for exec logs

### DIFF
--- a/backend/src/repos/agent-review-result.ts
+++ b/backend/src/repos/agent-review-result.ts
@@ -42,13 +42,19 @@ export async function getRecentReviewResults(agentId: string, limit: number) {
   }));
 }
 
-export async function getAgentReviewResults(agentId: string, limit: number, offset: number) {
+export async function getAgentReviewResults(
+  agentId: string,
+  limit: number,
+  offset: number,
+  rebalanceOnly = false,
+) {
+  const filter = rebalanceOnly ? ' AND rebalance IS TRUE' : '';
   const totalRes = await db.query(
-    'SELECT COUNT(*) as count FROM agent_review_result WHERE agent_id = $1',
+    `SELECT COUNT(*) as count FROM agent_review_result WHERE agent_id = $1${filter}`,
     [agentId],
   );
   const { rows } = await db.query(
-    'SELECT id, log, rebalance, new_allocation, short_report, error, created_at FROM agent_review_result WHERE agent_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3',
+    `SELECT id, log, rebalance, new_allocation, short_report, error, created_at FROM agent_review_result WHERE agent_id = $1${filter} ORDER BY created_at DESC LIMIT $2 OFFSET $3`,
     [agentId, limit, offset],
   );
   return { rows: rows as any[], total: Number(totalRes.rows[0].count) };

--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -127,14 +127,16 @@ export default async function agentRoutes(app: FastifyInstance) {
       const ctx = await getAgentForRequest(req, reply);
       if (!ctx) return;
       const { id, log } = ctx;
-      const { page = '1', pageSize = '10' } = req.query as {
+      const { page = '1', pageSize = '10', rebalanceOnly } = req.query as {
         page?: string;
         pageSize?: string;
+        rebalanceOnly?: string;
       };
       const p = Math.max(parseInt(page, 10), 1);
       const ps = Math.max(parseInt(pageSize, 10), 1);
       const offset = (p - 1) * ps;
-      const { rows, total } = await getAgentReviewResults(id, ps, offset);
+      const ro = rebalanceOnly === 'true';
+      const { rows, total } = await getAgentReviewResults(id, ps, offset, ro);
       log.info('fetched exec log');
       return {
         items: rows.map((r) => {

--- a/frontend/src/components/ui/Toggle.tsx
+++ b/frontend/src/components/ui/Toggle.tsx
@@ -1,0 +1,22 @@
+import type { ChangeEvent } from 'react';
+
+interface ToggleProps {
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+export default function Toggle({ label, checked, onChange }: ToggleProps) {
+  return (
+    <label className="flex items-center gap-1 text-sm cursor-pointer">
+      <span>{label}</span>
+      <input
+        type="checkbox"
+        className="sr-only peer"
+        checked={checked}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.checked)}
+      />
+      <div className="ml-2 relative w-10 h-5 bg-gray-200 rounded-full peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-5 peer-checked:after:border-white" />
+    </label>
+  );
+}

--- a/frontend/src/routes/AgentView.tsx
+++ b/frontend/src/routes/AgentView.tsx
@@ -14,6 +14,7 @@ import FormattedDate from '../components/ui/FormattedDate';
 import AgentUpdateModal from '../components/AgentUpdateModal';
 import AgentDetailsDesktop from '../components/AgentDetailsDesktop';
 import AgentDetailsMobile from '../components/AgentDetailsMobile';
+import Toggle from '../components/ui/Toggle';
 
 export default function AgentView() {
   const { id } = useParams();
@@ -41,11 +42,12 @@ export default function AgentView() {
   const [showUpdate, setShowUpdate] = useState(false);
 
   const [logPage, setLogPage] = useState(1);
+  const [onlyRebalance, setOnlyRebalance] = useState(false);
   const { data: logData } = useQuery({
-    queryKey: ['agent-log', id, logPage, user?.id],
+    queryKey: ['agent-log', id, logPage, user?.id, onlyRebalance],
     queryFn: async () => {
       const res = await api.get(`/agents/${id}/exec-log`, {
-        params: { page: logPage, pageSize: 10 },
+        params: { page: logPage, pageSize: 10, rebalanceOnly: onlyRebalance },
       });
       return res.data as {
         items: ExecLog[];
@@ -101,7 +103,14 @@ export default function AgentView() {
         )}
         {logData && (
             <div className="mt-6">
-              <h2 className="text-xl font-bold mb-2">Execution Log</h2>
+              <div className="flex items-center justify-between mb-2">
+                <h2 className="text-xl font-bold">Execution Log</h2>
+                <Toggle
+                  label="Only Rebalances"
+                  checked={onlyRebalance}
+                  onChange={setOnlyRebalance}
+                />
+              </div>
               {logData.items.length === 0 ? (
                   <p>No logs yet.</p>
               ) : (

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -14,6 +14,7 @@ import CreateAgentForm from '../components/forms/CreateAgentForm';
 import PriceChart from '../components/forms/PriceChart';
 import ErrorBoundary from '../components/ErrorBoundary';
 import { useToast } from '../lib/useToast';
+import Toggle from '../components/ui/Toggle';
 
 interface Agent {
   id: string;
@@ -271,16 +272,11 @@ export default function Dashboard() {
         <div className="bg-white shadow-md border border-gray-200 rounded p-6 w-full">
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-xl font-bold">My Agents</h2>
-            <label className="flex items-center gap-1 text-sm cursor-pointer">
-              <span>Only Active</span>
-              <input
-                type="checkbox"
-                className="sr-only peer"
-                checked={onlyActive}
-                onChange={(e) => setOnlyActive(e.target.checked)}
-              />
-              <div className="ml-2 relative w-10 h-5 bg-gray-200 rounded-full peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-5 peer-checked:after:border-white" />
-            </label>
+            <Toggle
+              label="Only Active"
+              checked={onlyActive}
+              onChange={setOnlyActive}
+            />
           </div>
           {!user ? (
             <p>Please log in to view your agents.</p>


### PR DESCRIPTION
## Summary
- add reusable toggle component
- allow execution log filtering by rebalance
- support rebalance filter on dashboard and backend API

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68b667249e84832cac02f62b959a802e