### PR TITLE
Show API key inputs when keys are missing

### DIFF
--- a/frontend/src/components/forms/ApiKeyProviderSelector.tsx
+++ b/frontend/src/components/forms/ApiKeyProviderSelector.tsx
@@ -82,13 +82,21 @@ export default function ApiKeyProviderSelector({
   return (
     <div>
       <h2 className="text-md font-bold">{label}</h2>
-      <SelectInput
-        id={`${type}-provider`}
-        value={value}
-        onChange={onChange}
-        options={configs.map((p) => ({ value: p.value, label: p.label }))}
-      />
-      {hasKey === false && <div className="mt-2">{selectedConfig.renderForm()}</div>}
+      {hasKey === false && configs.length === 1 ? (
+        <div className="mt-2">{configs[0].renderForm()}</div>
+      ) : (
+        <>
+          <SelectInput
+            id={`${type}-provider`}
+            value={value}
+            onChange={onChange}
+            options={configs.map((p) => ({ value: p.value, label: p.label }))}
+          />
+          {hasKey === false && (
+            <div className="mt-2">{selectedConfig.renderForm()}</div>
+          )}
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Render API key form for a provider when its key is absent

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd71680e14832c982fef6be222db51