### PR TITLE
fetch server ip dynamically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,6 @@ jobs:
         name: Build frontend and backend
         env:
           VITE_GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-          VITE_DO_SSH_HOST: ${{ secrets.DO_SSH_HOST }}
         run: |
           set -e
           npm --prefix frontend run build & pid1=$!
@@ -148,13 +147,12 @@ jobs:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           DOMAIN: ${{ secrets.DOMAIN }}
           DB_CONNECTION_STR: ${{ secrets.DB_CONNECTION_STR }}
-          OUTPUT_IP: ${{ secrets.OUTPUT_IP }}
         with:
           host: ${{ secrets.DO_SSH_HOST }}
           username: ${{ secrets.DO_SSH_USER }}
           key: ${{ secrets.DO_SSH_PRIVATE_KEY }}
           passphrase: ${{ secrets.DO_SSH_PASSPHRASE }}
-          envs: KEY_PASSWORD,GOOGLE_CLIENT_ID,DOMAIN,DB_CONNECTION_STR,OUTPUT_IP
+          envs: KEY_PASSWORD,GOOGLE_CLIENT_ID,DOMAIN,DB_CONNECTION_STR
           script: |
             set -euo pipefail
             cd ~/prompt-swap
@@ -162,7 +160,6 @@ jobs:
             export GOOGLE_CLIENT_ID="${GOOGLE_CLIENT_ID}"
             export DOMAIN="${DOMAIN}"
             export VITE_GOOGLE_CLIENT_ID="${GOOGLE_CLIENT_ID}"
-            export VITE_DO_SSH_HOST="${OUTPUT_IP}"
             export DB_CONNECTION_STR="${DB_CONNECTION_STR}"
             docker compose up -d --build
             timeout 60s bash -c 'until curl -fsS -H "Host: ${DOMAIN}" http://localhost/api/health; do sleep 3; done'

--- a/backend/src/routes/ip.ts
+++ b/backend/src/routes/ip.ts
@@ -1,0 +1,15 @@
+import type { FastifyInstance } from 'fastify';
+import { RATE_LIMITS } from '../rate-limit.js';
+import { getOutputIp } from '../util/output-ip.js';
+
+export default async function ipRoute(app: FastifyInstance) {
+  app.get(
+    '/ip',
+    {
+      config: { rateLimit: RATE_LIMITS.LAX },
+    },
+    async () => {
+      return { ip: getOutputIp() };
+    },
+  );
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -8,6 +8,7 @@ import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { RATE_LIMITS } from './rate-limit.js';
 import { errorResponse } from './util/errorMessages.js';
+import { fetchOutputIp } from './util/output-ip.js';
 
 export default async function buildServer(
   routesDir: string = path.join(process.cwd(), 'src/routes'),
@@ -46,6 +47,8 @@ export default async function buildServer(
       ...errorResponse(`Too many requests, please try again in ${context.after}.`),
     }),
   });
+
+  await fetchOutputIp();
 
   for (const file of fs.readdirSync(routesDir)) {
     if (file.endsWith('.js') || (file.endsWith('.ts') && !file.endsWith('.d.ts'))) {

--- a/backend/src/util/output-ip.ts
+++ b/backend/src/util/output-ip.ts
@@ -1,0 +1,19 @@
+let outputIp = 'unknown';
+let fetched = false;
+
+export async function fetchOutputIp(): Promise<string> {
+  if (!fetched) {
+    fetched = true;
+    try {
+      const res = await fetch('https://api.ipify.org');
+      outputIp = await res.text();
+    } catch (err) {
+      // ignore errors, keep 'unknown'
+    }
+  }
+  return outputIp;
+}
+
+export function getOutputIp(): string {
+  return outputIp;
+}

--- a/backend/test/ip.test.ts
+++ b/backend/test/ip.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import buildServer from '../src/server.js';
+
+describe('ip route', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns server ip', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ text: async () => '1.2.3.4' })) as any);
+    const app = await buildServer();
+    const res = await app.inject({ method: 'GET', url: '/api/ip' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ip: '1.2.3.4' });
+    await app.close();
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
       args:
         FRONTEND_BUILD_DIR: dist
         VITE_GOOGLE_CLIENT_ID: ${VITE_GOOGLE_CLIENT_ID}
-        VITE_DO_SSH_HOST: ${VITE_DO_SSH_HOST}
     environment:
       - DOMAIN=${DOMAIN}
     ports:

--- a/frontend/src/components/forms/ExchangeApiKeySection.tsx
+++ b/frontend/src/components/forms/ExchangeApiKeySection.tsx
@@ -1,4 +1,6 @@
 import { type ReactNode } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import api from '../../lib/axios';
 import ApiKeySection from './ApiKeySection';
 
 const videoGuideLinks: Record<string, string> = {
@@ -26,10 +28,19 @@ export default function ExchangeApiKeySection({ exchange, label }: Props) {
     getBalancePath: (id: string) => `/users/${id}/${exchange}-balance`,
   } as const;
 
+  const whitelistQuery = useQuery<string>({
+    queryKey: ['output-ip'],
+    enabled: exchange === 'binance',
+    queryFn: async () => {
+      const res = await api.get('/ip');
+      return (res.data as { ip: string }).ip;
+    },
+  });
+
   return exchange === 'binance' ? (
     <ApiKeySection
       {...commonProps}
-      whitelistHost={import.meta.env.VITE_DO_SSH_HOST}
+      whitelistHost={whitelistQuery.data}
     />
   ) : (
     <ApiKeySection {...commonProps} />


### PR DESCRIPTION
## Summary
- drop OUTPUT_IP usage from CI and docker compose
- add backend utility and route to fetch and serve server public IP
- frontend now requests IP via API instead of env var

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix backend run build`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend audit --audit-level=high`


------
https://chatgpt.com/codex/tasks/task_e_68be1f885814832cae772c6c38c29620