### PR TITLE
Update exec log status label

### DIFF
--- a/frontend/src/components/ExecSuccessItem.tsx
+++ b/frontend/src/components/ExecSuccessItem.tsx
@@ -26,7 +26,7 @@ export default function ExecSuccessItem({ response }: Props) {
     <div className={`mt-1 flex items-center gap-2 rounded border p-2 ${color}`}>
       <div className="flex-1 whitespace-pre-wrap break-words">
         <span className="font-bold mr-1">
-          {rebalance ? 'Rebalanced' : 'Hold'}
+          {rebalance ? 'Rebalance' : 'Hold'}
         </span>
         <span>{truncate(shortReport)}</span>
         {rebalance && typeof newAllocation === 'number' && (


### PR DESCRIPTION
## Summary
- show "Rebalance" instead of past tense "Rebalanced" in execution log entries

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd57b510b4832cb808b4dbf6e7421a