### PR TITLE
Refactor agent configuration UI

### DIFF
--- a/frontend/src/components/AgentDetailsDesktop.tsx
+++ b/frontend/src/components/AgentDetailsDesktop.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react';
-import { Eye, EyeOff, ChevronDown, ChevronRight } from 'lucide-react';
+import { Eye, EyeOff } from 'lucide-react';
 import AgentStatusLabel from './AgentStatusLabel';
 import TokenDisplay from './TokenDisplay';
-import StrategyForm from './StrategyForm';
 import AgentPnl from './AgentPnl';
 import FormattedDate from './ui/FormattedDate';
 import type { Agent } from '../lib/useAgentData';
@@ -12,17 +11,7 @@ interface Props {
 }
 
 export default function AgentDetailsDesktop({ agent }: Props) {
-  const [showStrategy, setShowStrategy] = useState(false);
   const [showPrompt, setShowPrompt] = useState(false);
-
-  const strategyData = {
-    tokenA: agent.tokenA,
-    tokenB: agent.tokenB,
-    minTokenAAllocation: agent.minTokenAAllocation,
-    minTokenBAllocation: agent.minTokenBAllocation,
-    risk: agent.risk,
-    reviewInterval: agent.reviewInterval,
-  };
 
   return (
     <div>
@@ -41,24 +30,6 @@ export default function AgentDetailsDesktop({ agent }: Props) {
         <span>/</span>
         <TokenDisplay token={agent.tokenB} />
       </p>
-      <div className="mt-2">
-        <div
-          className="flex items-center gap-1 cursor-pointer"
-          onClick={() => setShowStrategy((s) => !s)}
-        >
-          <h2 className="text-l font-bold">Strategy</h2>
-          {showStrategy ? (
-            <ChevronDown className="w-4 h-4" />
-          ) : (
-            <ChevronRight className="w-4 h-4" />
-          )}
-        </div>
-        {showStrategy && (
-          <div className="mt-2 max-w-2xl">
-            <StrategyForm data={strategyData} onChange={() => {}} disabled />
-          </div>
-        )}
-      </div>
       <div className="mt-2">
         <div className="flex items-center gap-1">
           <h2 className="text-l font-bold">Trading Instructions</h2>

--- a/frontend/src/routes/AgentPreview.tsx
+++ b/frontend/src/routes/AgentPreview.tsx
@@ -15,6 +15,8 @@ import { useToast } from '../lib/useToast';
 import Button from '../components/ui/Button';
 import { usePrerequisites } from '../lib/usePrerequisites';
 import AgentStartButton from '../components/AgentStartButton';
+import SelectInput from '../components/forms/SelectInput';
+import FormField from '../components/forms/FormField';
 
 interface AgentPreviewDetails {
   name: string;
@@ -50,6 +52,8 @@ export default function AgentPreview({ draft }: Props) {
   }, [data]);
   const tokens = agentData ? [agentData.tokenA, agentData.tokenB] : [];
   const { hasOpenAIKey, hasBinanceKey, models, balances } = usePrerequisites(tokens);
+  const [aiProvider, setAiProvider] = useState('openai');
+  const [exchange, setExchange] = useState('binance');
   const [model, setModel] = useState(draft?.model || '');
   const [hadModel, setHadModel] = useState(false);
   useEffect(() => {
@@ -108,6 +112,16 @@ export default function AgentPreview({ draft }: Props) {
         value={agentData.agentInstructions}
         onChange={(v) => setAgentData((d) => (d ? { ...d, agentInstructions: v } : d))}
       />
+      <div className="mt-4">
+        <FormField label="AI Provider" className="w-full max-w-xs">
+          <SelectInput
+            id="ai-provider"
+            value={aiProvider}
+            onChange={setAiProvider}
+            options={[{ value: 'openai', label: 'OpenAI' }]}
+          />
+        </FormField>
+      </div>
       {user && !hasOpenAIKey && (
         <div className="mt-4">
           <AiApiKeySection label="OpenAI API Key" />
@@ -115,25 +129,30 @@ export default function AgentPreview({ draft }: Props) {
       )}
       {user && hasOpenAIKey && (models.length || draft?.model) && (
         <div className="mt-4">
-          <h2 className="text-md font-bold">Model</h2>
-          <select
-            id="model"
-            value={model}
-            onChange={(e) => setModel(e.target.value)}
-            className="border rounded p-2"
-          >
-            {draft?.model && !models.length ? (
-              <option value={draft.model}>{draft.model}</option>
-            ) : (
-              models.map((m) => (
-                <option key={m} value={m}>
-                  {m}
-                </option>
-              ))
-            )}
-          </select>
+          <FormField label="Model" className="w-full max-w-xs">
+            <SelectInput
+              id="model"
+              value={model}
+              onChange={setModel}
+              options={
+                draft?.model && !models.length
+                  ? [{ value: draft.model, label: draft.model }]
+                  : models.map((m) => ({ value: m, label: m }))
+              }
+            />
+          </FormField>
         </div>
       )}
+      <div className="mt-4">
+        <FormField label="Exchange" className="w-full max-w-xs">
+          <SelectInput
+            id="exchange"
+            value={exchange}
+            onChange={setExchange}
+            options={[{ value: 'binance', label: 'Binance' }]}
+          />
+        </FormField>
+      </div>
       {user && !hasBinanceKey && (
         <div className="mt-4">
           <ExchangeApiKeySection exchange="binance" label="Binance API Credentials" />


### PR DESCRIPTION
## Summary
- Align AI provider, model, and exchange selectors with token dropdown styling on the Agent Preview page
- Expand Update Agent modal to include provider/model/exchange selectors and API key sections
- Remove unused strategy section from desktop agent view

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd4415b96c832c965609601c7dde13