### PR TITLE
Remove unused provider and strategy sections from agent view

### DIFF
--- a/frontend/src/components/AgentDetailsDesktop.tsx
+++ b/frontend/src/components/AgentDetailsDesktop.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import { Eye, EyeOff } from 'lucide-react';
 import AgentStatusLabel from './AgentStatusLabel';
 import TokenDisplay from './TokenDisplay';
-import StrategyForm from './StrategyForm';
 import AgentPnl from './AgentPnl';
 import FormattedDate from './ui/FormattedDate';
 import type { Agent } from '../lib/useAgentData';
@@ -13,12 +12,6 @@ interface Props {
 
 export default function AgentDetailsDesktop({ agent }: Props) {
   const [showPrompt, setShowPrompt] = useState(false);
-
-  const strategyData = {
-    tokens: agent.tokens,
-    risk: agent.risk,
-    reviewInterval: agent.reviewInterval,
-  };
 
   return (
     <div>
@@ -40,12 +33,6 @@ export default function AgentDetailsDesktop({ agent }: Props) {
           </span>
         ))}
       </p>
-      <div className="mt-2">
-        <h2 className="text-l font-bold">Strategy</h2>
-        <div className="mt-2 max-w-2xl">
-          <StrategyForm data={strategyData} onChange={() => {}} disabled />
-        </div>
-      </div>
       <div className="mt-2">
         <div className="flex items-center gap-1">
           <h2 className="text-l font-bold">Trading Instructions</h2>

--- a/frontend/src/routes/AgentView.tsx
+++ b/frontend/src/routes/AgentView.tsx
@@ -15,7 +15,6 @@ import AgentUpdateModal from '../components/AgentUpdateModal';
 import AgentDetailsDesktop from '../components/AgentDetailsDesktop';
 import AgentDetailsMobile from '../components/AgentDetailsMobile';
 import Toggle from '../components/ui/Toggle';
-import ApiKeyProviderSelector from '../components/forms/ApiKeyProviderSelector';
 
 export default function AgentView() {
   const { id } = useParams();
@@ -41,8 +40,6 @@ export default function AgentView() {
   });
 
   const [showUpdate, setShowUpdate] = useState(false);
-  const [aiProvider, setAiProvider] = useState('openai');
-  const [exchangeProvider, setExchangeProvider] = useState('binance');
 
   const [logPage, setLogPage] = useState(1);
   const [onlyRebalance, setOnlyRebalance] = useState(false);
@@ -68,20 +65,6 @@ export default function AgentView() {
     const isActive = data.status === 'active';
     return (
       <div className="p-4">
-        <div className="mb-4 space-y-4">
-          <ApiKeyProviderSelector
-            type="ai"
-            label="AI Provider"
-            value={aiProvider}
-            onChange={setAiProvider}
-          />
-          <ApiKeyProviderSelector
-            type="exchange"
-            label="Exchange"
-            value={exchangeProvider}
-            onChange={setExchangeProvider}
-          />
-        </div>
         <div className="hidden md:block">
           <AgentDetailsDesktop agent={data} />
         </div>


### PR DESCRIPTION
## Summary
- hide AI provider and exchange selectors on agent view page
- remove strategy block from desktop agent details

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd4c91c268832c90ded8d9fa88a14c