### PR TITLE
feat: enrich rebalancing prompt with prior orders

### DIFF
--- a/backend/src/repos/limit-orders.ts
+++ b/backend/src/repos/limit-orders.ts
@@ -50,3 +50,16 @@ export async function getLimitOrdersByReviewResult(
   );
   return rows as { planned_json: string; status: LimitOrderStatus }[];
 }
+
+export async function getRecentLimitOrders(agentId: string, limit: number) {
+  const { rows } = await db.query(
+    `SELECT e.planned_json, e.status
+       FROM limit_order e
+       JOIN agent_review_result r ON e.review_result_id = r.id
+      WHERE r.agent_id = $1
+      ORDER BY e.created_at DESC
+      LIMIT $2`,
+    [agentId, limit],
+  );
+  return rows as { planned_json: string; status: LimitOrderStatus }[];
+}

--- a/backend/src/util/ai.ts
+++ b/backend/src/util/ai.ts
@@ -1,5 +1,5 @@
 const developerInstructions =
-  "You assist a real trader in taking decisions on a given tokens configuration. Users may deposit or withdraw funds between runs; if the current balance doesn't match previous executions, treat the session as new. The user's comment may be found in the trading instructions field. Use the web search tool to find fresh news and prices and advise the user whether to rebalance or not. Fit report comment in 255 characters. If you suggest rebalancing, provide the new allocation in percentage (0-100) for the first token in the pair. If you don't suggest rebalancing, set rebalance to false and provide a short report comment. If you encounter an error, return an object with an error message.";
+  "You assist a real trader in taking decisions on a given tokens configuration. Users may deposit or withdraw funds between runs; if the current balance doesn't match previous executions, treat the session as new. The user's comment may be found in the trading instructions field. You must determine the target allocation based on current market conditions and the provided portfolio state. Use the web search tool to find fresh news and prices and advise the user whether to rebalance or not. Fit report comment in 255 characters. If you suggest rebalancing, provide the new allocation in percentage (0-100) for the first token in the pair. If you don't suggest rebalancing, set rebalance to false and provide a short report comment. If you encounter an error, return an object with an error message.";
 
 import type { TokenIndicators } from '../services/indicators.js';
 
@@ -20,11 +20,15 @@ export interface RebalancePrompt {
   instructions: string;
   config: {
     policy: { floorPercents: Record<string, number> };
-    portfolio: {
+    currentStatePortfolio: {
       ts: string;
       positions: RebalancePosition[];
-      weights: Record<string, number>;
+      currentWeights: Record<string, number>;
     };
+    previousLimitOrders?: {
+      planned: Record<string, unknown>;
+      status: string;
+    }[];
   };
   marketData: {
     currentPrice: number;

--- a/backend/test/callRebalancingAgent.test.ts
+++ b/backend/test/callRebalancingAgent.test.ts
@@ -11,12 +11,12 @@ describe('callRebalancingAgent structured output', () => {
       instructions: 'inst',
       config: {
         policy: { floorPercents: { USDT: 20 } },
-        portfolio: {
+        currentStatePortfolio: {
           ts: new Date().toISOString(),
           positions: [
             { sym: 'USDT', qty: 1, price_usdt: 1, value_usdt: 1 },
           ],
-          weights: { USDT: 1 },
+          currentWeights: { USDT: 1 },
         },
       },
       marketData: { currentPrice: 1 },
@@ -27,6 +27,7 @@ describe('callRebalancingAgent structured output', () => {
     const [, opts] = fetchMock.mock.calls[0];
     const body = JSON.parse(opts.body);
     expect(body.instructions).toMatch(/assist a real trader/i);
+    expect(body.instructions).toMatch(/determine the target allocation/i);
     const parsedInput = JSON.parse(body.input);
     expect(parsedInput.previous_responses).toEqual(['p1', 'p2']);
     expect(body.text.format.type).toBe('json_schema');

--- a/backend/test/fixtures/real-openai-log.json
+++ b/backend/test/fixtures/real-openai-log.json
@@ -6,7 +6,7 @@
   "background": false,
   "error": null,
   "incomplete_details": null,
-  "instructions": "You assist a real trader in taking decisions on a given tokens configuration. The user's comment may be found in the trading instructions field. Use the web search tool to find fresh news and prices and advise the user whether to rebalance or not. Fit report comment in 255 characters. If you suggest rebalancing, provide the new allocation in percentage (0-100) for the first token in the pair. If you don't suggest rebalancing, set rebalance to false and provide a short report comment. If you encounter an error, return an object with an error message.",
+  "instructions": "You assist a real trader in taking decisions on a given tokens configuration. Users may deposit or withdraw funds between runs; if the current balance doesn't match previous executions, treat the session as new. The user's comment may be found in the trading instructions field. You must determine the target allocation based on current market conditions and the provided portfolio state. Use the web search tool to find fresh news and prices and advise the user whether to rebalance or not. Fit report comment in 255 characters. If you suggest rebalancing, provide the new allocation in percentage (0-100) for the first token in the pair. If you don't suggest rebalancing, set rebalance to false and provide a short report comment. If you encounter an error, return an object with an error message.",
   "max_output_tokens": null,
   "max_tool_calls": null,
   "model": "gpt-5-nano-2025-08-07",


### PR DESCRIPTION
## Summary
- rename portfolio weights to currentWeights and expose currentStatePortfolio at config root
- include up to five recent limit orders in rebalancing prompt
- clarify default instructions so the agent determines target allocation from current market context
- adjust tests for new config shape and prompt wording

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68be58790320832ca4ab8e7080ffd989