### PR TITLE
Show backend host for Binance key whitelisting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
+FROM node:22.19.0-alpine AS build
+WORKDIR /app
+COPY frontend/package*.json frontend/tsconfig.json frontend/vite.config.ts ./frontend/
+RUN npm --prefix frontend ci
+COPY frontend ./frontend
+ARG VITE_GOOGLE_CLIENT_ID
+ARG VITE_DO_SSH_HOST
+RUN VITE_GOOGLE_CLIENT_ID=$VITE_GOOGLE_CLIENT_ID VITE_DO_SSH_HOST=$VITE_DO_SSH_HOST npm --prefix frontend run build
+
 FROM caddy:2.7-alpine
-ARG FRONTEND_BUILD_DIR=dist
 COPY Caddyfile /etc/caddy/Caddyfile
-COPY frontend/${FRONTEND_BUILD_DIR}/ /usr/share/caddy/
+COPY --from=build /app/frontend/dist /usr/share/caddy/
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
     build:
       context: .
       args:
-        FRONTEND_BUILD_DIR: dist
         VITE_GOOGLE_CLIENT_ID: ${VITE_GOOGLE_CLIENT_ID}
+        VITE_DO_SSH_HOST: ${DO_SSH_HOST}
     environment:
       - DOMAIN=${DOMAIN}
     ports:

--- a/frontend/src/components/WalletBalances.tsx
+++ b/frontend/src/components/WalletBalances.tsx
@@ -11,12 +11,7 @@ export default function WalletBalances({ balances, hasBinanceKey }: Props) {
   const { user } = useUser();
 
   if (!user || !hasBinanceKey) {
-    return (
-      <div>
-        <h3 className="text-md font-bold mb-2">Binance Balances</h3>
-        <p>Binance Balances - Unavailable</p>
-      </div>
-    );
+    return null;
   }
 
   return (

--- a/frontend/src/components/forms/ApiKeySection.tsx
+++ b/frontend/src/components/forms/ApiKeySection.tsx
@@ -6,6 +6,7 @@ import api from '../../lib/axios';
 import { useUser } from '../../lib/useUser';
 import { useToast } from '../../lib/useToast';
 import Button from '../ui/Button';
+import { Copy } from 'lucide-react';
 
 interface Field {
   name: string;
@@ -21,6 +22,7 @@ interface ApiKeySectionProps {
   videoGuideUrl?: string;
   balanceQueryKey?: string;
   getBalancePath?: (id: string) => string;
+  whitelistHost?: string;
 }
 
 const textSecurityStyle: CSSProperties & { WebkitTextSecurity: string } = {
@@ -35,6 +37,7 @@ export default function ApiKeySection({
   videoGuideUrl,
   balanceQueryKey,
   getBalancePath,
+  whitelistHost,
 }: ApiKeySectionProps) {
   const { user } = useUser();
   const toast = useToast();
@@ -214,13 +217,30 @@ export default function ApiKeySection({
           {balanceQueryKey && (
             balanceQuery.isLoading ? (
               <p>Loading balance...</p>
-            ) : balanceQuery.data ? (
-              <p className="text-sm text-gray-600">
-                Total balance: ${balanceQuery.data.totalUsd.toFixed(2)}
-              </p>
-            ) : null
-          )}
-        </div>
+          ) : balanceQuery.data ? (
+            <p className="text-sm text-gray-600">
+              Total balance: ${balanceQuery.data.totalUsd.toFixed(2)}
+            </p>
+          ) : null
+        )}
+      </div>
+    )}
+      {whitelistHost && (
+        <p className="text-sm text-gray-600 flex items-center gap-2">
+          Whitelist IP:
+          <span className="font-mono">{whitelistHost}</span>
+          <button
+            type="button"
+            className="p-1 border rounded"
+            onClick={() => {
+              navigator.clipboard.writeText(whitelistHost);
+              toast.show('Copied to clipboard');
+            }}
+            aria-label="Copy IP"
+          >
+            <Copy className="w-4 h-4" />
+          </button>
+        </p>
       )}
     </div>
   );

--- a/frontend/src/components/forms/ExchangeApiKeySection.tsx
+++ b/frontend/src/components/forms/ExchangeApiKeySection.tsx
@@ -15,16 +15,23 @@ interface Props {
 }
 
 export default function ExchangeApiKeySection({ exchange, label }: Props) {
-  return (
+  const commonProps = {
+    label,
+    queryKey: `${exchange}-key`,
+    getKeyPath: (id: string) => `/users/${id}/${exchange}-key`,
+    fields: exchangeFields,
+    videoGuideUrl: videoGuideLinks[exchange],
+    balanceQueryKey: `${exchange}-balance`,
+    getBalancePath: (id: string) => `/users/${id}/${exchange}-balance`,
+  } as const;
+
+  return exchange === 'binance' ? (
     <ApiKeySection
-      label={label}
-      queryKey={`${exchange}-key`}
-      getKeyPath={(id) => `/users/${id}/${exchange}-key`}
-      fields={exchangeFields}
-      videoGuideUrl={videoGuideLinks[exchange]}
-      balanceQueryKey={`${exchange}-balance`}
-      getBalancePath={(id) => `/users/${id}/${exchange}-balance`}
+      {...commonProps}
+      whitelistHost={import.meta.env.VITE_DO_SSH_HOST}
     />
+  ) : (
+    <ApiKeySection {...commonProps} />
   );
 }
 


### PR DESCRIPTION
## Summary
- Display backend host from `VITE_DO_SSH_HOST` when editing Binance API key, with a copy-to-clipboard button
- Hide Binance balance section when no API key is configured
- Pass the whitelist host only for Binance to avoid showing it on other exchanges
- Build the frontend inside Docker so `DO_SSH_HOST` is included in the production bundle

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd79a4aec0832ca5cb7e3ce1b9d48a