### PR TITLE
Refactor agent preview and update modals

### DIFF
--- a/frontend/src/components/AgentDetailsDesktop.tsx
+++ b/frontend/src/components/AgentDetailsDesktop.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Eye, EyeOff, ChevronDown, ChevronRight } from 'lucide-react';
+import { Eye, EyeOff } from 'lucide-react';
 import AgentStatusLabel from './AgentStatusLabel';
 import TokenDisplay from './TokenDisplay';
 import StrategyForm from './StrategyForm';
@@ -12,7 +12,6 @@ interface Props {
 }
 
 export default function AgentDetailsDesktop({ agent }: Props) {
-  const [showStrategy, setShowStrategy] = useState(false);
   const [showPrompt, setShowPrompt] = useState(false);
 
   const strategyData = {
@@ -42,22 +41,10 @@ export default function AgentDetailsDesktop({ agent }: Props) {
         ))}
       </p>
       <div className="mt-2">
-        <div
-          className="flex items-center gap-1 cursor-pointer"
-          onClick={() => setShowStrategy((s) => !s)}
-        >
-          <h2 className="text-l font-bold">Strategy</h2>
-          {showStrategy ? (
-            <ChevronDown className="w-4 h-4" />
-          ) : (
-            <ChevronRight className="w-4 h-4" />
-          )}
+        <h2 className="text-l font-bold">Strategy</h2>
+        <div className="mt-2 max-w-2xl">
+          <StrategyForm data={strategyData} onChange={() => {}} disabled />
         </div>
-        {showStrategy && (
-          <div className="mt-2 max-w-2xl">
-            <StrategyForm data={strategyData} onChange={() => {}} disabled />
-          </div>
-        )}
       </div>
       <div className="mt-2">
         <div className="flex items-center gap-1">

--- a/frontend/src/components/AgentUpdateModal.tsx
+++ b/frontend/src/components/AgentUpdateModal.tsx
@@ -10,6 +10,10 @@ import ConfirmDialog from './ui/ConfirmDialog';
 import StrategyForm from './StrategyForm';
 import AgentInstructions from './AgentInstructions';
 import { normalizeAllocations } from '../lib/allocations';
+import ApiKeyProviderSelector from './forms/ApiKeyProviderSelector';
+import WalletBalances from './WalletBalances';
+import { usePrerequisites } from '../lib/usePrerequisites';
+import SelectInput from './forms/SelectInput';
 
 interface Props {
   agent: Agent;
@@ -27,6 +31,12 @@ export default function AgentUpdateModal({ agent, open, onClose, onUpdated }: Pr
     agentInstructions: agent.agentInstructions,
   });
 
+  const tokens = data.tokens.map((t) => t.token);
+  const { hasOpenAIKey, hasBinanceKey, models, balances } = usePrerequisites(tokens);
+  const [model, setModel] = useState(agent.model || '');
+  const [aiProvider, setAiProvider] = useState('openai');
+  const [exchangeProvider, setExchangeProvider] = useState('binance');
+
   useEffect(() => {
     if (open) {
       setData({
@@ -35,14 +45,23 @@ export default function AgentUpdateModal({ agent, open, onClose, onUpdated }: Pr
         reviewInterval: agent.reviewInterval,
         agentInstructions: agent.agentInstructions,
       });
+      setModel(agent.model || '');
     }
   }, [open, agent]);
+
+  useEffect(() => {
+    if (!hasOpenAIKey) {
+      setModel('');
+    } else if (!model) {
+      setModel(agent.model || models[0] || '');
+    }
+  }, [hasOpenAIKey, models, agent.model, model]);
 
   const updateMut = useMutation({
     mutationFn: async () => {
       await api.put(`/agents/${agent.id}`, {
         userId: agent.userId,
-        model: agent.model,
+        model,
         status: agent.status,
         name: agent.name,
         tokens: data.tokens.map((t) => ({
@@ -96,6 +115,44 @@ export default function AgentUpdateModal({ agent, open, onClose, onUpdated }: Pr
         value={data.agentInstructions}
         onChange={(v) => setData((d) => ({ ...d, agentInstructions: v }))}
       />
+      <div className="mt-4 max-w-2xl">
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <ApiKeyProviderSelector
+              type="ai"
+              label="AI Provider"
+              value={aiProvider}
+              onChange={setAiProvider}
+            />
+            {hasOpenAIKey && (models.length || agent.model) && (
+              <div className="mt-2">
+                <h2 className="text-md font-bold">Model</h2>
+                <SelectInput
+                  id="update-model"
+                  value={model}
+                  onChange={setModel}
+                  options={
+                    agent.model && !models.length
+                      ? [{ value: agent.model, label: agent.model }]
+                      : models.map((m) => ({ value: m, label: m }))
+                  }
+                />
+              </div>
+            )}
+          </div>
+          <div>
+            <ApiKeyProviderSelector
+              type="exchange"
+              label="Exchange"
+              value={exchangeProvider}
+              onChange={setExchangeProvider}
+            />
+            <div className="mt-2">
+              <WalletBalances balances={balances} hasBinanceKey={hasBinanceKey} />
+            </div>
+          </div>
+        </div>
+      </div>
       <div className="mt-4 flex justify-end gap-2">
         <Button onClick={onClose}>Cancel</Button>
         <Button

--- a/frontend/src/components/forms/ApiKeyProviderSelector.tsx
+++ b/frontend/src/components/forms/ApiKeyProviderSelector.tsx
@@ -81,6 +81,10 @@ export default function ApiKeyProviderSelector({
     return configs[0].renderForm();
   }
 
+  if (available.length === 1) {
+    return null;
+  }
+
   return (
     <div>
       <h2 className="text-md font-bold">{label}</h2>

--- a/frontend/src/routes/AgentPreview.tsx
+++ b/frontend/src/routes/AgentPreview.tsx
@@ -14,6 +14,7 @@ import { useToast } from '../lib/useToast';
 import Button from '../components/ui/Button';
 import { usePrerequisites } from '../lib/usePrerequisites';
 import AgentStartButton from '../components/AgentStartButton';
+import SelectInput from '../components/forms/SelectInput';
 
 interface AgentPreviewDetails {
   name: string;
@@ -109,45 +110,47 @@ export default function AgentPreview({ draft }: Props) {
         onChange={(v) => setAgentData((d) => (d ? { ...d, agentInstructions: v } : d))}
       />
       {user && (
-        <div className="mt-4 space-y-4">
-          <ApiKeyProviderSelector
-            type="ai"
-            label="AI Provider"
-            value={aiProvider}
-            onChange={setAiProvider}
-          />
-          <ApiKeyProviderSelector
-            type="exchange"
-            label="Exchange"
-            value={exchangeProvider}
-            onChange={setExchangeProvider}
-          />
-        </div>
-      )}
-      {user && hasOpenAIKey && (models.length || draft?.model) && (
-        <div className="mt-4">
-          <h2 className="text-md font-bold">Model</h2>
-          <select
-            id="model"
-            value={model}
-            onChange={(e) => setModel(e.target.value)}
-            className="border rounded p-2"
-          >
-            {draft?.model && !models.length ? (
-              <option value={draft.model}>{draft.model}</option>
-            ) : (
-              models.map((m) => (
-                <option key={m} value={m}>
-                  {m}
-                </option>
-              ))
-            )}
-          </select>
+        <div className="mt-4 max-w-2xl">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <ApiKeyProviderSelector
+                type="ai"
+                label="AI Provider"
+                value={aiProvider}
+                onChange={setAiProvider}
+              />
+              {hasOpenAIKey && (models.length || draft?.model) && (
+                <div className="mt-2">
+                  <h2 className="text-md font-bold">Model</h2>
+                  <SelectInput
+                    id="model"
+                    value={model}
+                    onChange={setModel}
+                    options={
+                      draft?.model && !models.length
+                        ? [{ value: draft.model, label: draft.model }]
+                        : models.map((m) => ({ value: m, label: m }))
+                    }
+                  />
+                </div>
+              )}
+            </div>
+            <div>
+              <ApiKeyProviderSelector
+                type="exchange"
+                label="Exchange"
+                value={exchangeProvider}
+                onChange={setExchangeProvider}
+              />
+              <div className="mt-2">
+                <WalletBalances balances={balances} hasBinanceKey={hasBinanceKey} />
+              </div>
+            </div>
+          </div>
         </div>
       )}
 
-      <div className="mt-4">
-        <WalletBalances balances={balances} hasBinanceKey={hasBinanceKey} />
+      <div className="mt-4 max-w-2xl">
         <WarningSign>
           Trading agent will use all available balance for {agentData.tokens.map((t) => t.token.toUpperCase()).join(' and ')} in
           your Binance Spot wallet. Move excess funds to futures wallet before trading.


### PR DESCRIPTION
## Summary
- Align AI and exchange selectors with token inputs and add model dropdown
- Hide provider selectors when keys exist and remove strategy collapsible
- Extend update modal with model and key selectors

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd471a20c0832cb85a2e4fcb5fc299