### PR TITLE
Allow updating inactive agents

### DIFF
--- a/frontend/src/components/AgentUpdateModal.tsx
+++ b/frontend/src/components/AgentUpdateModal.tsx
@@ -108,7 +108,11 @@ export default function AgentUpdateModal({ agent, open, onClose, onUpdated }: Pr
       </div>
       <ConfirmDialog
         open={confirmOpen}
-        message="Update running agent?"
+        message={
+          agent.status === 'active'
+            ? 'Update running agent?'
+            : 'Update agent?'
+        }
         onConfirm={() => {
           setConfirmOpen(false);
           updateMut.mutate();

--- a/frontend/src/routes/AgentView.tsx
+++ b/frontend/src/routes/AgentView.tsx
@@ -72,34 +72,34 @@ export default function AgentView() {
           <AgentDetailsMobile agent={data} />
         </div>
         {isActive ? (
-            <div className="mt-4 flex gap-2">
-              <Button onClick={() => setShowUpdate(true)}>
-                Update Agent
-              </Button>
-              <Button
-                  disabled={stopMut.isPending}
-                  loading={stopMut.isPending}
-                  onClick={() => stopMut.mutate()}
-              >
-                Stop Agent
-              </Button>
-              <Button
-                  disabled={reviewMut.isPending}
-                  loading={reviewMut.isPending}
-                  onClick={() => id && reviewMut.mutate(id)}
-              >
-                Run Review
-              </Button>
-            </div>
-        ) : (
+          <div className="mt-4 flex gap-2">
+            <Button onClick={() => setShowUpdate(true)}>Update Agent</Button>
             <Button
-                className="mt-4"
-                disabled={startMut.isPending}
-                loading={startMut.isPending}
-                onClick={() => startMut.mutate()}
+              disabled={stopMut.isPending}
+              loading={stopMut.isPending}
+              onClick={() => stopMut.mutate()}
+            >
+              Stop Agent
+            </Button>
+            <Button
+              disabled={reviewMut.isPending}
+              loading={reviewMut.isPending}
+              onClick={() => id && reviewMut.mutate(id)}
+            >
+              Run Review
+            </Button>
+          </div>
+        ) : (
+          <div className="mt-4 flex gap-2">
+            <Button onClick={() => setShowUpdate(true)}>Update Agent</Button>
+            <Button
+              disabled={startMut.isPending}
+              loading={startMut.isPending}
+              onClick={() => startMut.mutate()}
             >
               Start Agent
             </Button>
+          </div>
         )}
         {logData && (
             <div className="mt-6">


### PR DESCRIPTION
## Summary
- show Update Agent button for inactive agents with Start
- adjust update confirmation message based on agent status

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd0c827f28832ca2e5a686ebf719f3