### PR TITLE
Add short review intervals and default to 30m

### DIFF
--- a/backend/scripts/start.ts
+++ b/backend/scripts/start.ts
@@ -14,6 +14,9 @@ async function main() {
   const log = app.log;
 
   const schedules: Record<string, string> = {
+    '10m': '*/10 * * * *',
+    '15m': '*/15 * * * *',
+    '30m': '*/30 * * * *',
     '1h': '0 * * * *',
     '3h': '0 */3 * * *',
     '5h': '0 */5 * * *',

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -16,6 +16,9 @@ export const riskOptions = [
 ];
 
 export const reviewIntervalOptions = [
+    {value: '10m', label: '10 Minutes'},
+    {value: '15m', label: '15 Minutes'},
+    {value: '30m', label: '30 Minutes'},
     {value: '1h', label: '1 Hour'},
     {value: '3h', label: '3 Hours'},
     {value: '5h', label: '5 Hours'},
@@ -42,7 +45,18 @@ export const createAgentSchema = z
             )
             .length(2),
         risk: z.enum(['low', 'medium', 'high']),
-        reviewInterval: z.enum(['1h', '3h', '5h', '12h', '24h', '3d', '1w']),
+        reviewInterval: z.enum([
+            '10m',
+            '15m',
+            '30m',
+            '1h',
+            '3h',
+            '5h',
+            '12h',
+            '24h',
+            '3d',
+            '1w',
+        ]),
     })
     .refine((data) => data.tokens[0].token !== data.tokens[1].token, {
         message: 'Tokens must be different',
@@ -65,6 +79,6 @@ export const createAgentDefaults: CreateAgentFormValues = {
         {token: 'SOL', minAllocation: 30},
     ],
     risk: 'low',
-    reviewInterval: '1h',
+    reviewInterval: '30m',
 };
 


### PR DESCRIPTION
## Summary
- allow 10m, 15m, and 30m agent review intervals
- schedule backend cron jobs for new minute intervals
- default to 30m review interval in UI forms

## Testing
- `psql --version`
- `psql -h localhost -U postgres -d promptswap_test -c '\l'`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm run build`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be15c525c8832ca523956f7b02a52e