### PR TITLE
copy built artifacts into docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+backend
+frontend/node_modules
+frontend/src
+frontend/public
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,4 @@
-# --- Build frontend from /frontend ---
-FROM node:22-alpine AS fe-build
-WORKDIR /app/frontend
-
-# inject build-time env so Vite embeds secrets
-ARG VITE_GOOGLE_CLIENT_ID
-ENV VITE_GOOGLE_CLIENT_ID=${VITE_GOOGLE_CLIENT_ID}
-
-# deps (cache-friendly)
-COPY frontend/package*.json ./
-RUN npm ci
-
-# source + build
-COPY frontend/ .
-# Vite -> dist ; CRA/Next static -> build. Your compose sets FRONTEND_BUILD_DIR.
-RUN npm run build
-
-# --- Caddy runtime ---
 FROM caddy:2.7-alpine
-
-# allow switching between dist/build via build-arg
 ARG FRONTEND_BUILD_DIR=dist
-
-# static files
-COPY --from=fe-build /app/frontend/${FRONTEND_BUILD_DIR} /usr/share/caddy
-
-# caddy config
 COPY Caddyfile /etc/caddy/Caddyfile
+COPY frontend/${FRONTEND_BUILD_DIR}/ /usr/share/caddy/

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+src
+test
+scripts
+tsconfig.json
+vitest.config.ts

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,12 +1,3 @@
-# Build backend
-FROM node:22-alpine AS build
-WORKDIR /app
-COPY package*.json ./
-RUN npm ci
-COPY . .
-RUN npm run build
-
-# Production image
 FROM node:22-alpine
 WORKDIR /app
 ENV NODE_ENV=production
@@ -14,5 +5,5 @@ ENV PORT=3000
 EXPOSE 3000
 COPY package*.json ./
 RUN npm ci --omit=dev
-COPY --from=build /app/dist ./dist
+COPY dist ./dist
 CMD ["npm", "start"]

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+src
+public


### PR DESCRIPTION
## Summary
- skip frontend and backend builds in Dockerfiles and copy ready-to-run artifacts
- trim Docker contexts to omit source and test files

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68bac8ed80d8832c9eb242e0f5291b1f