### PR TITLE
Show API key inputs when keys are missing

### DIFF
--- a/frontend/src/components/forms/ApiKeyProviderSelector.tsx
+++ b/frontend/src/components/forms/ApiKeyProviderSelector.tsx
@@ -60,10 +60,10 @@ export default function ApiKeyProviderSelector({
       enabled: !!user,
       queryFn: async () => {
         try {
-          await api.get(cfg.getKeyPath(user!.id));
-          return true;
+          const res = await api.get(cfg.getKeyPath(user!.id));
+          return res.data.key as string;
         } catch (err) {
-          if (axios.isAxiosError(err) && err.response?.status === 404) return false;
+          if (axios.isAxiosError(err) && err.response?.status === 404) return null;
           throw err;
         }
       },
@@ -77,18 +77,26 @@ export default function ApiKeyProviderSelector({
     0,
   );
   const selectedConfig = configs[selectedIndex];
-  const hasKey = queries[selectedIndex]?.data;
+  const hasKey = !!queries[selectedIndex]?.data;
 
   return (
     <div>
       <h2 className="text-md font-bold">{label}</h2>
-      <SelectInput
-        id={`${type}-provider`}
-        value={value}
-        onChange={onChange}
-        options={configs.map((p) => ({ value: p.value, label: p.label }))}
-      />
-      {hasKey === false && <div className="mt-2">{selectedConfig.renderForm()}</div>}
+      {hasKey === false && configs.length === 1 ? (
+        <div className="mt-2">{configs[0].renderForm()}</div>
+      ) : (
+        <>
+          <SelectInput
+            id={`${type}-provider`}
+            value={value}
+            onChange={onChange}
+            options={configs.map((p) => ({ value: p.value, label: p.label }))}
+          />
+          {hasKey === false && (
+            <div className="mt-2">{selectedConfig.renderForm()}</div>
+          )}
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Render API key form for a provider when its key is absent
- Align query cache data to reliably detect missing keys

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd71680e14832c982fef6be222db51