### PR TITLE
feat: add manual rebalance confirmation

### DIFF
--- a/backend/test/agentExecLog.test.ts
+++ b/backend/test/agentExecLog.test.ts
@@ -272,12 +272,62 @@ describe('agent exec log routes', () => {
       [reviewResultId],
     );
     expect(rows).toHaveLength(1);
+    expect(JSON.parse(rows[0].planned_json)).toMatchObject({ price: 99.9 });
     res = await app.inject({
       method: 'POST',
       url: `/api/agents/${agent.id}/exec-log/${reviewResultId}/rebalance`,
       headers: { 'x-user-id': userId },
     });
     expect(res.statusCode).toBe(400);
+    vi.restoreAllMocks();
+    await app.close();
+  });
+
+  it('previews manual rebalance order', async () => {
+    const app = await buildServer();
+    const userId = await insertUser('21');
+    const agent = await insertAgent({
+      userId,
+      model: 'gpt',
+      status: 'active',
+      startBalance: null,
+      name: 'A',
+      tokens: [
+        { token: 'BTC', minAllocation: 10 },
+        { token: 'ETH', minAllocation: 20 },
+      ],
+      risk: 'low',
+      reviewInterval: '1h',
+      agentInstructions: 'inst',
+      manualRebalance: true,
+    });
+    const reviewResultId = await insertReviewResult({
+      agentId: agent.id,
+      log: '',
+      rebalance: true,
+      newAllocation: 60,
+    });
+    vi.spyOn(binance, 'fetchAccount').mockResolvedValue({
+      balances: [
+        { asset: 'BTC', free: '1', locked: '0' },
+        { asset: 'ETH', free: '1', locked: '0' },
+      ],
+    } as any);
+    vi.spyOn(binance, 'fetchPairData').mockResolvedValue({
+      currentPrice: 100,
+    } as any);
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/agents/${agent.id}/exec-log/${reviewResultId}/rebalance/preview`,
+      headers: { 'x-user-id': userId },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.order).toMatchObject({
+      side: 'BUY',
+      quantity: 0.2,
+      price: 99.9,
+    });
     vi.restoreAllMocks();
     await app.close();
   });

--- a/backend/test/rebalance.test.ts
+++ b/backend/test/rebalance.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { FastifyBaseLogger } from 'fastify';
 import { getLimitOrders } from './repos/limit-orders.js';
 import { insertUser } from './repos/users.js';
 import { insertAgent } from './repos/agents.js';
 import { insertReviewResult } from './repos/agent-review-result.js';
+import { db } from '../src/db/index.js';
 
 vi.mock('../src/services/binance.js', () => ({
   fetchPairData: vi.fn().mockResolvedValue({ currentPrice: 100 }),
@@ -14,6 +15,9 @@ import { createRebalanceLimitOrder } from '../src/services/rebalance.js';
 import { createLimitOrder } from '../src/services/binance.js';
 
 describe('createRebalanceLimitOrder', () => {
+  beforeEach(async () => {
+    await db.query('TRUNCATE limit_order RESTART IDENTITY CASCADE');
+  });
   it('saves execution with status and exec result', async () => {
     const log = { info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
     const userId = await insertUser('1');
@@ -52,7 +56,8 @@ describe('createRebalanceLimitOrder', () => {
       symbol: 'BTCETH',
       side: 'BUY',
       quantity: 0.5,
-      price: 100,
+      price: 99.9,
+      manuallyEdited: false,
     });
     expect(row.status).toBe('open');
     expect(row.review_result_id).toBe(reviewResultId);
@@ -61,7 +66,50 @@ describe('createRebalanceLimitOrder', () => {
       symbol: 'BTCETH',
       side: 'BUY',
       quantity: 0.5,
-      price: 100,
+      price: 99.9,
+    });
+  });
+
+  it('allows manual overrides and sets flag', async () => {
+    const log = { info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
+    const userId = await insertUser('2');
+    const agent = await insertAgent({
+      userId,
+      model: 'm',
+      status: 'active',
+      startBalance: null,
+      name: 'A',
+      tokens: [
+        { token: 'BTC', minAllocation: 10 },
+        { token: 'ETH', minAllocation: 20 },
+      ],
+      risk: 'low',
+      reviewInterval: '1h',
+      agentInstructions: 'inst',
+      manualRebalance: false,
+    });
+    const reviewResultId = await insertReviewResult({ agentId: agent.id, log: '' });
+    await createRebalanceLimitOrder({
+      userId,
+      tokens: ['BTC', 'ETH'],
+      positions: [
+        { sym: 'BTC', value_usdt: 50 },
+        { sym: 'ETH', value_usdt: 150 },
+      ],
+      newAllocation: 50,
+      log,
+      reviewResultId,
+      price: 120,
+      quantity: 0.3,
+      manuallyEdited: true,
+    });
+    const row = (await getLimitOrders())[0];
+    expect(JSON.parse(row.planned_json)).toMatchObject({
+      symbol: 'BTCETH',
+      side: 'BUY',
+      quantity: 0.3,
+      price: 120,
+      manuallyEdited: true,
     });
   });
 });

--- a/frontend/src/routes/AgentView.tsx
+++ b/frontend/src/routes/AgentView.tsx
@@ -137,6 +137,7 @@ export default function AgentView() {
                                 log={log}
                                 agentId={id!}
                                 manualRebalance={data.manualRebalance}
+                                tokens={data.tokens.map((t) => t.token)}
                               />
                             </td>
                           </tr>
@@ -153,6 +154,7 @@ export default function AgentView() {
                             log={log}
                             agentId={id!}
                             manualRebalance={data.manualRebalance}
+                            tokens={data.tokens.map((t) => t.token)}
                           />
                         </div>
                       ))}


### PR DESCRIPTION
## Summary
- prompt manual rebalancing with a confirmation dialog including quantity and price
- compute limit order defaults with 0.1% better price and allow manual overrides
- preview rebalance orders via new endpoint and flag manually edited orders

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test` *(fails: connect ECONNREFUSED)*
- `npm --prefix backend run build`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba6c4c46c8832c9b8b9010ad0d0951