### PR TITLE
Verify Binance API keys with test order

### DIFF
--- a/backend/test/apiKeys.test.ts
+++ b/backend/test/apiKeys.test.ts
@@ -162,6 +162,7 @@ describe('Binance API key routes', () => {
     expect(row!.binance_api_secret_enc).toBeNull();
 
     fetchMock.mockResolvedValueOnce({ ok: true } as any);
+    fetchMock.mockResolvedValueOnce({ ok: true } as any);
     res = await app.inject({
       method: 'POST',
       url: `/api/users/${userId}/binance-key`,
@@ -215,6 +216,7 @@ describe('Binance API key routes', () => {
       secret: '<REDACTED>',
     });
 
+    fetchMock.mockResolvedValueOnce({ ok: true } as any);
     fetchMock.mockResolvedValueOnce({ ok: true } as any);
     res = await app.inject({
       method: 'PUT',


### PR DESCRIPTION
## Summary
- verify Binance API keys by placing a test order to ensure trading permissions
- adjust API key route tests for new verification flow

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`
- `npm --prefix backend audit --audit-level=high`


------
https://chatgpt.com/codex/tasks/task_e_68bd7e25f2c4832c83905b39dbdda15a