### PR TITLE
Show percent PnL alongside USD

### DIFF
--- a/frontend/src/components/AgentPnl.tsx
+++ b/frontend/src/components/AgentPnl.tsx
@@ -11,15 +11,27 @@ export default function AgentPnl({ tokens, startBalanceUsd }: Props) {
     balance === null ? '-' : isLoading ? 'Loading...' : `$${balance.toFixed(2)}`;
   const pnl =
     balance !== null && startBalanceUsd != null ? balance - startBalanceUsd : null;
+  const pnlPercent =
+    pnl !== null && startBalanceUsd ? (pnl / startBalanceUsd) * 100 : null;
   const pnlText =
     pnl === null
       ? '-'
       : isLoading
       ? 'Loading...'
-      : `${pnl > 0 ? '+' : pnl < 0 ? '-' : ''}$${Math.abs(pnl).toFixed(2)}`;
+      : `${pnl > 0 ? '+' : pnl < 0 ? '-' : ''}$${Math.abs(pnl).toFixed(2)}${
+          pnlPercent !== null
+            ? ` (${pnlPercent > 0 ? '+' : pnlPercent < 0 ? '-' : ''}${Math.abs(pnlPercent).toFixed(2)}%)`
+            : ''
+        }`;
   const pnlClass =
     pnl === null || isLoading
       ? ''
+      : pnlPercent !== null
+      ? pnlPercent <= -3
+        ? 'text-red-600'
+        : pnlPercent >= 3
+        ? 'text-green-600'
+        : 'text-gray-600'
       : pnl <= -0.03
       ? 'text-red-600'
       : pnl >= 0.03
@@ -30,7 +42,11 @@ export default function AgentPnl({ tokens, startBalanceUsd }: Props) {
       ? undefined
       : `PnL = $${balance!.toFixed(2)} - $${startBalanceUsd!.toFixed(2)} = ${
           pnl > 0 ? '+' : pnl < 0 ? '-' : ''
-        }$${Math.abs(pnl).toFixed(2)}`;
+        }$${Math.abs(pnl).toFixed(2)}${
+          pnlPercent !== null
+            ? ` (${pnlPercent > 0 ? '+' : pnlPercent < 0 ? '-' : ''}${Math.abs(pnlPercent).toFixed(2)}%)`
+            : ''
+        }`;
   return (
     <p className="mt-2">
       <strong>Balance (USD):</strong> {balanceText}

--- a/frontend/src/components/AgentPnlMobile.tsx
+++ b/frontend/src/components/AgentPnlMobile.tsx
@@ -11,15 +11,27 @@ export default function AgentPnlMobile({ tokens, startBalanceUsd }: Props) {
     balance === null ? '-' : isLoading ? 'Loading...' : `$${balance.toFixed(2)}`;
   const pnl =
     balance !== null && startBalanceUsd != null ? balance - startBalanceUsd : null;
+  const pnlPercent =
+    pnl !== null && startBalanceUsd ? (pnl / startBalanceUsd) * 100 : null;
   const pnlText =
     pnl === null
       ? '-'
       : isLoading
       ? 'Loading...'
-      : `${pnl > 0 ? '+' : pnl < 0 ? '-' : ''}$${Math.abs(pnl).toFixed(2)}`;
+      : `${pnl > 0 ? '+' : pnl < 0 ? '-' : ''}$${Math.abs(pnl).toFixed(2)}${
+          pnlPercent !== null
+            ? ` (${pnlPercent > 0 ? '+' : pnlPercent < 0 ? '-' : ''}${Math.abs(pnlPercent).toFixed(2)}%)`
+            : ''
+        }`;
   const pnlClass =
     pnl === null || isLoading
       ? ''
+      : pnlPercent !== null
+      ? pnlPercent <= -3
+        ? 'text-red-600'
+        : pnlPercent >= 3
+        ? 'text-green-600'
+        : 'text-gray-600'
       : pnl <= -0.03
       ? 'text-red-600'
       : pnl >= 0.03
@@ -30,7 +42,11 @@ export default function AgentPnlMobile({ tokens, startBalanceUsd }: Props) {
       ? undefined
       : `PnL = $${balance!.toFixed(2)} - $${startBalanceUsd!.toFixed(2)} = ${
           pnl > 0 ? '+' : pnl < 0 ? '-' : ''
-        }$${Math.abs(pnl).toFixed(2)}`;
+        }$${Math.abs(pnl).toFixed(2)}${
+          pnlPercent !== null
+            ? ` (${pnlPercent > 0 ? '+' : pnlPercent < 0 ? '-' : ''}${Math.abs(pnlPercent).toFixed(2)}%)`
+            : ''
+        }`;
   return (
     <p className="mt-2">
       <strong>Balance:</strong> {balanceText}

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -41,15 +41,29 @@ function AgentRow({
     balance !== null && agent.startBalanceUsd != null
       ? balance - agent.startBalanceUsd
       : null;
+  const pnlPercent =
+    pnl !== null && agent.startBalanceUsd
+      ? (pnl / agent.startBalanceUsd) * 100
+      : null;
   const pnlText =
     pnl === null
       ? '-'
       : isLoading
       ? 'Loading...'
-      : `${pnl > 0 ? '+' : pnl < 0 ? '-' : ''}$${Math.abs(pnl).toFixed(2)}`;
+      : `${pnl > 0 ? '+' : pnl < 0 ? '-' : ''}$${Math.abs(pnl).toFixed(2)}${
+          pnlPercent !== null
+            ? ` (${pnlPercent > 0 ? '+' : pnlPercent < 0 ? '-' : ''}${Math.abs(pnlPercent).toFixed(2)}%)`
+            : ''
+        }`;
   const pnlClass =
     pnl === null || isLoading
       ? ''
+      : pnlPercent !== null
+      ? pnlPercent <= -3
+        ? 'text-red-600'
+        : pnlPercent >= 3
+        ? 'text-green-600'
+        : 'text-gray-600'
       : pnl <= -0.03
       ? 'text-red-600'
       : pnl >= 0.03
@@ -60,7 +74,11 @@ function AgentRow({
       ? undefined
       : `PnL = $${balance!.toFixed(2)} - $${agent.startBalanceUsd!.toFixed(2)} = ${
           pnl > 0 ? '+' : pnl < 0 ? '-' : ''
-        }$${Math.abs(pnl).toFixed(2)}`;
+        }$${Math.abs(pnl).toFixed(2)}${
+          pnlPercent !== null
+            ? ` (${pnlPercent > 0 ? '+' : pnlPercent < 0 ? '-' : ''}${Math.abs(pnlPercent).toFixed(2)}%)`
+            : ''
+        }`;
   return (
     <tr key={agent.id}>
       <td>
@@ -123,15 +141,29 @@ function AgentBlock({
     balance !== null && agent.startBalanceUsd != null
       ? balance - agent.startBalanceUsd
       : null;
+  const pnlPercent =
+    pnl !== null && agent.startBalanceUsd
+      ? (pnl / agent.startBalanceUsd) * 100
+      : null;
   const pnlText =
     pnl === null
       ? '-'
       : isLoading
       ? 'Loading...'
-      : `${pnl > 0 ? '+' : pnl < 0 ? '-' : ''}$${Math.abs(pnl).toFixed(2)}`;
+      : `${pnl > 0 ? '+' : pnl < 0 ? '-' : ''}$${Math.abs(pnl).toFixed(2)}${
+          pnlPercent !== null
+            ? ` (${pnlPercent > 0 ? '+' : pnlPercent < 0 ? '-' : ''}${Math.abs(pnlPercent).toFixed(2)}%)`
+            : ''
+        }`;
   const pnlClass =
     pnl === null || isLoading
       ? ''
+      : pnlPercent !== null
+      ? pnlPercent <= -3
+        ? 'text-red-600'
+        : pnlPercent >= 3
+        ? 'text-green-600'
+        : 'text-gray-600'
       : pnl <= -0.03
       ? 'text-red-600'
       : pnl >= 0.03
@@ -142,7 +174,11 @@ function AgentBlock({
       ? undefined
       : `PnL = $${balance!.toFixed(2)} - $${agent.startBalanceUsd!.toFixed(2)} = ${
           pnl > 0 ? '+' : pnl < 0 ? '-' : ''
-        }$${Math.abs(pnl).toFixed(2)}`;
+        }$${Math.abs(pnl).toFixed(2)}${
+          pnlPercent !== null
+            ? ` (${pnlPercent > 0 ? '+' : pnlPercent < 0 ? '-' : ''}${Math.abs(pnlPercent).toFixed(2)}%)`
+            : ''
+        }`;
   return (
     <div className="border rounded p-3 text-sm">
       <div className="mb-2 flex items-center gap-1 font-medium">


### PR DESCRIPTION
## Summary
- display PnL percentages next to USD values in agent listings and detail components
- color and tooltip logic now uses percentage change for clearer performance context

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68be514d6db4832cb907984ce9d82e1a