### PR TITLE
feat: add security headers

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,6 +1,13 @@
 {$DOMAIN} {
     encode gzip zstd
 
+    header {
+        Strict-Transport-Security "max-age=31536000; includeSubDomains"
+        X-Content-Type-Options "nosniff"
+        Referrer-Policy "no-referrer"
+        Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self' data:; frame-ancestors 'none'"
+    }
+
     @api path /api* /healthz
     handle @api {
         reverse_proxy backend:3000

--- a/Caddyfile
+++ b/Caddyfile
@@ -5,7 +5,7 @@
         Strict-Transport-Security "max-age=31536000; includeSubDomains"
         X-Content-Type-Options "nosniff"
         Referrer-Policy "no-referrer"
-        Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self' data:; frame-ancestors 'none'"
+        Content-Security-Policy "default-src 'self'; script-src 'self' https://accounts.google.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self' data:; frame-ancestors 'none'"
     }
 
     @api path /api* /healthz

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@fastify/cookie": "^9.4.0",
+        "@fastify/helmet": "^11.1.1",
         "@fastify/rate-limit": "^8.1.1",
         "dotenv": "^16.6.1",
         "fastify": "^4.24.3",
@@ -508,6 +509,16 @@
       "license": "MIT",
       "dependencies": {
         "fast-json-stringify": "^5.7.0"
+      }
+    },
+    "node_modules/@fastify/helmet": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/helmet/-/helmet-11.1.1.tgz",
+      "integrity": "sha512-pjJxjk6SLEimITWadtYIXt6wBMfFC1I6OQyH/jYVCqSAn36sgAIFjeNiibHtifjCd+e25442pObis3Rjtame6A==",
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^4.2.1",
+        "helmet": "^7.0.0"
       }
     },
     "node_modules/@fastify/merge-json-schemas": {
@@ -1767,6 +1778,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.2.0.tgz",
+      "integrity": "sha512-ZRiwvN089JfMXokizgqEPXsl2Guk094yExfoDXR0cBYWxtBbaSww/w+vT4WEJsBW2iTUi1GgZ6swmoug3Oy4Xw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/https-proxy-agent": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@fastify/cookie": "^9.4.0",
+    "@fastify/helmet": "^11.1.1",
     "@fastify/rate-limit": "^8.1.1",
     "dotenv": "^16.6.1",
     "fastify": "^4.24.3",

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,6 +1,7 @@
 import Fastify, { type FastifyInstance } from 'fastify';
 import rateLimit from '@fastify/rate-limit';
 import cookie from '@fastify/cookie';
+import helmet from '@fastify/helmet';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -13,6 +14,23 @@ export default async function buildServer(
   const app = Fastify({ logger: true });
 
   await app.register(cookie);
+
+  await app.register(helmet, {
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'"],
+        styleSrc: ["'self'", "'unsafe-inline'"],
+        imgSrc: ["'self'", 'data:', 'https:'],
+        connectSrc: ["'self'"],
+        fontSrc: ["'self'", 'data:'],
+        objectSrc: ["'none'"],
+        frameAncestors: ["'none'"],
+      },
+    },
+    frameguard: { action: 'deny' },
+    referrerPolicy: { policy: 'no-referrer' },
+  });
 
   await app.register(rateLimit, {
     global: false,

--- a/backend/test/health.test.ts
+++ b/backend/test/health.test.ts
@@ -2,11 +2,14 @@ import { describe, it, expect } from 'vitest';
 import buildServer from '../src/server.js';
 
 describe('health route', () => {
-  it('returns ok', async () => {
+  it('returns ok with security headers', async () => {
     const app = await buildServer();
     const res = await app.inject({ method: 'GET', url: '/api/health' });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ ok: true });
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+    expect(res.headers['referrer-policy']).toBe('no-referrer');
+    expect(res.headers['content-security-policy']).toContain("default-src 'self'");
     await app.close();
   });
 });


### PR DESCRIPTION
## Summary
- secure Fastify server with `@fastify/helmet` for CSP, frameguard and referrer policy
- configure Caddy to emit HSTS and a strict Content-Security-Policy
- verify health endpoint includes security headers

## Testing
- `pg_isready`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68bac743c134832c89461320aff0b2b1