### PR TITLE
Improve mobile API key section layout

### DIFF
--- a/frontend/src/components/forms/AiApiKeySection.tsx
+++ b/frontend/src/components/forms/AiApiKeySection.tsx
@@ -1,8 +1,9 @@
+import { type ReactNode } from 'react';
 import ApiKeySection from './ApiKeySection';
 
 const aiFields = [{ name: 'key', placeholder: 'API key' }];
 
-export default function AiApiKeySection({ label }: { label: string }) {
+export default function AiApiKeySection({ label }: { label: ReactNode }) {
   return (
     <ApiKeySection
       label={label}

--- a/frontend/src/components/forms/ApiKeyProviderSelector.tsx
+++ b/frontend/src/components/forms/ApiKeyProviderSelector.tsx
@@ -33,7 +33,14 @@ const exchangeConfigs: ProviderConfig[] = [
     queryKey: 'binance-key',
     getKeyPath: (id) => `/users/${id}/binance-key`,
     renderForm: () => (
-      <ExchangeApiKeySection exchange="binance" label="Binance API Credentials" />
+      <ExchangeApiKeySection
+        exchange="binance"
+        label={
+          <>
+            Binance API <span className="hidden sm:inline">Credentials</span>
+          </>
+        }
+      />
     ),
   },
 ];

--- a/frontend/src/components/forms/ApiKeySection.tsx
+++ b/frontend/src/components/forms/ApiKeySection.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useMemo, useState, type CSSProperties } from 'react';
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from 'react';
 import { useForm } from 'react-hook-form';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import axios from 'axios';
@@ -15,7 +21,7 @@ interface Field {
 }
 
 interface ApiKeySectionProps {
-  label?: string;
+  label?: ReactNode;
   queryKey: string;
   getKeyPath: (id: string) => string;
   fields: Field[];
@@ -226,21 +232,23 @@ export default function ApiKeySection({
       </div>
     )}
       {whitelistHost && (
-        <p className="text-sm text-gray-600 flex items-center gap-2">
-          Whitelist IP:
-          <span className="font-mono">{whitelistHost}</span>
-          <button
-            type="button"
-            className="p-1 border rounded"
-            onClick={() => {
-              navigator.clipboard.writeText(whitelistHost);
-              toast.show('Copied to clipboard');
-            }}
-            aria-label="Copy IP"
-          >
-            <Copy className="w-4 h-4" />
-          </button>
-        </p>
+        <div className="text-sm text-gray-600 sm:flex sm:items-center sm:gap-2">
+          <span className="block sm:inline">Whitelist IP:</span>
+          <span className="flex items-center gap-2">
+            <span className="font-mono">{whitelistHost}</span>
+            <button
+              type="button"
+              className="p-1 border rounded"
+              onClick={() => {
+                navigator.clipboard.writeText(whitelistHost);
+                toast.show('Copied to clipboard');
+              }}
+              aria-label="Copy IP"
+            >
+              <Copy className="w-4 h-4" />
+            </button>
+          </span>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/forms/ExchangeApiKeySection.tsx
+++ b/frontend/src/components/forms/ExchangeApiKeySection.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode } from 'react';
 import ApiKeySection from './ApiKeySection';
 
 const videoGuideLinks: Record<string, string> = {
@@ -11,7 +12,7 @@ const exchangeFields = [
 
 interface Props {
   exchange: string;
-  label: string;
+  label: ReactNode;
 }
 
 export default function ExchangeApiKeySection({ exchange, label }: Props) {

--- a/frontend/src/routes/Keys.tsx
+++ b/frontend/src/routes/Keys.tsx
@@ -12,7 +12,14 @@ export default function Keys() {
         decrypted solely when needed to call providers and are never shared.
       </div>
       <AiApiKeySection label="OpenAI API Key" />
-      <ExchangeApiKeySection exchange="binance" label="Binance API Credentials" />
+      <ExchangeApiKeySection
+        exchange="binance"
+        label={
+          <>
+            Binance API <span className="hidden sm:inline">Credentials</span>
+          </>
+        }
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Stack whitelist IP label above the IP on mobile for better readability
- Show "Binance API" on small screens and append "Credentials" on larger displays

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd8900d544832c93a3543d78f44f5d