### PR TITLE
feat: manage open orders

### DIFF
--- a/backend/scripts/start.ts
+++ b/backend/scripts/start.ts
@@ -3,6 +3,7 @@ import buildServer from '../src/server.js';
 import '../src/util/env.js';
 import { migrate } from '../src/db/index.js';
 import reviewPortfolios from '../src/jobs/review-portfolio.js';
+import checkOpenOrders from '../src/jobs/check-open-orders.js';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -14,6 +15,7 @@ async function main() {
   const log = app.log;
 
   const schedules: Record<string, string> = {
+    openOrders: '*/3 * * * *',
     '10m': '*/10 * * * *',
     '15m': '*/15 * * * *',
     '30m': '*/30 * * * *',
@@ -26,7 +28,9 @@ async function main() {
     '1w': '0 0 * * 0',
   };
   for (const [interval, cronExp] of Object.entries(schedules)) {
-    schedule(cronExp, () => reviewPortfolios(log, interval));
+    if (interval === 'openOrders')
+      schedule(cronExp, () => checkOpenOrders(log));
+    else schedule(cronExp, () => reviewPortfolios(log, interval));
   }
 
   try {

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -99,4 +99,6 @@ CREATE INDEX IF NOT EXISTS idx_users_email_enc ON users(email_enc);
 CREATE INDEX IF NOT EXISTS idx_agents_user_id_status ON agents(user_id, status);
 CREATE INDEX IF NOT EXISTS idx_agents_status_review_interval ON agents(status, review_interval);
 CREATE INDEX IF NOT EXISTS idx_limit_order_review_result_id_status ON limit_order(review_result_id, status);
+CREATE INDEX IF NOT EXISTS idx_limit_order_user_id_status ON limit_order(user_id, status);
+CREATE INDEX IF NOT EXISTS idx_limit_order_order_id ON limit_order(order_id);
 CREATE INDEX IF NOT EXISTS idx_agent_review_raw_log_agent_id ON agent_review_raw_log(agent_id);

--- a/backend/src/jobs/check-open-orders.ts
+++ b/backend/src/jobs/check-open-orders.ts
@@ -1,0 +1,78 @@
+import type { FastifyBaseLogger } from 'fastify';
+import {
+  getAllOpenLimitOrders,
+  updateLimitOrderStatus,
+} from '../repos/limit-orders.js';
+import { cancelOrder, fetchOpenOrders, parseBinanceError } from '../services/binance.js';
+
+interface GroupedOrder {
+  user_id: string;
+  order_id: string;
+  agent_status: string;
+  planned: { symbol: string };
+}
+
+export default async function checkOpenOrders(log: FastifyBaseLogger) {
+  const orders = await getAllOpenLimitOrders();
+  if (!orders.length) return;
+
+  const groups = groupByUserAndSymbol(orders);
+  for (const list of groups.values()) {
+    await reconcileGroup(log, list);
+  }
+}
+
+function groupByUserAndSymbol(orders: any[]) {
+  const groups = new Map<string, GroupedOrder[]>();
+  for (const o of orders) {
+    const planned = JSON.parse(o.planned_json);
+    const key = `${o.user_id}-${planned.symbol}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push({ ...o, planned });
+  }
+  return groups;
+}
+
+async function reconcileGroup(log: FastifyBaseLogger, list: GroupedOrder[]) {
+  const { user_id, planned } = list[0];
+  let open: any[] = [];
+  try {
+    const res = await fetchOpenOrders(user_id, { symbol: planned.symbol });
+    open = Array.isArray(res) ? res : [];
+  } catch (err) {
+    log.error({ err }, 'failed to fetch open orders');
+    return;
+  }
+  for (const o of list) {
+    await reconcileOrder(log, o, planned.symbol, open);
+  }
+}
+
+async function reconcileOrder(
+  log: FastifyBaseLogger,
+  o: GroupedOrder,
+  symbol: string,
+  open: any[],
+) {
+  const exists = open.some((r) => String(r.orderId) === o.order_id);
+  if (!exists) {
+    await updateLimitOrderStatus(o.user_id, o.order_id, 'filled');
+    return;
+  }
+  if (o.agent_status !== 'active') {
+    try {
+      await cancelOrder(o.user_id, {
+        symbol,
+        orderId: Number(o.order_id),
+      });
+      await updateLimitOrderStatus(o.user_id, o.order_id, 'canceled');
+    } catch (err) {
+      const msg = parseBinanceError(err);
+      if (msg && /UNKNOWN_ORDER/i.test(msg)) {
+        await updateLimitOrderStatus(o.user_id, o.order_id, 'filled');
+      } else {
+        log.error({ err }, 'failed to cancel order');
+      }
+    }
+  }
+}

--- a/backend/test/openOrdersCleanup.test.ts
+++ b/backend/test/openOrdersCleanup.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import type { FastifyBaseLogger } from 'fastify';
+import { db } from '../src/db/index.js';
+
+const sampleIndicators = {
+  ret: { '1h': 0, '4h': 0, '24h': 0, '7d': 0, '30d': 0 },
+  sma_dist: { '20': 0, '50': 0, '200': 0 },
+  macd_hist: 0,
+  vol: { rv_7d: 0, rv_30d: 0, atr_pct: 0 },
+  range: { bb_bw: 0, donchian20: 0 },
+  volume: { z_1h: 0, z_24h: 0 },
+  corr: { BTC_30d: 0 },
+  regime: { BTC: 'range' },
+};
+
+vi.mock('../src/util/ai.js', () => ({
+  callRebalancingAgent: vi.fn().mockResolvedValue('ok'),
+}));
+
+vi.mock('../src/util/crypto.js', () => ({
+  decrypt: vi.fn().mockReturnValue('key'),
+}));
+
+const cancelOrder = vi.fn().mockResolvedValue(undefined);
+vi.mock('../src/services/binance.js', () => ({
+  fetchAccount: vi.fn().mockResolvedValue({
+    balances: [
+      { asset: 'BTC', free: '1', locked: '0' },
+      { asset: 'ETH', free: '1', locked: '0' },
+    ],
+  }),
+  fetchPairData: vi.fn().mockResolvedValue({ currentPrice: 100 }),
+  fetchMarketTimeseries: vi.fn().mockResolvedValue({ minute_60: [], hourly_24h: [], monthly_24m: [] }),
+  fetchPairInfo: vi.fn().mockResolvedValue({
+    symbol: 'BTCETH',
+    baseAsset: 'BTC',
+    quoteAsset: 'ETH',
+    quantityPrecision: 8,
+    pricePrecision: 8,
+  }),
+  cancelOrder,
+  parseBinanceError: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../src/services/indicators.js', () => ({
+  fetchTokenIndicators: vi.fn().mockResolvedValue(sampleIndicators),
+}));
+
+vi.mock('../src/services/rebalance.js', () => ({
+  createRebalanceLimitOrder: vi.fn().mockResolvedValue(undefined),
+}));
+
+let reviewAgentPortfolio: (log: FastifyBaseLogger, agentId: string) => Promise<void>;
+
+beforeAll(async () => {
+  ({ reviewAgentPortfolio } = await import('../src/jobs/review-portfolio.js'));
+});
+
+describe('cleanup open orders', () => {
+  it('cancels open orders before running agent', async () => {
+    await db.query('INSERT INTO users (id) VALUES ($1)', ['1']);
+    await db.query("INSERT INTO ai_api_keys (user_id, provider, api_key_enc) VALUES ($1, 'openai', $2)", ['1', 'enc']);
+    await db.query(
+      "INSERT INTO agents (id, user_id, model, status, name, risk, review_interval, agent_instructions, manual_rebalance) VALUES ($1, $2, 'gpt', 'active', 'A', 'low', '1h', 'inst', false)",
+      ['1', '1'],
+    );
+    await db.query(
+      "INSERT INTO agent_tokens (agent_id, token, min_allocation, position) VALUES ($1, 'BTC', 10, 1), ($1, 'ETH', 20, 2)",
+      ['1'],
+    );
+    const rr = await db.query(
+      "INSERT INTO agent_review_result (agent_id, log, rebalance, new_allocation, short_report) VALUES ($1, $2, true, 50, 's') RETURNING id",
+      ['1', 'log'],
+    );
+    await db.query(
+      "INSERT INTO limit_order (user_id, planned_json, status, review_result_id, order_id) VALUES ($1, $2, 'open', $3, $4)",
+      ['1', JSON.stringify({ symbol: 'BTCETH', side: 'BUY', quantity: 1, price: 1 }), rr.rows[0].id, '123'],
+    );
+    const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
+    await reviewAgentPortfolio(log, '1');
+    expect(cancelOrder).toHaveBeenCalledTimes(1);
+    const { rows } = await db.query("SELECT status FROM limit_order WHERE order_id = '123'");
+    expect(rows[0].status).toBe('canceled');
+  });
+});

--- a/backend/test/reviewPortfolio.test.ts
+++ b/backend/test/reviewPortfolio.test.ts
@@ -43,6 +43,8 @@ vi.mock('../src/services/binance.js', () => ({
     quantityPrecision: 8,
     pricePrecision: 8,
   }),
+  cancelOrder: vi.fn().mockResolvedValue(undefined),
+  parseBinanceError: vi.fn().mockReturnValue(null),
 }));
 
 vi.mock('../src/services/indicators.js', () => ({


### PR DESCRIPTION
## Summary
- cleanup and cancel stale Binance orders before each agent run
- schedule background job to verify and close open limit orders
- add indexes for faster order lookups and cover with tests
- refactor open orders check job into smaller helpers for readability

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68be6b6cf428832c81ab240714fcf1df