### PR TITLE
Validate backend path parameters with zod

### DIFF
--- a/backend/src/routes/binance-balance.ts
+++ b/backend/src/routes/binance-balance.ts
@@ -1,15 +1,25 @@
 import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
 import { fetchAccount, fetchTotalBalanceUsd } from '../services/binance.js';
 import { requireUserIdMatch } from '../util/auth.js';
 import { errorResponse, ERROR_MESSAGES } from '../util/errorMessages.js';
 import { RATE_LIMITS } from '../rate-limit.js';
+import { parseParams } from '../util/validation.js';
+
+const idParams = z.object({ id: z.string().regex(/^\d+$/) });
+const idTokenParams = z.object({
+  id: z.string().regex(/^\d+$/),
+  token: z.string(),
+});
 
 export default async function binanceBalanceRoutes(app: FastifyInstance) {
   app.get(
     '/users/:id/binance-balance',
     { config: { rateLimit: RATE_LIMITS.MODERATE } },
     async (req, reply) => {
-      const id = (req.params as any).id as string;
+      const params = parseParams(idParams, req.params, reply);
+      if (!params) return;
+      const { id } = params;
       if (!requireUserIdMatch(req, reply, id)) return;
     let total;
     try {
@@ -29,12 +39,13 @@ export default async function binanceBalanceRoutes(app: FastifyInstance) {
     '/users/:id/binance-balance/:token',
     { config: { rateLimit: RATE_LIMITS.RELAXED } },
     async (req, reply) => {
-      const { id, token } = req.params as any;
-      const userId = id as string;
-      if (!requireUserIdMatch(req, reply, userId)) return;
+      const params = parseParams(idTokenParams, req.params, reply);
+      if (!params) return;
+      const { id, token } = params;
+      if (!requireUserIdMatch(req, reply, id)) return;
       let account;
       try {
-        account = await fetchAccount(userId);
+        account = await fetchAccount(id);
       } catch {
         return reply
           .code(500)
@@ -42,7 +53,7 @@ export default async function binanceBalanceRoutes(app: FastifyInstance) {
       }
       if (!account)
         return reply.code(404).send(errorResponse(ERROR_MESSAGES.notFound));
-      const sym = (token as string).toUpperCase();
+      const sym = token.toUpperCase();
       const bal = account.balances.find((b) => b.asset === sym);
       if (!bal) return { asset: sym, free: 0, locked: 0 };
       return {

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -1,10 +1,14 @@
 import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
 import { requireAdmin } from '../util/auth.js';
 import { listUsers, setUserEnabled, getUser } from '../repos/users.js';
 import { RATE_LIMITS } from '../rate-limit.js';
 import { errorResponse } from '../util/errorMessages.js';
 import { decrypt } from '../util/crypto.js';
 import { env } from '../util/env.js';
+import { parseParams } from '../util/validation.js';
+
+const idParams = z.object({ id: z.string().regex(/^\d+$/) });
 
 export default async function usersRoutes(app: FastifyInstance) {
   app.get(
@@ -30,11 +34,12 @@ export default async function usersRoutes(app: FastifyInstance) {
     async (req, reply) => {
       const adminId = await requireAdmin(req, reply);
       if (!adminId) return;
-      const { id } = req.params as { id: string };
-      const userId = id;
-      const row = await getUser(userId);
+      const params = parseParams(idParams, req.params, reply);
+      if (!params) return;
+      const { id } = params;
+      const row = await getUser(id);
       if (!row) return reply.code(404).send(errorResponse('user not found'));
-      await setUserEnabled(userId, true);
+      await setUserEnabled(id, true);
       return { ok: true };
     },
   );
@@ -45,11 +50,12 @@ export default async function usersRoutes(app: FastifyInstance) {
     async (req, reply) => {
       const adminId = await requireAdmin(req, reply);
       if (!adminId) return;
-      const { id } = req.params as { id: string };
-      const userId = id;
-      const row = await getUser(userId);
+      const params = parseParams(idParams, req.params, reply);
+      if (!params) return;
+      const { id } = params;
+      const row = await getUser(id);
       if (!row) return reply.code(404).send(errorResponse('user not found'));
-      await setUserEnabled(userId, false);
+      await setUserEnabled(id, false);
       return { ok: true };
     },
   );

--- a/backend/src/util/redact.ts
+++ b/backend/src/util/redact.ts
@@ -1,5 +1,0 @@
-export function redactKey(key: string, visible = 4): string {
-  if (key.length <= visible) return key[0] + '...';
-  if (key.length <= visible * 2) return key.slice(0, visible) + '...';
-  return key.slice(0, visible) + '...' + key.slice(-visible);
-}

--- a/backend/src/util/validation.ts
+++ b/backend/src/util/validation.ts
@@ -1,0 +1,16 @@
+import type { FastifyReply } from 'fastify';
+import { z } from 'zod';
+import { errorResponse } from './errorMessages.js';
+
+export function parseParams<S extends z.ZodTypeAny>(
+  schema: S,
+  params: unknown,
+  reply: FastifyReply,
+): z.infer<S> | undefined {
+  const result = schema.safeParse(params);
+  if (!result.success) {
+    reply.code(400).send(errorResponse('invalid path parameter'));
+    return;
+  }
+  return result.data;
+}

--- a/backend/test/pathParams.test.ts
+++ b/backend/test/pathParams.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import buildServer from '../src/server.js';
+import { authCookies } from './helpers.js';
+
+// Ensure that invalid path parameters are rejected
+
+describe('path parameter validation', () => {
+  it('returns 400 for invalid user id', async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/users/abc/ai-key',
+      cookies: authCookies('1'),
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: 'invalid path parameter' });
+  });
+});


### PR DESCRIPTION
## Summary
- centralize path parameter validation with a `parseParams` helper
- apply zod path checks across agent, user, balance, API key, and model routes
- add regression test for invalid path parameters
- replace `redactKey` helper with static `<REDACTED>` placeholder in API key responses

## Testing
- `npm --prefix backend run build`
- `apt-get install -y postgresql` *(fails: Unable to locate package postgresql)*
- `pg_isready` *(command not found)*
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test` *(fails: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2704b954832c85575ee094bd8555