### PR TITLE
chore: run backend container as non-root user

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,4 +6,6 @@ EXPOSE 3000
 COPY package*.json ./
 RUN npm ci --omit=dev
 COPY dist ./dist
+RUN mkdir -p /data && chown -R node:node /app /data
+USER node
 CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- run backend container as node user instead of root

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd2b0d3e5c832ca97eb751511fa31a