### PR TITLE
fix(pg): default import for node esm

### DIFF
--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -1,4 +1,5 @@
-import { Pool } from 'pg';
+import pg from 'pg';
+const { Pool } = pg;
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';


### PR DESCRIPTION
## Summary
- fix pg import to work under Node ESM by default importing and destructuring Pool

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd3c3821b8832cb9ffcf406ab5548f