### PR TITLE
feat: use AES-GCM for encryption

### DIFF
--- a/backend/src/util/crypto.ts
+++ b/backend/src/util/crypto.ts
@@ -1,8 +1,9 @@
 import { randomBytes, scryptSync, createCipheriv, createDecipheriv } from 'node:crypto';
 
-const ALGORITHM = 'aes-256-ctr';
-const IV_LENGTH = 16; // AES block size
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12; // Recommended IV length for GCM
 const SALT_LENGTH = 16;
+const TAG_LENGTH = 16;
 
 export function encrypt(text: string, password: string): string {
   const iv = randomBytes(IV_LENGTH);
@@ -10,16 +11,26 @@ export function encrypt(text: string, password: string): string {
   const key = scryptSync(password, salt, 32);
   const cipher = createCipheriv(ALGORITHM, key, iv);
   const encrypted = Buffer.concat([cipher.update(text, 'utf8'), cipher.final()]);
-  return Buffer.concat([salt, iv, encrypted]).toString('base64');
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([salt, iv, tag, encrypted]).toString('base64');
 }
 
 export function decrypt(payload: string, password: string): string {
   const buffer = Buffer.from(payload, 'base64');
   const salt = buffer.subarray(0, SALT_LENGTH);
   const iv = buffer.subarray(SALT_LENGTH, SALT_LENGTH + IV_LENGTH);
-  const encrypted = buffer.subarray(SALT_LENGTH + IV_LENGTH);
+  const tag = buffer.subarray(
+    SALT_LENGTH + IV_LENGTH,
+    SALT_LENGTH + IV_LENGTH + TAG_LENGTH,
+  );
+  const encrypted = buffer.subarray(SALT_LENGTH + IV_LENGTH + TAG_LENGTH);
   const key = scryptSync(password, salt, 32);
   const decipher = createDecipheriv(ALGORITHM, key, iv);
-  const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
-  return decrypted.toString('utf8');
+  decipher.setAuthTag(tag);
+  try {
+    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+    return decrypted.toString('utf8');
+  } catch {
+    throw new Error('Failed to decrypt payload');
+  }
 }


### PR DESCRIPTION
## Summary
- switch crypto util to AES-256-GCM
- include auth tag in encrypted payload and verify during decryption

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test` *(fails: connect ECONNREFUSED)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd091fb848832cbcb57430bb1c0613