### PR TITLE
Include API key IDs on agents

### DIFF
--- a/frontend/src/lib/useAgentData.ts
+++ b/frontend/src/lib/useAgentData.ts
@@ -15,6 +15,8 @@ export interface Agent {
   agentInstructions: string;
   startBalanceUsd: number | null;
   manualRebalance: boolean;
+  aiApiKeyId: string | null;
+  exchangeApiKeyId: string | null;
 }
 
 export function useAgentData(id?: string) {

--- a/frontend/src/routes/AgentView.tsx
+++ b/frontend/src/routes/AgentView.tsx
@@ -15,6 +15,8 @@ import AgentUpdateModal from '../components/AgentUpdateModal';
 import AgentDetailsDesktop from '../components/AgentDetailsDesktop';
 import AgentDetailsMobile from '../components/AgentDetailsMobile';
 import Toggle from '../components/ui/Toggle';
+import AiApiKeySection from '../components/forms/AiApiKeySection';
+import ExchangeApiKeySection from '../components/forms/ExchangeApiKeySection';
 
 export default function AgentView() {
   const { id } = useParams();
@@ -62,9 +64,20 @@ export default function AgentView() {
   if (!data) return <div className="p-4">Loading...</div>;
   if (data.status === 'draft') return <AgentPreview draft={data} />;
 
-  const isActive = data.status === 'active';
-  return (
+    const isActive = data.status === 'active';
+    return (
       <div className="p-4">
+        {!data.aiApiKeyId || !data.exchangeApiKeyId ? (
+          <div className="mb-4 space-y-4">
+            {!data.aiApiKeyId && <AiApiKeySection label="OpenAI API Key" />}
+            {!data.exchangeApiKeyId && (
+              <ExchangeApiKeySection
+                exchange="binance"
+                label="Binance API Credentials"
+              />
+            )}
+          </div>
+        ) : null}
         <div className="hidden md:block">
           <AgentDetailsDesktop agent={data} />
         </div>


### PR DESCRIPTION
## Summary
- return AI and exchange API key IDs with agent data
- show API key inputs on agent view when IDs are missing

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix frontend run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd15e0bc18832c9851ab7dad34be3e