### PR TITLE
Surface Binance error when key validation fails

### DIFF
--- a/backend/src/routes/api-keys.ts
+++ b/backend/src/routes/api-keys.ts
@@ -134,8 +134,17 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
       if (err) return reply.code(err.code).send(err.body);
       err = ensureKeyAbsent(row, ['binance_api_key_enc', 'binance_api_secret_enc']);
       if (err) return reply.code(err.code).send(err.body);
-      if (!(await verifyApiKey(ApiKeyType.Binance, key, secret)))
-        return reply.code(400).send(errorResponse('verification failed'));
+      const verRes = await verifyApiKey(ApiKeyType.Binance, key, secret);
+      if (verRes !== true)
+        return reply
+          .code(400)
+          .send(
+            errorResponse(
+              `verification failed${
+                typeof verRes === 'string' ? `: ${verRes}` : ''
+              }`,
+            ),
+          );
       const encKey = encryptKey(key);
       const encSecret = encryptKey(secret);
       await setBinanceKey(id, encKey, encSecret);
@@ -178,8 +187,17 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
         'binance_api_secret_enc',
       ]);
       if (err) return reply.code(err.code).send(err.body);
-      if (!(await verifyApiKey(ApiKeyType.Binance, key, secret)))
-        return reply.code(400).send(errorResponse('verification failed'));
+      const verRes = await verifyApiKey(ApiKeyType.Binance, key, secret);
+      if (verRes !== true)
+        return reply
+          .code(400)
+          .send(
+            errorResponse(
+              `verification failed${
+                typeof verRes === 'string' ? `: ${verRes}` : ''
+              }`,
+            ),
+          );
       const encKey = encryptKey(key);
       const encSecret = encryptKey(secret);
       await setBinanceKey(id, encKey, encSecret);

--- a/backend/test/apiKeys.test.ts
+++ b/backend/test/apiKeys.test.ts
@@ -148,7 +148,10 @@ describe('Binance API key routes', () => {
     const secret1 = 'bsec1234567890';
     const secret2 = 'bsecabcdefghij';
 
-    fetchMock.mockResolvedValueOnce({ ok: false } as any);
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ msg: 'Invalid API-key' }),
+    } as any);
     let res = await app.inject({
       method: 'POST',
       url: `/api/users/${userId}/binance-key`,
@@ -156,7 +159,9 @@ describe('Binance API key routes', () => {
       payload: { key: 'bad', secret: 'bad' },
     });
     expect(res.statusCode).toBe(400);
-    expect(res.json()).toMatchObject({ error: 'verification failed' });
+    expect(res.json()).toMatchObject({
+      error: 'verification failed: Invalid API-key',
+    });
     let row = await getBinanceKeyRow(userId);
     expect(row!.binance_api_key_enc).toBeNull();
     expect(row!.binance_api_secret_enc).toBeNull();


### PR DESCRIPTION
## Summary
- include Binance's error message in API key validation failures
- show detailed Binance error when updating existing key
- adjust tests for new error format

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test` *(fails: connect ECONNREFUSED)*
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68be0cbc0b8c832cb78e756c2c442ee9