### PR TITLE
Cache Binance pair info for precise limit orders

### DIFF
--- a/backend/src/services/rebalance.ts
+++ b/backend/src/services/rebalance.ts
@@ -1,6 +1,6 @@
 import type { FastifyBaseLogger } from 'fastify';
 import { insertLimitOrder, type LimitOrderStatus } from '../repos/limit-orders.js';
-import { fetchPairData, createLimitOrder } from './binance.js';
+import { fetchPairData, fetchPairInfo, createLimitOrder } from './binance.js';
 
 export const MIN_LIMIT_ORDER_USD = 0.02;
 
@@ -54,11 +54,14 @@ export async function createRebalanceLimitOrder(opts: {
     log.info('no rebalance needed');
     return;
   }
+  const info = await fetchPairInfo(token1, token2);
+  const qty = quantity ?? order.quantity;
+  const prc = price ?? order.price;
   const params = {
-    symbol: `${token1}${token2}`.toUpperCase(),
+    symbol: info.symbol,
     side: order.side,
-    quantity: quantity ?? order.quantity,
-    price: price ?? order.price,
+    quantity: Number(qty.toFixed(info.quantityPrecision)),
+    price: Number(prc.toFixed(info.pricePrecision)),
   } as const;
   log.info({ order: params }, 'creating limit order');
   try {

--- a/backend/test/agentExecLog.test.ts
+++ b/backend/test/agentExecLog.test.ts
@@ -261,6 +261,13 @@ describe('agent exec log routes', () => {
     vi.spyOn(binance, 'fetchPairData').mockResolvedValue({
       currentPrice: 100,
     } as any);
+    vi.spyOn(binance, 'fetchPairInfo').mockResolvedValue({
+      symbol: 'BTCETH',
+      baseAsset: 'BTC',
+      quoteAsset: 'ETH',
+      quantityPrecision: 8,
+      pricePrecision: 8,
+    } as any);
     vi.spyOn(binance, 'createLimitOrder').mockResolvedValue({ orderId: 1 } as any);
     let res = await app.inject({
       method: 'POST',
@@ -317,6 +324,13 @@ describe('agent exec log routes', () => {
     vi.spyOn(binance, 'fetchPairData').mockResolvedValue({
       currentPrice: 100,
     } as any);
+    vi.spyOn(binance, 'fetchPairInfo').mockResolvedValue({
+      symbol: 'BTCETH',
+      baseAsset: 'BTC',
+      quoteAsset: 'ETH',
+      quantityPrecision: 8,
+      pricePrecision: 8,
+    } as any);
     const spy = vi
       .spyOn(binance, 'createLimitOrder')
       .mockResolvedValue({ orderId: 1 } as any);
@@ -369,6 +383,13 @@ describe('agent exec log routes', () => {
     vi.spyOn(binance, 'fetchPairData').mockResolvedValue({
       currentPrice: 100,
     } as any);
+    vi.spyOn(binance, 'fetchPairInfo').mockResolvedValue({
+      symbol: 'BTCETH',
+      baseAsset: 'BTC',
+      quoteAsset: 'ETH',
+      quantityPrecision: 8,
+      pricePrecision: 8,
+    } as any);
     const res = await app.inject({
       method: 'GET',
       url: `/api/agents/${agent.id}/exec-log/${reviewResultId}/rebalance/preview`,
@@ -417,6 +438,13 @@ describe('agent exec log routes', () => {
     } as any);
     vi.spyOn(binance, 'fetchPairData').mockResolvedValue({
       currentPrice: 100,
+    } as any);
+    vi.spyOn(binance, 'fetchPairInfo').mockResolvedValue({
+      symbol: 'BTCETH',
+      baseAsset: 'BTC',
+      quoteAsset: 'ETH',
+      quantityPrecision: 8,
+      pricePrecision: 8,
     } as any);
     vi.spyOn(binance, 'createLimitOrder').mockRejectedValue(
       new Error(

--- a/backend/test/binance.test.ts
+++ b/backend/test/binance.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { fetchPairData } from '../src/services/binance.js';
+import { fetchPairData, fetchPairInfo } from '../src/services/binance.js';
 
 describe('fetchPairData', () => {
   afterEach(() => {
@@ -49,5 +49,54 @@ describe('fetchPairData', () => {
     const data = await fetchPairData('USDT', 'BTC');
     expect(fetchMock).toHaveBeenCalledTimes(8);
     expect(data.year).toEqual(yearData);
+  });
+});
+
+describe('fetchPairInfo', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches and caches exchange info', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        symbols: [
+          {
+            symbol: 'SOLBTC',
+            baseAsset: 'SOL',
+            quoteAsset: 'BTC',
+            quantityPrecision: 3,
+            pricePrecision: 5,
+            filters: [
+              { filterType: 'LOT_SIZE', stepSize: '0.001' },
+              { filterType: 'PRICE_FILTER', tickSize: '0.00001' },
+            ],
+          },
+        ],
+      }),
+    } as any);
+    vi.stubGlobal('fetch', fetchMock);
+    const info1 = await fetchPairInfo('SOL', 'BTC');
+    expect(info1.symbol).toBe('SOLBTC');
+    const info2 = await fetchPairInfo('SOL', 'BTC');
+    expect(info1).toBe(info2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries with reversed pair on invalid symbol', async () => {
+    const errRes = {
+      ok: false,
+      text: async () => JSON.stringify({ code: -1121, msg: 'Invalid symbol.' }),
+    } as any;
+    const okRes = {
+      ok: true,
+      json: async () => ({ symbols: [{ symbol: 'ETHBTC', baseAsset: 'ETH', quoteAsset: 'BTC', quantityPrecision: 3, pricePrecision: 5, filters: [] }] }),
+    } as any;
+    const fetchMock = vi.fn().mockResolvedValueOnce(errRes).mockResolvedValueOnce(okRes);
+    vi.stubGlobal('fetch', fetchMock);
+    const info = await fetchPairInfo('BTC', 'ETH');
+    expect(info.symbol).toBe('ETHBTC');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/backend/test/indicators.test.ts
+++ b/backend/test/indicators.test.ts
@@ -4,6 +4,7 @@ import { fetchPairData } from '../src/services/binance.js';
 
 vi.mock('../src/services/binance.js', () => ({
   fetchPairData: vi.fn(),
+  fetchPairInfo: vi.fn(),
 }));
 
 describe('fetchTokenIndicators', () => {

--- a/backend/test/reviewPortfolio.test.ts
+++ b/backend/test/reviewPortfolio.test.ts
@@ -36,6 +36,13 @@ vi.mock('../src/services/binance.js', () => ({
   }),
   fetchPairData: vi.fn().mockResolvedValue({ currentPrice: 100 }),
   fetchMarketTimeseries: vi.fn().mockResolvedValue(sampleTimeseries),
+  fetchPairInfo: vi.fn().mockResolvedValue({
+    symbol: 'BTCETH',
+    baseAsset: 'BTC',
+    quoteAsset: 'ETH',
+    quantityPrecision: 8,
+    pricePrecision: 8,
+  }),
 }));
 
 vi.mock('../src/services/indicators.js', () => ({
@@ -55,6 +62,7 @@ let callRebalancingAgent: any;
 let fetchAccount: any;
 let fetchPairData: any;
 let fetchMarketTimeseries: any;
+let fetchPairInfo: any;
 let fetchTokenIndicators: any;
 let createRebalanceLimitOrder: any;
 
@@ -63,9 +71,8 @@ beforeAll(async () => {
     '../src/jobs/review-portfolio.js'
   ));
   ({ callRebalancingAgent } = await import('../src/util/ai.js'));
-  ({ fetchAccount, fetchPairData, fetchMarketTimeseries } = await import(
-    '../src/services/binance.js'
-  ));
+  ({ fetchAccount, fetchPairData, fetchMarketTimeseries, fetchPairInfo } =
+    await import('../src/services/binance.js'));
   ({ fetchTokenIndicators } = await import('../src/services/indicators.js'));
   ({ createRebalanceLimitOrder } = await import('../src/services/rebalance.js'));
 });


### PR DESCRIPTION
## Summary
- cache exchangeInfo responses to map token pairs to Binance symbols with price and quantity precision
- round limit order params using cached precision and correct pair symbol
- store pair info in review cache to reuse across agent evaluations

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68be4aae31e0832cac1883d5220453e0