### PR TITLE
copy built artifacts into docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+backend
+frontend/node_modules
+frontend/src
+frontend/public
+.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: ${{ github.ref_name }}
     services:
       postgres:
         image: postgres:16
@@ -40,29 +41,29 @@ jobs:
           npm --prefix frontend ci &
           wait
 
-      - name: Lint frontend
-        run: npm --prefix frontend run lint
+      - name: Lint frontend and test backend
+        run: |
+          npm --prefix frontend run lint &
+          DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test &
+          wait
 
-      - name: Test backend
+      - name: Build frontend and backend
         env:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/promptswap_test
-        run: npm --prefix backend test
+          VITE_GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+        run: |
+          npm --prefix frontend run build &
+          npm --prefix backend run build &
+          wait
 
-      - name: Build backend
-        run: npm run build
-
-  deploy:
-    needs: build
-    # run on push (not PR) and only on main or dev
-    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' }}
-    runs-on: ubuntu-latest
-    # use environment derived from branch; define env-specific secrets there
-    environment: ${{ github.ref_name }}
-    steps:
-      - uses: actions/checkout@v4
+      - name: Prune production dependencies
+        run: |
+          npm --prefix frontend prune --production &
+          npm --prefix backend prune --production &
+          wait
 
       # Export secrets to env, then validate in bash
       - name: Verify required secrets
+        if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') }}
         env:
           DO_SSH_HOST: ${{ secrets.DO_SSH_HOST }}
           DO_SSH_USER: ${{ secrets.DO_SSH_USER }}
@@ -83,6 +84,7 @@ jobs:
           done
 
       - name: Upload files to droplet
+        if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') }}
         uses: appleboy/scp-action@v0.1.4
         with:
           host: ${{ secrets.DO_SSH_HOST }}
@@ -93,6 +95,7 @@ jobs:
           target: "~/prompt-swap"
 
       - name: Deploy with Docker Compose
+        if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') }}
         uses: appleboy/ssh-action@v1.1.0
         env:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,4 @@
-# --- Build frontend from /frontend ---
-FROM node:22-alpine AS fe-build
-WORKDIR /app/frontend
-
-# inject build-time env so Vite embeds secrets
-ARG VITE_GOOGLE_CLIENT_ID
-ENV VITE_GOOGLE_CLIENT_ID=${VITE_GOOGLE_CLIENT_ID}
-
-# deps (cache-friendly)
-COPY frontend/package*.json ./
-RUN npm ci
-
-# source + build
-COPY frontend/ .
-# Vite -> dist ; CRA/Next static -> build. Your compose sets FRONTEND_BUILD_DIR.
-RUN npm run build
-
-# --- Caddy runtime ---
 FROM caddy:2.7-alpine
-
-# allow switching between dist/build via build-arg
 ARG FRONTEND_BUILD_DIR=dist
-
-# static files
-COPY --from=fe-build /app/frontend/${FRONTEND_BUILD_DIR} /usr/share/caddy
-
-# caddy config
 COPY Caddyfile /etc/caddy/Caddyfile
+COPY frontend/${FRONTEND_BUILD_DIR}/ /usr/share/caddy/

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+src
+test
+/scripts
+tsconfig.json
+vitest.config.ts

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,12 +1,3 @@
-# Build backend
-FROM node:22-alpine AS build
-WORKDIR /app
-COPY package*.json ./
-RUN npm ci
-COPY . .
-RUN npm run build
-
-# Production image
 FROM node:22-alpine
 WORKDIR /app
 ENV NODE_ENV=production
@@ -14,5 +5,5 @@ ENV PORT=3000
 EXPOSE 3000
 COPY package*.json ./
 RUN npm ci --omit=dev
-COPY --from=build /app/dist ./dist
+COPY dist ./dist
 CMD ["npm", "start"]

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+src
+public


### PR DESCRIPTION
## Summary
- run frontend lint and backend tests concurrently in CI
- build frontend and backend in parallel and prune to production dependencies
- parallelize production dependency pruning
- trim Docker build contexts and skip building inside images (previous commits)
- pass Google OAuth client ID to the frontend build step so login works after deployment

## Testing
- `npm --prefix frontend run lint`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`
- `VITE_GOOGLE_CLIENT_ID=test-client npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68bac8ed80d8832c9eb242e0f5291b1f