### PR TITLE
Fail CI on parallel errors and update API key tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,25 +40,31 @@ jobs:
       - &install_deps
         name: Install dependencies
         run: |
-          npm --prefix backend ci &
-          npm --prefix frontend ci &
-          wait
+          set -e
+          npm --prefix backend ci & pid1=$!
+          npm --prefix frontend ci & pid2=$!
+          wait $pid1
+          wait $pid2
         shell: bash
 
       - &audit_deps
         name: Audit dependencies
         run: |
-          npm --prefix backend audit --audit-level=high &
-          npm --prefix frontend audit --audit-level=high &
-          wait
+          set -e
+          npm --prefix backend audit --audit-level=high & pid1=$!
+          npm --prefix frontend audit --audit-level=high & pid2=$!
+          wait $pid1
+          wait $pid2
         shell: bash
 
       - &lint_test
         name: Lint frontend and test backend
         run: |
-          npm --prefix frontend run lint &
-          DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test &
-          wait
+          set -e
+          npm --prefix frontend run lint & pid1=$!
+          DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test & pid2=$!
+          wait $pid1
+          wait $pid2
         shell: bash
 
       - &build_app
@@ -66,17 +72,21 @@ jobs:
         env:
           VITE_GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
         run: |
-          npm --prefix frontend run build &
-          npm --prefix backend run build &
-          wait
+          set -e
+          npm --prefix frontend run build & pid1=$!
+          npm --prefix backend run build & pid2=$!
+          wait $pid1
+          wait $pid2
         shell: bash
 
       - &prune_deps
         name: Prune production dependencies
         run: |
-          npm --prefix frontend prune --production &
-          npm --prefix backend prune --production &
-          wait
+          set -e
+          npm --prefix frontend prune --production & pid1=$!
+          npm --prefix backend prune --production & pid2=$!
+          wait $pid1
+          wait $pid2
         shell: bash
 
   build-and-deploy:

--- a/backend/test/apiKeys.test.ts
+++ b/backend/test/apiKeys.test.ts
@@ -58,7 +58,7 @@ describe('AI API key routes', () => {
       payload: { key: key1 },
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toMatchObject({ key: 'aike...7890' });
+    expect(res.json()).toMatchObject({ key: '<REDACTED>' });
     row = await getAiKeyRow(userId);
     expect(row!.ai_api_key_enc).not.toBe(key1);
 
@@ -68,7 +68,7 @@ describe('AI API key routes', () => {
       cookies: authCookies(userId),
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toMatchObject({ key: 'aike...7890' });
+    expect(res.json()).toMatchObject({ key: '<REDACTED>' });
 
     res = await app.inject({
       method: 'POST',
@@ -92,7 +92,7 @@ describe('AI API key routes', () => {
       url: `/api/users/${userId}/ai-key`,
       cookies: authCookies(userId),
     });
-    expect(res.json()).toMatchObject({ key: 'aike...7890' });
+    expect(res.json()).toMatchObject({ key: '<REDACTED>' });
 
     fetchMock.mockResolvedValueOnce({ ok: true } as any);
     res = await app.inject({
@@ -102,7 +102,7 @@ describe('AI API key routes', () => {
       payload: { key: key2 },
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toMatchObject({ key: 'aike...ghij' });
+    expect(res.json()).toMatchObject({ key: '<REDACTED>' });
 
     res = await app.inject({
       method: 'DELETE',
@@ -170,8 +170,8 @@ describe('Binance API key routes', () => {
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({
-      key: 'bkey...7890',
-      secret: 'bsec...7890',
+      key: '<REDACTED>',
+      secret: '<REDACTED>',
     });
     row = await getBinanceKeyRow(userId);
     expect(row!.binance_api_key_enc).not.toBe(key1);
@@ -184,8 +184,8 @@ describe('Binance API key routes', () => {
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({
-      key: 'bkey...7890',
-      secret: 'bsec...7890',
+      key: '<REDACTED>',
+      secret: '<REDACTED>',
     });
 
     res = await app.inject({
@@ -211,8 +211,8 @@ describe('Binance API key routes', () => {
       cookies: authCookies(userId),
     });
     expect(res.json()).toMatchObject({
-      key: 'bkey...7890',
-      secret: 'bsec...7890',
+      key: '<REDACTED>',
+      secret: '<REDACTED>',
     });
 
     fetchMock.mockResolvedValueOnce({ ok: true } as any);
@@ -224,8 +224,8 @@ describe('Binance API key routes', () => {
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({
-      key: 'bkey...ghij',
-      secret: 'bsec...ghij',
+      key: '<REDACTED>',
+      secret: '<REDACTED>',
     });
 
     res = await app.inject({

--- a/frontend/src/components/forms/ApiKeyProviderSelector.tsx
+++ b/frontend/src/components/forms/ApiKeyProviderSelector.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from 'react';
+import { useMemo, type ReactElement } from 'react';
+
 import { useQueries } from '@tanstack/react-query';
 import axios from 'axios';
 import { useUser } from '../../lib/useUser';
@@ -12,7 +13,7 @@ interface ProviderConfig {
   label: string;
   queryKey: string;
   getKeyPath: (id: string) => string;
-  renderForm: () => JSX.Element;
+  renderForm: () => ReactElement;
 }
 
 const aiConfigs: ProviderConfig[] = [


### PR DESCRIPTION
## Summary
- ensure each parallel CI step exits on any failure
- adjust API key tests for redacted responses
- fix JSX type error in ApiKeyProviderSelector

## Testing
- `npm --prefix frontend run lint`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd3627f1e4832c9a34a1017ec906e9