### PR TITLE
Remove unused React import causing build failure

### DIFF
--- a/frontend/src/components/ExecTxCard.tsx
+++ b/frontend/src/components/ExecTxCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { LimitOrder } from '../lib/types';
 
 interface Props {


### PR DESCRIPTION
## Summary
- fix ExecTxCard component by dropping unused React import that broke TypeScript build

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba5de43594832cba52811ff8510740