### PR TITLE
Fix Binance symbol and quantity precision for limit orders

### DIFF
--- a/backend/src/services/binance.ts
+++ b/backend/src/services/binance.ts
@@ -180,6 +180,38 @@ export async function cancelOpenOrders(
   return res.json();
 }
 
+type ExchangeInfo = {
+  symbols: { filters: { filterType: string; stepSize?: string }[] }[];
+};
+
+const exchangeInfoCache = new Map<string, Promise<ExchangeInfo>>();
+
+async function fetchExchangeInfo(symbol: string): Promise<ExchangeInfo> {
+  let infoPromise = exchangeInfoCache.get(symbol);
+  if (!infoPromise) {
+    infoPromise = fetch(
+      `https://api.binance.com/api/v3/exchangeInfo?symbol=${symbol}`,
+    )
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.text();
+          throw new Error(`failed to fetch info data: ${res.status} ${body}`);
+        }
+        return (res.json() as Promise<ExchangeInfo>);
+      })
+      .catch((err) => {
+        exchangeInfoCache.delete(symbol);
+        throw err;
+      });
+    exchangeInfoCache.set(symbol, infoPromise);
+  }
+  return infoPromise;
+}
+
+export function __clearExchangeInfoCache() {
+  exchangeInfoCache.clear();
+}
+
 async function fetchSymbolData(symbol: string) {
   const [priceRes, depthRes, dayRes, yearRes] = await Promise.all([
     fetch(`https://api.binance.com/api/v3/ticker/price?symbol=${symbol}`),
@@ -207,6 +239,13 @@ async function fetchSymbolData(symbol: string) {
     asks: [string, string][];
   };
   const yearJson = (await yearRes.json()) as unknown[];
+  const infoJson = await fetchExchangeInfo(symbol);
+  const lot = infoJson.symbols[0]?.filters.find(
+    (f) => f.filterType === 'LOT_SIZE',
+  );
+  if (!lot?.stepSize) {
+    throw new Error('missing step size for symbol');
+  }
   return {
     currentPrice: Number(priceJson.price),
     orderBook: {
@@ -215,6 +254,7 @@ async function fetchSymbolData(symbol: string) {
     },
     day: await dayRes.json(),
     year: yearJson,
+    stepSize: Number(lot.stepSize),
   };
 }
 
@@ -226,11 +266,15 @@ export async function fetchPairData(token1: string, token2: string) {
   let lastErr: unknown;
   for (const symbol of symbols) {
     try {
-      return await fetchSymbolData(symbol);
+      const data = await fetchSymbolData(symbol);
+      return { symbol, ...data };
     } catch (err) {
       lastErr = err;
-      if (err instanceof Error && /Invalid symbol/i.test(err.message)) {
-        continue;
+      if (err instanceof Error) {
+        const msg = parseBinanceError(err) ?? err.message;
+        if (/Invalid symbol/i.test(msg)) {
+          continue;
+        }
       }
       throw err;
     }

--- a/backend/src/services/rebalance.ts
+++ b/backend/src/services/rebalance.ts
@@ -14,16 +14,38 @@ export async function calcRebalanceOrder(opts: {
   const pos1 = positions.find((p) => p.sym === token1);
   const pos2 = positions.find((p) => p.sym === token2);
   if (!pos1 || !pos2) return null;
-  const { currentPrice } = await fetchPairData(token1, token2);
+  const pair = await fetchPairData(token1, token2);
+  const { currentPrice, symbol, stepSize } = pair as {
+    currentPrice: number;
+    symbol: string;
+    stepSize: number | undefined;
+  };
+  if (stepSize === undefined) {
+    throw new Error('missing step size for symbol');
+  }
   const total = pos1.value_usdt + pos2.value_usdt;
   const target1 = (newAllocation / 100) * total;
   const diff = target1 - pos1.value_usdt;
   if (!diff || Math.abs(diff) < MIN_LIMIT_ORDER_USD) return null;
-  const side = diff > 0 ? 'BUY' : 'SELL';
-  const quantity = Math.abs(diff) / currentPrice;
+  const baseIsToken1 = symbol === `${token1}${token2}`.toUpperCase();
+  const side = baseIsToken1
+    ? diff > 0
+      ? 'BUY'
+      : 'SELL'
+    : diff > 0
+    ? 'SELL'
+    : 'BUY';
+  const rawQty = Math.abs(diff) / currentPrice;
+  const step = stepSize;
+  const precision = String(step).includes('.')
+    ? String(step).split('.')[1].replace(/0+$/, '').length
+    : 0;
+  const quantity = Number(
+    (Math.floor(rawQty / step) * step).toFixed(precision),
+  );
   const better = side === 'BUY' ? 0.999 : 1.001;
   const price = currentPrice * better;
-  return { side, quantity, price } as const;
+  return { side, quantity, price, symbol, stepSize } as const;
 }
 
 export async function createRebalanceLimitOrder(opts: {
@@ -48,16 +70,23 @@ export async function createRebalanceLimitOrder(opts: {
     quantity,
     manuallyEdited,
   } = opts;
-  const [token1, token2] = tokens;
   const order = await calcRebalanceOrder({ tokens, positions, newAllocation });
   if (!order) {
     log.info('no rebalance needed');
     return;
   }
+  const step = order.stepSize;
+  const precision = String(step).includes('.')
+    ? String(step).split('.')[1].replace(/0+$/, '').length
+    : 0;
+  const qty =
+    quantity !== undefined
+      ? Number((Math.floor(quantity / step) * step).toFixed(precision))
+      : order.quantity;
   const params = {
-    symbol: `${token1}${token2}`.toUpperCase(),
+    symbol: order.symbol,
     side: order.side,
-    quantity: quantity ?? order.quantity,
+    quantity: qty,
     price: price ?? order.price,
   } as const;
   log.info({ order: params }, 'creating limit order');

--- a/backend/test/agentExecLog.test.ts
+++ b/backend/test/agentExecLog.test.ts
@@ -259,7 +259,9 @@ describe('agent exec log routes', () => {
       ],
     } as any);
     vi.spyOn(binance, 'fetchPairData').mockResolvedValue({
+      symbol: 'BTCETH',
       currentPrice: 100,
+      stepSize: 0.001,
     } as any);
     vi.spyOn(binance, 'createLimitOrder').mockResolvedValue({ orderId: 1 } as any);
     let res = await app.inject({
@@ -315,7 +317,9 @@ describe('agent exec log routes', () => {
       ],
     } as any);
     vi.spyOn(binance, 'fetchPairData').mockResolvedValue({
+      symbol: 'BTCETH',
       currentPrice: 100,
+      stepSize: 0.001,
     } as any);
     const spy = vi
       .spyOn(binance, 'createLimitOrder')
@@ -367,7 +371,9 @@ describe('agent exec log routes', () => {
       ],
     } as any);
     vi.spyOn(binance, 'fetchPairData').mockResolvedValue({
+      symbol: 'BTCETH',
       currentPrice: 100,
+      stepSize: 0.001,
     } as any);
     const res = await app.inject({
       method: 'GET',
@@ -416,7 +422,9 @@ describe('agent exec log routes', () => {
       ],
     } as any);
     vi.spyOn(binance, 'fetchPairData').mockResolvedValue({
+      symbol: 'BTCETH',
       currentPrice: 100,
+      stepSize: 0.001,
     } as any);
     vi.spyOn(binance, 'createLimitOrder').mockRejectedValue(
       new Error(

--- a/backend/test/indicators.test.ts
+++ b/backend/test/indicators.test.ts
@@ -25,9 +25,21 @@ describe('fetchTokenIndicators', () => {
     (fetchPairData as unknown as ReturnType<typeof vi.fn>).mockImplementation(
       async (token: string) => {
         if (token === 'BTC') {
-          return { currentPrice: 400, day: {}, year: makeYear(2) };
+          return {
+            symbol: 'BTCUSDT',
+            currentPrice: 400,
+            day: {},
+            year: makeYear(2),
+            stepSize: 0.001,
+          };
         }
-        return { currentPrice: 200, day: {}, year: makeYear(1) };
+        return {
+          symbol: `${token}USDT`,
+          currentPrice: 200,
+          day: {},
+          year: makeYear(1),
+          stepSize: 0.001,
+        };
       },
     );
 

--- a/backend/test/rebalance.test.ts
+++ b/backend/test/rebalance.test.ts
@@ -7,12 +7,16 @@ import { insertReviewResult } from './repos/agent-review-result.js';
 import { db } from '../src/db/index.js';
 
 vi.mock('../src/services/binance.js', () => ({
-  fetchPairData: vi.fn().mockResolvedValue({ currentPrice: 100 }),
+  fetchPairData: vi.fn().mockResolvedValue({
+    symbol: 'BTCUSDT',
+    currentPrice: 100,
+    stepSize: 0.001,
+  }),
   createLimitOrder: vi.fn().mockResolvedValue({ orderId: 1 }),
 }));
 
 import { createRebalanceLimitOrder } from '../src/services/rebalance.js';
-import { createLimitOrder } from '../src/services/binance.js';
+import { createLimitOrder, fetchPairData } from '../src/services/binance.js';
 
 describe('createRebalanceLimitOrder', () => {
   beforeEach(async () => {
@@ -28,8 +32,8 @@ describe('createRebalanceLimitOrder', () => {
       startBalance: null,
       name: 'A',
       tokens: [
-        { token: 'BTC', minAllocation: 10 },
-        { token: 'ETH', minAllocation: 20 },
+        { token: 'USDT', minAllocation: 10 },
+        { token: 'BTC', minAllocation: 20 },
       ],
       risk: 'low',
       reviewInterval: '1h',
@@ -39,10 +43,10 @@ describe('createRebalanceLimitOrder', () => {
     const reviewResultId = await insertReviewResult({ agentId: agent.id, log: '' });
     await createRebalanceLimitOrder({
       userId,
-      tokens: ['BTC', 'ETH'],
+      tokens: ['USDT', 'BTC'],
       positions: [
+        { sym: 'USDT', value_usdt: 150 },
         { sym: 'BTC', value_usdt: 50 },
-        { sym: 'ETH', value_usdt: 150 },
       ],
       newAllocation: 50,
       log,
@@ -53,7 +57,7 @@ describe('createRebalanceLimitOrder', () => {
 
     expect(row.user_id).toBe(userId);
     expect(JSON.parse(row.planned_json)).toMatchObject({
-      symbol: 'BTCETH',
+      symbol: 'BTCUSDT',
       side: 'BUY',
       quantity: 0.5,
       price: 99.9,
@@ -63,7 +67,7 @@ describe('createRebalanceLimitOrder', () => {
     expect(row.review_result_id).toBe(reviewResultId);
     expect(row.order_id).toBe('1');
     expect(createLimitOrder).toHaveBeenCalledWith(userId, {
-      symbol: 'BTCETH',
+      symbol: 'BTCUSDT',
       side: 'BUY',
       quantity: 0.5,
       price: 99.9,
@@ -80,8 +84,8 @@ describe('createRebalanceLimitOrder', () => {
       startBalance: null,
       name: 'A',
       tokens: [
-        { token: 'BTC', minAllocation: 10 },
-        { token: 'ETH', minAllocation: 20 },
+        { token: 'USDT', minAllocation: 10 },
+        { token: 'BTC', minAllocation: 20 },
       ],
       risk: 'low',
       reviewInterval: '1h',
@@ -91,10 +95,10 @@ describe('createRebalanceLimitOrder', () => {
     const reviewResultId = await insertReviewResult({ agentId: agent.id, log: '' });
     await createRebalanceLimitOrder({
       userId,
-      tokens: ['BTC', 'ETH'],
+      tokens: ['USDT', 'BTC'],
       positions: [
+        { sym: 'USDT', value_usdt: 150 },
         { sym: 'BTC', value_usdt: 50 },
-        { sym: 'ETH', value_usdt: 150 },
       ],
       newAllocation: 50,
       log,
@@ -105,7 +109,7 @@ describe('createRebalanceLimitOrder', () => {
     });
     const row = (await getLimitOrders())[0];
     expect(JSON.parse(row.planned_json)).toMatchObject({
-      symbol: 'BTCETH',
+      symbol: 'BTCUSDT',
       side: 'BUY',
       quantity: 0.3,
       price: 120,
@@ -123,8 +127,8 @@ describe('createRebalanceLimitOrder', () => {
       startBalance: null,
       name: 'A',
       tokens: [
-        { token: 'BTC', minAllocation: 10 },
-        { token: 'ETH', minAllocation: 20 },
+        { token: 'USDT', minAllocation: 10 },
+        { token: 'BTC', minAllocation: 20 },
       ],
       risk: 'low',
       reviewInterval: '1h',
@@ -135,10 +139,10 @@ describe('createRebalanceLimitOrder', () => {
     vi.mocked(createLimitOrder).mockClear();
     await createRebalanceLimitOrder({
       userId,
-      tokens: ['BTC', 'ETH'],
+      tokens: ['USDT', 'BTC'],
       positions: [
-        { sym: 'BTC', value_usdt: 100 },
-        { sym: 'ETH', value_usdt: 99.99 },
+        { sym: 'USDT', value_usdt: 100 },
+        { sym: 'BTC', value_usdt: 99.99 },
       ],
       newAllocation: 50,
       log,
@@ -147,5 +151,83 @@ describe('createRebalanceLimitOrder', () => {
     const rows = await getLimitOrders();
     expect(rows).toHaveLength(0);
     expect(createLimitOrder).not.toHaveBeenCalled();
+  });
+
+  it('rounds quantity down to step size precision', async () => {
+    const log = { info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
+    const userId = await insertUser('4');
+    const agent = await insertAgent({
+      userId,
+      model: 'm',
+      status: 'active',
+      startBalance: null,
+      name: 'A',
+      tokens: [
+        { token: 'BTC', minAllocation: 10 },
+        { token: 'USDT', minAllocation: 20 },
+      ],
+      risk: 'low',
+      reviewInterval: '1h',
+      agentInstructions: 'inst',
+      manualRebalance: false,
+    });
+    const reviewResultId = await insertReviewResult({ agentId: agent.id, log: '' });
+    vi.mocked(fetchPairData).mockResolvedValueOnce({
+      symbol: 'BTCUSDT',
+      currentPrice: 1,
+      stepSize: 0.01,
+    } as any);
+    await createRebalanceLimitOrder({
+      userId,
+      tokens: ['BTC', 'USDT'],
+      positions: [
+        { sym: 'BTC', value_usdt: 0 },
+        { sym: 'USDT', value_usdt: 100.555 },
+      ],
+      newAllocation: 50,
+      log,
+      reviewResultId,
+    });
+    const row = (await getLimitOrders())[0];
+    expect(JSON.parse(row.planned_json)).toMatchObject({ quantity: 50.27 });
+    expect(createLimitOrder).toHaveBeenCalledWith(userId, expect.objectContaining({ quantity: 50.27 }));
+  });
+
+  it('throws if step size is missing', async () => {
+    const log = { info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
+    const userId = await insertUser('5');
+    const agent = await insertAgent({
+      userId,
+      model: 'm',
+      status: 'active',
+      startBalance: null,
+      name: 'A',
+      tokens: [
+        { token: 'USDT', minAllocation: 10 },
+        { token: 'BTC', minAllocation: 20 },
+      ],
+      risk: 'low',
+      reviewInterval: '1h',
+      agentInstructions: 'inst',
+      manualRebalance: false,
+    });
+    const reviewResultId = await insertReviewResult({ agentId: agent.id, log: '' });
+    vi.mocked(fetchPairData).mockResolvedValueOnce({
+      symbol: 'BTCUSDT',
+      currentPrice: 1,
+    } as any);
+    await expect(
+      createRebalanceLimitOrder({
+        userId,
+        tokens: ['USDT', 'BTC'],
+        positions: [
+          { sym: 'USDT', value_usdt: 150 },
+          { sym: 'BTC', value_usdt: 50 },
+        ],
+        newAllocation: 50,
+        log,
+        reviewResultId,
+      }),
+    ).rejects.toThrow(/step size/);
   });
 });

--- a/backend/test/reviewPortfolio.test.ts
+++ b/backend/test/reviewPortfolio.test.ts
@@ -34,7 +34,11 @@ vi.mock('../src/services/binance.js', () => ({
       { asset: 'ETH', free: '2', locked: '0' },
     ],
   }),
-  fetchPairData: vi.fn().mockResolvedValue({ currentPrice: 100 }),
+  fetchPairData: vi.fn().mockResolvedValue({
+    symbol: 'BTCUSDT',
+    currentPrice: 100,
+    stepSize: 0.001,
+  }),
   fetchMarketTimeseries: vi.fn().mockResolvedValue(sampleTimeseries),
 }));
 


### PR DESCRIPTION
## Summary
- Fetch Binance exchange info to determine lot size step and return it with pair data
- Round rebalance order quantities down to the allowed step size to avoid precision errors
- Throw error when step size cannot be determined to prevent invalid orders
- Add tests covering step size retrieval, quantity rounding, and missing step size failures
- Cache Binance exchangeInfo per symbol to avoid redundant requests and provide a reset helper for tests
- Fix reversed pair retry test to match early termination before exchange info fetch
- Parse Binance errors so reversed pair lookups retry correctly on invalid symbol responses

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68be2850ab34832cbc28412b21995b33