### PR TITLE
feat: add API key provider selector

### DIFF
--- a/frontend/src/components/forms/ApiKeyProviderSelector.tsx
+++ b/frontend/src/components/forms/ApiKeyProviderSelector.tsx
@@ -1,0 +1,94 @@
+import { useMemo } from 'react';
+import { useQueries } from '@tanstack/react-query';
+import axios from 'axios';
+import { useUser } from '../../lib/useUser';
+import api from '../../lib/axios';
+import SelectInput from './SelectInput';
+import AiApiKeySection from './AiApiKeySection';
+import ExchangeApiKeySection from './ExchangeApiKeySection';
+
+interface ProviderConfig {
+  value: string;
+  label: string;
+  queryKey: string;
+  getKeyPath: (id: string) => string;
+  renderForm: () => JSX.Element;
+}
+
+const aiConfigs: ProviderConfig[] = [
+  {
+    value: 'openai',
+    label: 'OpenAI',
+    queryKey: 'ai-key',
+    getKeyPath: (id) => `/users/${id}/ai-key`,
+    renderForm: () => <AiApiKeySection label="OpenAI API Key" />,
+  },
+];
+
+const exchangeConfigs: ProviderConfig[] = [
+  {
+    value: 'binance',
+    label: 'Binance',
+    queryKey: 'binance-key',
+    getKeyPath: (id) => `/users/${id}/binance-key`,
+    renderForm: () => (
+      <ExchangeApiKeySection exchange="binance" label="Binance API Credentials" />
+    ),
+  },
+];
+
+interface Props {
+  type: 'ai' | 'exchange';
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+}
+
+export default function ApiKeyProviderSelector({
+  type,
+  label,
+  value,
+  onChange,
+}: Props) {
+  const { user } = useUser();
+  const configs = type === 'ai' ? aiConfigs : exchangeConfigs;
+
+  const queries = useQueries({
+    queries: configs.map((cfg) => ({
+      queryKey: [cfg.queryKey, user?.id],
+      enabled: !!user,
+      queryFn: async () => {
+        try {
+          await api.get(cfg.getKeyPath(user!.id));
+          return true;
+        } catch (err) {
+          if (axios.isAxiosError(err) && err.response?.status === 404) return false;
+          throw err;
+        }
+      },
+    })),
+  });
+
+  const available = useMemo(
+    () => configs.filter((_, i) => queries[i]?.data),
+    [configs, queries],
+  );
+
+  if (!user) return null;
+
+  if (available.length === 0) {
+    return configs[0].renderForm();
+  }
+
+  return (
+    <div>
+      <h2 className="text-md font-bold">{label}</h2>
+      <SelectInput
+        id={`${type}-provider`}
+        value={value}
+        onChange={onChange}
+        options={available.map((p) => ({ value: p.value, label: p.label }))}
+      />
+    </div>
+  );
+}

--- a/frontend/src/routes/AgentPreview.tsx
+++ b/frontend/src/routes/AgentPreview.tsx
@@ -8,8 +8,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import axios from 'axios';
 import api from '../lib/axios';
 import { useUser } from '../lib/useUser';
-import AiApiKeySection from '../components/forms/AiApiKeySection';
-import ExchangeApiKeySection from '../components/forms/ExchangeApiKeySection';
+import ApiKeyProviderSelector from '../components/forms/ApiKeyProviderSelector';
 import WalletBalances from '../components/WalletBalances';
 import { useToast } from '../lib/useToast';
 import Button from '../components/ui/Button';
@@ -49,6 +48,8 @@ export default function AgentPreview({ draft }: Props) {
   const tokens = agentData ? agentData.tokens.map((t) => t.token) : [];
   const { hasOpenAIKey, hasBinanceKey, models, balances } = usePrerequisites(tokens);
   const [model, setModel] = useState(draft?.model || '');
+  const [aiProvider, setAiProvider] = useState('openai');
+  const [exchangeProvider, setExchangeProvider] = useState('binance');
   useEffect(() => {
     setModel(draft?.model || '');
   }, [draft?.model]);
@@ -107,9 +108,20 @@ export default function AgentPreview({ draft }: Props) {
         value={agentData.agentInstructions}
         onChange={(v) => setAgentData((d) => (d ? { ...d, agentInstructions: v } : d))}
       />
-      {user && !hasOpenAIKey && (
-        <div className="mt-4">
-          <AiApiKeySection label="OpenAI API Key" />
+      {user && (
+        <div className="mt-4 space-y-4">
+          <ApiKeyProviderSelector
+            type="ai"
+            label="AI Provider"
+            value={aiProvider}
+            onChange={setAiProvider}
+          />
+          <ApiKeyProviderSelector
+            type="exchange"
+            label="Exchange"
+            value={exchangeProvider}
+            onChange={setExchangeProvider}
+          />
         </div>
       )}
       {user && hasOpenAIKey && (models.length || draft?.model) && (
@@ -131,11 +143,6 @@ export default function AgentPreview({ draft }: Props) {
               ))
             )}
           </select>
-        </div>
-      )}
-      {user && !hasBinanceKey && (
-        <div className="mt-4">
-          <ExchangeApiKeySection exchange="binance" label="Binance API Credentials" />
         </div>
       )}
 

--- a/frontend/src/routes/AgentView.tsx
+++ b/frontend/src/routes/AgentView.tsx
@@ -15,8 +15,7 @@ import AgentUpdateModal from '../components/AgentUpdateModal';
 import AgentDetailsDesktop from '../components/AgentDetailsDesktop';
 import AgentDetailsMobile from '../components/AgentDetailsMobile';
 import Toggle from '../components/ui/Toggle';
-import AiApiKeySection from '../components/forms/AiApiKeySection';
-import ExchangeApiKeySection from '../components/forms/ExchangeApiKeySection';
+import ApiKeyProviderSelector from '../components/forms/ApiKeyProviderSelector';
 
 export default function AgentView() {
   const { id } = useParams();
@@ -42,6 +41,8 @@ export default function AgentView() {
   });
 
   const [showUpdate, setShowUpdate] = useState(false);
+  const [aiProvider, setAiProvider] = useState('openai');
+  const [exchangeProvider, setExchangeProvider] = useState('binance');
 
   const [logPage, setLogPage] = useState(1);
   const [onlyRebalance, setOnlyRebalance] = useState(false);
@@ -67,17 +68,20 @@ export default function AgentView() {
     const isActive = data.status === 'active';
     return (
       <div className="p-4">
-        {!data.aiApiKeyId || !data.exchangeApiKeyId ? (
-          <div className="mb-4 space-y-4">
-            {!data.aiApiKeyId && <AiApiKeySection label="OpenAI API Key" />}
-            {!data.exchangeApiKeyId && (
-              <ExchangeApiKeySection
-                exchange="binance"
-                label="Binance API Credentials"
-              />
-            )}
-          </div>
-        ) : null}
+        <div className="mb-4 space-y-4">
+          <ApiKeyProviderSelector
+            type="ai"
+            label="AI Provider"
+            value={aiProvider}
+            onChange={setAiProvider}
+          />
+          <ApiKeyProviderSelector
+            type="exchange"
+            label="Exchange"
+            value={exchangeProvider}
+            onChange={setExchangeProvider}
+          />
+        </div>
         <div className="hidden md:block">
           <AgentDetailsDesktop agent={data} />
         </div>


### PR DESCRIPTION
## Summary
- add ApiKeyProviderSelector component that shows provider dropdown or key form
- use selector in agent preview and agent view to handle missing or restored keys

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd31a0305c832c9adb2ad4b86462db