### PR TITLE
Disallow stablecoin-only trading pairs

### DIFF
--- a/frontend/src/components/StrategyForm.tsx
+++ b/frontend/src/components/StrategyForm.tsx
@@ -2,7 +2,7 @@ import TokenSelect from './forms/TokenSelect';
 import TextInput from './forms/TextInput';
 import SelectInput from './forms/SelectInput';
 import FormField from './forms/FormField';
-import { tokens, riskOptions, reviewIntervalOptions } from '../lib/constants';
+import { tokens, riskOptions, reviewIntervalOptions, stableCoins } from '../lib/constants';
 
 interface StrategyData {
   tokens: { token: string; minAllocation: number }[];
@@ -36,7 +36,11 @@ export default function StrategyForm({ data, onChange, disabled = false }: Props
               ])
             }
             options={tokens.filter(
-              (t) => t.value === token1.token || t.value !== token2.token,
+              (t) =>
+                t.value === token1.token ||
+                (t.value !== token2.token &&
+                  !(stableCoins.includes(t.value) &&
+                    stableCoins.includes(token2.token)))
             )}
             disabled={disabled}
           />
@@ -52,7 +56,11 @@ export default function StrategyForm({ data, onChange, disabled = false }: Props
               ])
             }
             options={tokens.filter(
-              (t) => t.value === token2.token || t.value !== token1.token,
+              (t) =>
+                t.value === token2.token ||
+                (t.value !== token1.token &&
+                  !(stableCoins.includes(t.value) &&
+                    stableCoins.includes(token1.token)))
             )}
             disabled={disabled}
           />

--- a/frontend/src/components/forms/CreateAgentForm.tsx
+++ b/frontend/src/components/forms/CreateAgentForm.tsx
@@ -11,6 +11,7 @@ import {
     riskOptions,
     reviewIntervalOptions,
     tokens,
+    stableCoins,
 } from '../../lib/constants';
 import useAllocationNormalization from '../../lib/useAllocationNormalization';
 import TokenSelect from './TokenSelect';
@@ -100,7 +101,11 @@ export default function CreateAgentForm({
                                     value={field.value}
                                     onChange={field.onChange}
                                     options={tokens.filter(
-                                        (t) => t.value === token1 || t.value !== token2
+                                        (t) =>
+                                            t.value === token1 ||
+                                            (t.value !== token2 &&
+                                                !(stableCoins.includes(t.value) &&
+                                                    stableCoins.includes(token2)))
                                     )}
                                 />
                             )}
@@ -116,7 +121,11 @@ export default function CreateAgentForm({
                                     value={field.value}
                                     onChange={field.onChange}
                                     options={tokens.filter(
-                                        (t) => t.value === token2 || t.value !== token1
+                                        (t) =>
+                                            t.value === token2 ||
+                                            (t.value !== token1 &&
+                                                !(stableCoins.includes(t.value) &&
+                                                    stableCoins.includes(token1)))
                                     )}
                                 />
                             )}

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -10,6 +10,8 @@ export const tokens = [
     {value: 'USDC', label: 'USDC'},
 ];
 
+export const stableCoins = ['USDT', 'USDC'];
+
 export const riskOptions = [
     {value: 'low', label: createElement(RiskDisplay, {risk: 'low'})},
     {value: 'medium', label: createElement(RiskDisplay, {risk: 'medium'})},
@@ -63,6 +65,17 @@ export const createAgentSchema = z
         message: 'Tokens must be different',
         path: ['tokens', 1, 'token'],
     })
+    .refine(
+        (data) =>
+            !(
+                stableCoins.includes(data.tokens[0].token.toUpperCase()) &&
+                stableCoins.includes(data.tokens[1].token.toUpperCase())
+            ),
+        {
+            message: 'Stablecoin pairs are not allowed',
+            path: ['tokens', 1, 'token'],
+        }
+    )
     .refine(
         (data) =>
             data.tokens[0].minAllocation + data.tokens[1].minAllocation <= 95,


### PR DESCRIPTION
## Summary
- prevent selecting two stablecoins when creating or editing strategies
- validate strategy form data against stablecoin pairs

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be59687d7c832c8ea88d809d4179b9