### PR TITLE
Fix Binance symbol and quantity precision for limit orders

### DIFF
--- a/backend/test/agentExecLog.test.ts
+++ b/backend/test/agentExecLog.test.ts
@@ -259,7 +259,9 @@ describe('agent exec log routes', () => {
       ],
     } as any);
     vi.spyOn(binance, 'fetchPairData').mockResolvedValue({
+      symbol: 'BTCETH',
       currentPrice: 100,
+      stepSize: 0.001,
     } as any);
     vi.spyOn(binance, 'createLimitOrder').mockResolvedValue({ orderId: 1 } as any);
     let res = await app.inject({
@@ -315,7 +317,9 @@ describe('agent exec log routes', () => {
       ],
     } as any);
     vi.spyOn(binance, 'fetchPairData').mockResolvedValue({
+      symbol: 'BTCETH',
       currentPrice: 100,
+      stepSize: 0.001,
     } as any);
     const spy = vi
       .spyOn(binance, 'createLimitOrder')
@@ -367,7 +371,9 @@ describe('agent exec log routes', () => {
       ],
     } as any);
     vi.spyOn(binance, 'fetchPairData').mockResolvedValue({
+      symbol: 'BTCETH',
       currentPrice: 100,
+      stepSize: 0.001,
     } as any);
     const res = await app.inject({
       method: 'GET',
@@ -416,7 +422,9 @@ describe('agent exec log routes', () => {
       ],
     } as any);
     vi.spyOn(binance, 'fetchPairData').mockResolvedValue({
+      symbol: 'BTCETH',
       currentPrice: 100,
+      stepSize: 0.001,
     } as any);
     vi.spyOn(binance, 'createLimitOrder').mockRejectedValue(
       new Error(

--- a/backend/test/indicators.test.ts
+++ b/backend/test/indicators.test.ts
@@ -25,9 +25,21 @@ describe('fetchTokenIndicators', () => {
     (fetchPairData as unknown as ReturnType<typeof vi.fn>).mockImplementation(
       async (token: string) => {
         if (token === 'BTC') {
-          return { currentPrice: 400, day: {}, year: makeYear(2) };
+          return {
+            symbol: 'BTCUSDT',
+            currentPrice: 400,
+            day: {},
+            year: makeYear(2),
+            stepSize: 0.001,
+          };
         }
-        return { currentPrice: 200, day: {}, year: makeYear(1) };
+        return {
+          symbol: `${token}USDT`,
+          currentPrice: 200,
+          day: {},
+          year: makeYear(1),
+          stepSize: 0.001,
+        };
       },
     );
 

--- a/backend/test/reviewPortfolio.test.ts
+++ b/backend/test/reviewPortfolio.test.ts
@@ -34,7 +34,11 @@ vi.mock('../src/services/binance.js', () => ({
       { asset: 'ETH', free: '2', locked: '0' },
     ],
   }),
-  fetchPairData: vi.fn().mockResolvedValue({ currentPrice: 100 }),
+  fetchPairData: vi.fn().mockResolvedValue({
+    symbol: 'BTCUSDT',
+    currentPrice: 100,
+    stepSize: 0.001,
+  }),
   fetchMarketTimeseries: vi.fn().mockResolvedValue(sampleTimeseries),
 }));
 


### PR DESCRIPTION
## Summary
- Fetch Binance exchange info to determine lot size step and return it with pair data
- Round and format rebalance order quantities to the allowed step size, ensuring Binance accepts the precision
- Throw error when step size cannot be determined to prevent invalid orders
- Add tests covering step size retrieval, quantity rounding, and missing step size failures
- Cache Binance exchangeInfo per symbol to avoid redundant requests and provide a reset helper for tests
- Fix reversed pair retry test to match early termination before exchange info fetch
- Parse Binance errors so reversed pair lookups retry correctly on invalid symbol responses
- Make Binance error parsing more robust by safely extracting the `msg` field from trailing JSON
- Recognize Binance error code -1121 in addition to message text to handle invalid symbol responses consistently

## Testing
- `npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68be2850ab34832cbc28412b21995b33