### PR TITLE
Enforce user ownership for API key routes

### DIFF
--- a/backend/src/routes/api-keys.ts
+++ b/backend/src/routes/api-keys.ts
@@ -16,6 +16,7 @@ import {
 import { removeAgentFromSchedule } from '../jobs/review-portfolio.js';
 import { cancelOpenOrders } from '../services/binance.js';
 import { redactKey } from '../util/redact.js';
+import { requireUserIdMatch } from '../util/auth.js';
 import {
   ApiKeyType,
   verifyApiKey,
@@ -33,6 +34,7 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
     { config: { rateLimit: RATE_LIMITS.TIGHT } },
     async (req, reply) => {
       const id = (req.params as any).id as string;
+      if (!requireUserIdMatch(req, reply, id)) return;
       const { key } = req.body as { key: string };
       const row = await getAiKeyRow(id);
       let err = ensureUser(row);
@@ -52,6 +54,7 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
     { config: { rateLimit: RATE_LIMITS.MODERATE } },
     async (req, reply) => {
       const id = (req.params as any).id as string;
+      if (!requireUserIdMatch(req, reply, id)) return;
       const row = await getAiKeyRow(id);
       const err = ensureKeyPresent(row, ['ai_api_key_enc']);
       if (err) return reply.code(err.code).send(err.body);
@@ -65,6 +68,7 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
     { config: { rateLimit: RATE_LIMITS.TIGHT } },
     async (req, reply) => {
       const id = (req.params as any).id as string;
+      if (!requireUserIdMatch(req, reply, id)) return;
       const { key } = req.body as { key: string };
       const row = await getAiKeyRow(id);
       const err = ensureKeyPresent(row, ['ai_api_key_enc']);
@@ -82,6 +86,7 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
     { config: { rateLimit: RATE_LIMITS.VERY_TIGHT } },
     async (req, reply) => {
       const id = (req.params as any).id as string;
+      if (!requireUserIdMatch(req, reply, id)) return;
       const row = await getAiKeyRow(id);
       const err = ensureKeyPresent(row, ['ai_api_key_enc']);
       if (err) return reply.code(err.code).send(err.body);
@@ -109,6 +114,7 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
     { config: { rateLimit: RATE_LIMITS.TIGHT } },
     async (req, reply) => {
       const id = (req.params as any).id as string;
+      if (!requireUserIdMatch(req, reply, id)) return;
       const { key, secret } = req.body as { key: string; secret: string };
       const row = await getBinanceKeyRow(id);
       let err = ensureUser(row);
@@ -129,6 +135,7 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
     { config: { rateLimit: RATE_LIMITS.MODERATE } },
     async (req, reply) => {
       const id = (req.params as any).id as string;
+      if (!requireUserIdMatch(req, reply, id)) return;
       const row = await getBinanceKeyRow(id);
       const err = ensureKeyPresent(row, [
         'binance_api_key_enc',
@@ -146,6 +153,7 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
     { config: { rateLimit: RATE_LIMITS.TIGHT } },
     async (req, reply) => {
       const id = (req.params as any).id as string;
+      if (!requireUserIdMatch(req, reply, id)) return;
       const { key, secret } = req.body as { key: string; secret: string };
       const row = await getBinanceKeyRow(id);
       const err = ensureKeyPresent(row, [
@@ -167,6 +175,7 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
     { config: { rateLimit: RATE_LIMITS.VERY_TIGHT } },
     async (req, reply) => {
       const id = (req.params as any).id as string;
+      if (!requireUserIdMatch(req, reply, id)) return;
       const row = await getBinanceKeyRow(id);
       const err = ensureKeyPresent(row, [
         'binance_api_key_enc',

--- a/backend/test/apiKeys.test.ts
+++ b/backend/test/apiKeys.test.ts
@@ -41,6 +41,7 @@ describe('AI API key routes', () => {
     let res = await app.inject({
       method: 'POST',
       url: `/api/users/${userId}/ai-key`,
+      headers: { 'x-user-id': userId },
       payload: { key: 'bad' },
     });
     expect(res.statusCode).toBe(400);
@@ -52,6 +53,7 @@ describe('AI API key routes', () => {
     res = await app.inject({
       method: 'POST',
       url: `/api/users/${userId}/ai-key`,
+      headers: { 'x-user-id': userId },
       payload: { key: key1 },
     });
     expect(res.statusCode).toBe(200);
@@ -59,13 +61,18 @@ describe('AI API key routes', () => {
     row = await getAiKeyRow(userId);
     expect(row!.ai_api_key_enc).not.toBe(key1);
 
-    res = await app.inject({ method: 'GET', url: `/api/users/${userId}/ai-key` });
+    res = await app.inject({
+      method: 'GET',
+      url: `/api/users/${userId}/ai-key`,
+      headers: { 'x-user-id': userId },
+    });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ key: 'aike...7890' });
 
     res = await app.inject({
       method: 'POST',
       url: `/api/users/${userId}/ai-key`,
+      headers: { 'x-user-id': userId },
       payload: { key: 'dup' },
     });
     expect(res.statusCode).toBe(400);
@@ -74,30 +81,55 @@ describe('AI API key routes', () => {
     res = await app.inject({
       method: 'PUT',
       url: `/api/users/${userId}/ai-key`,
+      headers: { 'x-user-id': userId },
       payload: { key: 'bad2' },
     });
     expect(res.statusCode).toBe(400);
     expect(res.json()).toMatchObject({ error: 'verification failed' });
-    res = await app.inject({ method: 'GET', url: `/api/users/${userId}/ai-key` });
+    res = await app.inject({
+      method: 'GET',
+      url: `/api/users/${userId}/ai-key`,
+      headers: { 'x-user-id': userId },
+    });
     expect(res.json()).toMatchObject({ key: 'aike...7890' });
 
     fetchMock.mockResolvedValueOnce({ ok: true } as any);
     res = await app.inject({
       method: 'PUT',
       url: `/api/users/${userId}/ai-key`,
+      headers: { 'x-user-id': userId },
       payload: { key: key2 },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ key: 'aike...ghij' });
 
-    res = await app.inject({ method: 'DELETE', url: `/api/users/${userId}/ai-key` });
+    res = await app.inject({
+      method: 'DELETE',
+      url: `/api/users/${userId}/ai-key`,
+      headers: { 'x-user-id': userId },
+    });
     expect(res.statusCode).toBe(200);
 
-    res = await app.inject({ method: 'GET', url: `/api/users/${userId}/ai-key` });
+    res = await app.inject({
+      method: 'GET',
+      url: `/api/users/${userId}/ai-key`,
+      headers: { 'x-user-id': userId },
+    });
     expect(res.statusCode).toBe(404);
 
     await app.close();
     (globalThis as any).fetch = originalFetch;
+  });
+
+  it("forbids accessing another user's ai key", async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/users/999/ai-key',
+      headers: { 'x-user-id': '1' },
+    });
+    expect(res.statusCode).toBe(403);
+    await app.close();
   });
 });
 
@@ -119,6 +151,7 @@ describe('Binance API key routes', () => {
     let res = await app.inject({
       method: 'POST',
       url: `/api/users/${userId}/binance-key`,
+      headers: { 'x-user-id': userId },
       payload: { key: 'bad', secret: 'bad' },
     });
     expect(res.statusCode).toBe(400);
@@ -131,6 +164,7 @@ describe('Binance API key routes', () => {
     res = await app.inject({
       method: 'POST',
       url: `/api/users/${userId}/binance-key`,
+      headers: { 'x-user-id': userId },
       payload: { key: key1, secret: secret1 },
     });
     expect(res.statusCode).toBe(200);
@@ -142,7 +176,11 @@ describe('Binance API key routes', () => {
     expect(row!.binance_api_key_enc).not.toBe(key1);
     expect(row!.binance_api_secret_enc).not.toBe(secret1);
 
-    res = await app.inject({ method: 'GET', url: `/api/users/${userId}/binance-key` });
+    res = await app.inject({
+      method: 'GET',
+      url: `/api/users/${userId}/binance-key`,
+      headers: { 'x-user-id': userId },
+    });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({
       key: 'bkey...7890',
@@ -152,6 +190,7 @@ describe('Binance API key routes', () => {
     res = await app.inject({
       method: 'POST',
       url: `/api/users/${userId}/binance-key`,
+      headers: { 'x-user-id': userId },
       payload: { key: 'dup', secret: 'dup' },
     });
     expect(res.statusCode).toBe(400);
@@ -160,11 +199,16 @@ describe('Binance API key routes', () => {
     res = await app.inject({
       method: 'PUT',
       url: `/api/users/${userId}/binance-key`,
+      headers: { 'x-user-id': userId },
       payload: { key: 'bad2', secret: 'bad2' },
     });
     expect(res.statusCode).toBe(400);
     expect(res.json()).toMatchObject({ error: 'verification failed' });
-    res = await app.inject({ method: 'GET', url: `/api/users/${userId}/binance-key` });
+    res = await app.inject({
+      method: 'GET',
+      url: `/api/users/${userId}/binance-key`,
+      headers: { 'x-user-id': userId },
+    });
     expect(res.json()).toMatchObject({
       key: 'bkey...7890',
       secret: 'bsec...7890',
@@ -174,6 +218,7 @@ describe('Binance API key routes', () => {
     res = await app.inject({
       method: 'PUT',
       url: `/api/users/${userId}/binance-key`,
+      headers: { 'x-user-id': userId },
       payload: { key: key2, secret: secret2 },
     });
     expect(res.statusCode).toBe(200);
@@ -182,14 +227,33 @@ describe('Binance API key routes', () => {
       secret: 'bsec...ghij',
     });
 
-    res = await app.inject({ method: 'DELETE', url: `/api/users/${userId}/binance-key` });
+    res = await app.inject({
+      method: 'DELETE',
+      url: `/api/users/${userId}/binance-key`,
+      headers: { 'x-user-id': userId },
+    });
     expect(res.statusCode).toBe(200);
 
-    res = await app.inject({ method: 'GET', url: `/api/users/${userId}/binance-key` });
+    res = await app.inject({
+      method: 'GET',
+      url: `/api/users/${userId}/binance-key`,
+      headers: { 'x-user-id': userId },
+    });
     expect(res.statusCode).toBe(404);
 
     await app.close();
     (globalThis as any).fetch = originalFetch;
+  });
+
+  it("forbids accessing another user's binance key", async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/users/999/binance-key',
+      headers: { 'x-user-id': '1' },
+    });
+    expect(res.statusCode).toBe(403);
+    await app.close();
   });
 });
 
@@ -225,6 +289,7 @@ describe('key deletion effects on agents', () => {
     const res = await app.inject({
       method: 'DELETE',
       url: `/api/users/${userId}/binance-key`,
+      headers: { 'x-user-id': userId },
     });
     expect(res.statusCode).toBe(200);
     const row = await db.query('SELECT status FROM agents WHERE id = $1', [
@@ -263,6 +328,7 @@ describe('key deletion effects on agents', () => {
     const res = await app.inject({
       method: 'DELETE',
       url: `/api/users/${userId}/ai-key`,
+      headers: { 'x-user-id': userId },
     });
     expect(res.statusCode).toBe(200);
     const row = await db.query('SELECT status, model FROM agents WHERE id = $1', [


### PR DESCRIPTION
## Summary
- require user ID match for all AI and Binance API key routes
- test that only key owners can manage AI and Binance keys

## Testing
- ⚠️ `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test` (failed: connect ECONNREFUSED)
- ✅ `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68bab4ca4e30832cae69a8dcff9f0d62