### PR TITLE
Increase Postgres health check frequency in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test
+        options: >-
+          --health-cmd pg_isready -U postgres
+          --health-interval 3s
+          --health-timeout 5s
+          --health-retries 40
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- increase Postgres service health check frequency to every 3 seconds and allow more retries in CI

## Testing
- `npm --prefix frontend run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd44562cf8832cbc284bdd0480536c