### PR TITLE
fix: wrap long logs on mobile

### DIFF
--- a/frontend/src/components/ExecLogItem.tsx
+++ b/frontend/src/components/ExecLogItem.tsx
@@ -116,14 +116,14 @@ export default function ExecLogItem({ log, agentId, manualRebalance, tokens }: P
   return (
     <div className="w-full">
       <div className="flex items-start">
-        <div className="flex-1">
+        <div className="flex-1 min-w-0">
           {!hasError && !hasResponse && text && (
             <div className="whitespace-pre-wrap break-words">{truncate(text)}</div>
           )}
           {hasError && (
             <div className="mt-1 flex items-center gap-2 rounded border border-red-300 bg-red-50 p-2 text-red-800">
               <AlertCircle className="h-4 w-4" />
-              <div className="flex-1 break-words">
+              <div className="flex-1 min-w-0 break-words">
                 <span className="font-bold mr-1">ERROR</span>
                 <span>
                   {truncate(

--- a/frontend/src/components/ExecSuccessItem.tsx
+++ b/frontend/src/components/ExecSuccessItem.tsx
@@ -24,7 +24,7 @@ export default function ExecSuccessItem({ response }: Props) {
 
   return (
     <div className={`mt-1 flex items-center gap-2 rounded border p-2 ${color}`}>
-      <div className="flex-1 whitespace-pre-wrap break-words">
+      <div className="flex-1 min-w-0 whitespace-pre-wrap break-words">
         <span className="font-bold mr-1">
           {rebalance ? 'Rebalanced' : 'Hold'}
         </span>


### PR DESCRIPTION
## Summary
- allow execution log text to wrap on small screens
- prevent log error and success items from causing horizontal overflow

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd5932c248832ca972923b34fcf1c0