### PR TITLE
feat: allow admins to share OpenAI keys

### DIFF
--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -24,6 +24,12 @@ CREATE TABLE IF NOT EXISTS ai_api_keys(
   UNIQUE(user_id, provider)
 );
 
+CREATE TABLE IF NOT EXISTS ai_api_key_shares(
+  owner_user_id BIGINT NOT NULL REFERENCES users(id),
+  target_user_id BIGINT PRIMARY KEY REFERENCES users(id),
+  created_at TIMESTAMP NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC')
+);
+
 CREATE TABLE IF NOT EXISTS exchange_keys(
   id BIGSERIAL PRIMARY KEY,
   user_id BIGINT NOT NULL REFERENCES users(id),

--- a/backend/src/repos/api-keys.ts
+++ b/backend/src/repos/api-keys.ts
@@ -2,10 +2,22 @@ import { db } from '../db/index.js';
 
 export async function getAiKeyRow(id: string) {
   const { rows } = await db.query(
-    "SELECT ak.id, ak.api_key_enc AS ai_api_key_enc FROM users u LEFT JOIN ai_api_keys ak ON ak.user_id = u.id AND ak.provider = 'openai' WHERE u.id = $1",
+    "SELECT ak.id AS own_id, ak.api_key_enc AS own_enc, oak.id AS shared_id, oak.api_key_enc AS shared_enc FROM users u LEFT JOIN ai_api_keys ak ON ak.user_id = u.id AND ak.provider = 'openai' LEFT JOIN ai_api_key_shares s ON s.target_user_id = u.id LEFT JOIN ai_api_keys oak ON oak.user_id = s.owner_user_id AND oak.provider = 'openai' WHERE u.id = $1",
     [id],
   );
-  return rows[0] as { id?: string; ai_api_key_enc?: string } | undefined;
+  const row = rows[0] as
+    | { own_id?: string; own_enc?: string; shared_id?: string; shared_enc?: string }
+    | undefined;
+  if (!row) return undefined;
+  if (row.own_id)
+    return { id: row.own_id, ai_api_key_enc: row.own_enc, is_shared: false };
+  if (row.shared_id)
+    return {
+      id: row.shared_id,
+      ai_api_key_enc: row.shared_enc,
+      is_shared: true,
+    };
+  return { is_shared: false };
 }
 
 export async function setAiKey(id: string, enc: string) {
@@ -20,6 +32,28 @@ export async function clearAiKey(id: string) {
     "DELETE FROM ai_api_keys WHERE user_id = $1 AND provider = 'openai'",
     [id],
   );
+}
+
+export async function shareAiKey(ownerId: string, targetId: string) {
+  await db.query(
+    "INSERT INTO ai_api_key_shares (owner_user_id, target_user_id) VALUES ($1, $2) ON CONFLICT (target_user_id) DO UPDATE SET owner_user_id = EXCLUDED.owner_user_id",
+    [ownerId, targetId],
+  );
+}
+
+export async function revokeAiKeyShare(ownerId: string, targetId: string) {
+  await db.query(
+    'DELETE FROM ai_api_key_shares WHERE owner_user_id = $1 AND target_user_id = $2',
+    [ownerId, targetId],
+  );
+}
+
+export async function hasAiKeyShare(ownerId: string, targetId: string) {
+  const { rowCount } = await db.query(
+    'SELECT 1 FROM ai_api_key_shares WHERE owner_user_id = $1 AND target_user_id = $2',
+    [ownerId, targetId],
+  );
+  return rowCount > 0;
 }
 
 export async function getBinanceKeyRow(id: string) {

--- a/backend/src/routes/api-keys.ts
+++ b/backend/src/routes/api-keys.ts
@@ -8,6 +8,9 @@ import {
   getBinanceKeyRow,
   setBinanceKey,
   clearBinanceKey,
+  shareAiKey,
+  revokeAiKeyShare,
+  hasAiKeyShare,
 } from '../repos/api-keys.js';
 import {
   getActiveAgentsByUser,
@@ -16,17 +19,18 @@ import {
 } from '../repos/agents.js';
 import { removeAgentFromSchedule } from '../jobs/review-portfolio.js';
 import { cancelOpenOrders } from '../services/binance.js';
-import { requireUserIdMatch } from '../util/auth.js';
+import { requireUserIdMatch, requireAdmin } from '../util/auth.js';
 import {
   ApiKeyType,
   verifyApiKey,
   encryptKey,
-  decryptKey,
   ensureUser,
   ensureKeyAbsent,
   ensureKeyPresent,
+  decryptKey,
 } from '../util/api-keys.js';
-import { errorResponse } from '../util/errorMessages.js';
+import { errorResponse, ERROR_MESSAGES } from '../util/errorMessages.js';
+import { findUserByEmail } from '../repos/users.js';
 import { parseParams } from '../util/validation.js';
 
 const idParams = z.object({ id: z.string().regex(/^\d+$/) });
@@ -44,6 +48,10 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
       const row = await getAiKeyRow(id);
       let err = ensureUser(row);
       if (err) return reply.code(err.code).send(err.body);
+      if (row!.is_shared)
+        return reply
+          .code(403)
+          .send(errorResponse(ERROR_MESSAGES.forbidden));
       err = ensureKeyAbsent(row, ['ai_api_key_enc']);
       if (err) return reply.code(err.code).send(err.body);
       if (!(await verifyApiKey(ApiKeyType.Ai, key)))
@@ -63,10 +71,11 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
       const { id } = params;
       if (!requireUserIdMatch(req, reply, id)) return;
       const row = await getAiKeyRow(id);
-      const err = ensureKeyPresent(row, ['ai_api_key_enc']);
-      if (err) return reply.code(err.code).send(err.body);
-      const key = decryptKey(row!.ai_api_key_enc!);
-      return { key: '<REDACTED>' };
+      if (!row?.id)
+        return reply
+          .code(404)
+          .send(errorResponse(ERROR_MESSAGES.notFound));
+      return { key: '<REDACTED>', ...(row.is_shared ? { shared: true } : {}) };
     },
   );
 
@@ -80,8 +89,14 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
       if (!requireUserIdMatch(req, reply, id)) return;
       const { key } = req.body as { key: string };
       const row = await getAiKeyRow(id);
-      const err = ensureKeyPresent(row, ['ai_api_key_enc']);
-      if (err) return reply.code(err.code).send(err.body);
+      if (row?.is_shared)
+        return reply
+          .code(403)
+          .send(errorResponse(ERROR_MESSAGES.forbidden));
+      if (!row?.ai_api_key_enc)
+        return reply
+          .code(404)
+          .send(errorResponse(ERROR_MESSAGES.notFound));
       if (!(await verifyApiKey(ApiKeyType.Ai, key)))
         return reply.code(400).send(errorResponse('verification failed'));
       const enc = encryptKey(key);
@@ -99,8 +114,14 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
       const { id } = params;
       if (!requireUserIdMatch(req, reply, id)) return;
       const row = await getAiKeyRow(id);
-      const err = ensureKeyPresent(row, ['ai_api_key_enc']);
-      if (err) return reply.code(err.code).send(err.body);
+      if (row?.is_shared)
+        return reply
+          .code(403)
+          .send(errorResponse(ERROR_MESSAGES.forbidden));
+      if (!row?.ai_api_key_enc)
+        return reply
+          .code(404)
+          .send(errorResponse(ERROR_MESSAGES.notFound));
       const agents = await getActiveAgentsByUser(id);
       for (const agent of agents) {
         removeAgentFromSchedule(agent.id);
@@ -116,6 +137,60 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
       }
       await draftAgentsByUser(id);
       await clearAiKey(id);
+      return { ok: true };
+    },
+  );
+
+  app.post(
+    '/users/:id/ai-key/share',
+    { config: { rateLimit: RATE_LIMITS.MODERATE } },
+    async (req, reply) => {
+      const params = parseParams(idParams, req.params, reply);
+      if (!params) return;
+      const { id } = params;
+      const adminId = await requireAdmin(req, reply);
+      if (!adminId || adminId !== id) return;
+      const { email } = req.body as { email: string };
+      const row = await getAiKeyRow(id);
+      const err = ensureKeyPresent(row, ['ai_api_key_enc']);
+      if (err) return reply.code(err.code).send(err.body);
+      const target = await findUserByEmail(email);
+      if (!target) return reply.code(404).send(errorResponse('user not found'));
+      await shareAiKey(id, target.id);
+      return { ok: true };
+    },
+  );
+
+  app.delete(
+    '/users/:id/ai-key/share',
+    { config: { rateLimit: RATE_LIMITS.MODERATE } },
+    async (req, reply) => {
+      const params = parseParams(idParams, req.params, reply);
+      if (!params) return;
+      const { id } = params;
+      const adminId = await requireAdmin(req, reply);
+      if (!adminId || adminId !== id) return;
+      const { email } = req.body as { email: string };
+      const target = await findUserByEmail(email);
+      if (!target) return reply.code(404).send(errorResponse('user not found'));
+      if (!(await hasAiKeyShare(id, target.id)))
+        return reply.code(404).send(errorResponse('share not found'));
+      const keyRow = await getAiKeyRow(target.id);
+      if (keyRow?.is_shared) {
+        const agents = await getActiveAgentsByUser(target.id);
+        for (const agent of agents) {
+          removeAgentFromSchedule(agent.id);
+          const token1 = agent.tokens[0].token;
+          const token2 = agent.tokens[1].token;
+          try {
+            await cancelOpenOrders(target.id, { symbol: `${token1}${token2}` });
+          } catch (err) {
+            req.log.error({ err, agentId: agent.id }, 'failed to cancel open orders');
+          }
+        }
+        await draftAgentsByUser(target.id);
+      }
+      await revokeAiKeyShare(id, target.id);
       return { ok: true };
     },
   );

--- a/backend/test/apiKeys.test.ts
+++ b/backend/test/apiKeys.test.ts
@@ -12,14 +12,16 @@ vi.mock('../src/services/binance.js', async () => {
 });
 
 import buildServer from '../src/server.js';
-import { insertUser } from './repos/users.js';
+import { insertUser, insertAdminUser } from './repos/users.js';
 import {
   getAiKeyRow,
   getBinanceKeyRow,
   setAiKey,
   setBinanceKey,
+  shareAiKey,
 } from '../src/repos/api-keys.js';
 import { insertAgent } from './repos/agents.js';
+import { getUserApiKeys } from '../src/repos/agents.js';
 import { db } from '../src/db/index.js';
 import { encrypt } from '../src/util/crypto.js';
 import { removeAgentFromSchedule } from '../src/jobs/review-portfolio.js';
@@ -48,7 +50,7 @@ describe('AI API key routes', () => {
     expect(res.statusCode).toBe(400);
     expect(res.json()).toMatchObject({ error: 'verification failed' });
     let row = await getAiKeyRow(userId);
-    expect(row!.ai_api_key_enc).toBeNull();
+    expect(row!.ai_api_key_enc).toBeUndefined();
 
     fetchMock.mockResolvedValueOnce({ ok: true } as any);
     res = await app.inject({
@@ -120,6 +122,76 @@ describe('AI API key routes', () => {
 
     await app.close();
     (globalThis as any).fetch = originalFetch;
+  });
+
+  it('allows admin to share and revoke ai key', async () => {
+    const app = await buildServer();
+    const adminId = await insertAdminUser('admin1', encrypt('admin@example.com', process.env.KEY_PASSWORD!));
+    const userId = await insertUser('u1', encrypt('user@example.com', process.env.KEY_PASSWORD!));
+    const ai = encrypt('aikey1234567890', process.env.KEY_PASSWORD!);
+    await setAiKey(adminId, ai);
+
+    let res = await app.inject({
+      method: 'POST',
+      url: `/api/users/${adminId}/ai-key/share`,
+      cookies: authCookies(adminId),
+      payload: { email: 'user@example.com' },
+    });
+    expect(res.statusCode).toBe(200);
+
+    res = await app.inject({
+      method: 'GET',
+      url: `/api/users/${userId}/ai-key`,
+      cookies: authCookies(userId),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ key: '<REDACTED>' });
+
+    let keyRow = await getUserApiKeys(userId);
+    expect(keyRow?.ai_api_key_enc).toBeDefined();
+
+    res = await app.inject({
+      method: 'POST',
+      url: `/api/users/${userId}/ai-key`,
+      cookies: authCookies(userId),
+      payload: { key: 'newkey1234567890' },
+    });
+    expect(res.statusCode).toBe(403);
+
+    res = await app.inject({
+      method: 'PUT',
+      url: `/api/users/${userId}/ai-key`,
+      cookies: authCookies(userId),
+      payload: { key: 'newkeyabcdefghij' },
+    });
+    expect(res.statusCode).toBe(403);
+
+    res = await app.inject({
+      method: 'DELETE',
+      url: `/api/users/${userId}/ai-key`,
+      cookies: authCookies(userId),
+    });
+    expect(res.statusCode).toBe(403);
+
+    res = await app.inject({
+      method: 'DELETE',
+      url: `/api/users/${adminId}/ai-key/share`,
+      cookies: authCookies(adminId),
+      payload: { email: 'user@example.com' },
+    });
+    expect(res.statusCode).toBe(200);
+
+    keyRow = await getUserApiKeys(userId);
+    expect(keyRow?.ai_api_key_enc).toBeNull();
+
+    res = await app.inject({
+      method: 'GET',
+      url: `/api/users/${userId}/ai-key`,
+      cookies: authCookies(userId),
+    });
+    expect(res.statusCode).toBe(404);
+
+    await app.close();
   });
 
   it("forbids accessing another user's ai key", async () => {
@@ -346,6 +418,158 @@ describe('key deletion effects on agents', () => {
     expect(row.rows[0].model).toBeNull();
     expect(removeAgentFromSchedule).toHaveBeenCalledWith(agent.id);
     expect(cancelOpenOrders).toHaveBeenCalledWith(userId, { symbol: 'BTCETH' });
+    await app.close();
+  });
+
+  it('drafts agents when shared ai key is revoked', async () => {
+    const app = await buildServer();
+    const adminId = await insertAdminUser(
+      'a5',
+      encrypt('admin@example.com', process.env.KEY_PASSWORD!),
+    );
+    const userId = await insertUser(
+      'u5',
+      encrypt('user@example.com', process.env.KEY_PASSWORD!),
+    );
+    const ai = encrypt('aikey', process.env.KEY_PASSWORD!);
+    const bk = encrypt('bkey', process.env.KEY_PASSWORD!);
+    const bs = encrypt('skey', process.env.KEY_PASSWORD!);
+    await setAiKey(adminId, ai);
+    await setBinanceKey(userId, bk, bs);
+    await shareAiKey(adminId, userId);
+    const agent = await insertAgent({
+      userId,
+      model: 'gpt-5',
+      status: 'active',
+      startBalance: 100,
+      name: 'A3',
+      tokens: [
+        { token: 'BTC', minAllocation: 10 },
+        { token: 'ETH', minAllocation: 20 },
+      ],
+      risk: 'low',
+      reviewInterval: '1h',
+      agentInstructions: 'prompt',
+      manualRebalance: false,
+    });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/users/${adminId}/ai-key/share`,
+      cookies: authCookies(adminId),
+      payload: { email: 'user@example.com' },
+    });
+    expect(res.statusCode).toBe(200);
+    const row = await db.query('SELECT status, model FROM agents WHERE id = $1', [
+      agent.id,
+    ]);
+    expect(row.rows[0].status).toBe('draft');
+    expect(row.rows[0].model).toBeNull();
+    expect(removeAgentFromSchedule).toHaveBeenCalledWith(agent.id);
+    expect(cancelOpenOrders).toHaveBeenCalledWith(userId, { symbol: 'BTCETH' });
+    await app.close();
+  });
+
+  it('ignores agent cleanup when user has their own ai key', async () => {
+    const app = await buildServer();
+    const adminId = await insertAdminUser(
+      'a7',
+      encrypt('admin@example.com', process.env.KEY_PASSWORD!),
+    );
+    const userId = await insertUser(
+      'u7',
+      encrypt('user@example.com', process.env.KEY_PASSWORD!),
+    );
+    const aiAdmin = encrypt('aikey', process.env.KEY_PASSWORD!);
+    const aiUser = encrypt('userkey', process.env.KEY_PASSWORD!);
+    const bk = encrypt('bkey', process.env.KEY_PASSWORD!);
+    const bs = encrypt('skey', process.env.KEY_PASSWORD!);
+    await setAiKey(adminId, aiAdmin);
+    await setAiKey(userId, aiUser);
+    await setBinanceKey(userId, bk, bs);
+    await shareAiKey(adminId, userId);
+    const agent = await insertAgent({
+      userId,
+      model: 'gpt-5',
+      status: 'active',
+      startBalance: 100,
+      name: 'A5',
+      tokens: [
+        { token: 'BTC', minAllocation: 10 },
+        { token: 'ETH', minAllocation: 20 },
+      ],
+      risk: 'low',
+      reviewInterval: '1h',
+      agentInstructions: 'prompt',
+      manualRebalance: false,
+    });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/users/${adminId}/ai-key/share`,
+      cookies: authCookies(adminId),
+      payload: { email: 'user@example.com' },
+    });
+    expect(res.statusCode).toBe(200);
+    const row = await db.query('SELECT status, model FROM agents WHERE id = $1', [
+      agent.id,
+    ]);
+    expect(row.rows[0].status).toBe('active');
+    expect(row.rows[0].model).toBe('gpt-5');
+    expect(removeAgentFromSchedule).not.toHaveBeenCalled();
+    expect(cancelOpenOrders).not.toHaveBeenCalled();
+    const keyRow = await getUserApiKeys(userId);
+    expect(keyRow?.ai_api_key_enc).toBeDefined();
+    await app.close();
+  });
+
+  it('does not affect agents if no shared ai key exists', async () => {
+    const app = await buildServer();
+    const adminId = await insertAdminUser(
+      'a6',
+      encrypt('admin@example.com', process.env.KEY_PASSWORD!),
+    );
+    const userId = await insertUser(
+      'u6',
+      encrypt('user@example.com', process.env.KEY_PASSWORD!),
+    );
+    const aiAdmin = encrypt('aikey', process.env.KEY_PASSWORD!);
+    const aiUser = encrypt('userkey', process.env.KEY_PASSWORD!);
+    const bk = encrypt('bkey', process.env.KEY_PASSWORD!);
+    const bs = encrypt('skey', process.env.KEY_PASSWORD!);
+    await setAiKey(adminId, aiAdmin);
+    await setAiKey(userId, aiUser);
+    await setBinanceKey(userId, bk, bs);
+    const agent = await insertAgent({
+      userId,
+      model: 'gpt-5',
+      status: 'active',
+      startBalance: 100,
+      name: 'A4',
+      tokens: [
+        { token: 'BTC', minAllocation: 10 },
+        { token: 'ETH', minAllocation: 20 },
+      ],
+      risk: 'low',
+      reviewInterval: '1h',
+      agentInstructions: 'prompt',
+      manualRebalance: false,
+    });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/users/${adminId}/ai-key/share`,
+      cookies: authCookies(adminId),
+      payload: { email: 'user@example.com' },
+    });
+    expect(res.statusCode).toBe(404);
+    const row = await db.query('SELECT status, model FROM agents WHERE id = $1', [
+      agent.id,
+    ]);
+    expect(row.rows[0].status).toBe('active');
+    expect(row.rows[0].model).toBe('gpt-5');
+    expect(removeAgentFromSchedule).not.toHaveBeenCalled();
+    expect(cancelOpenOrders).not.toHaveBeenCalled();
     await app.close();
   });
 });

--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -11,7 +11,7 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   await db.query(
-    'TRUNCATE TABLE agent_review_raw_log, agent_review_result, limit_order, agent_tokens, agents, ai_api_keys, exchange_keys, user_identities, users RESTART IDENTITY CASCADE',
+    'TRUNCATE TABLE agent_review_raw_log, agent_review_result, limit_order, agent_tokens, agents, ai_api_key_shares, ai_api_keys, exchange_keys, user_identities, users RESTART IDENTITY CASCADE',
   );
 });
 

--- a/frontend/src/components/forms/AiApiKeySection.tsx
+++ b/frontend/src/components/forms/AiApiKeySection.tsx
@@ -3,12 +3,19 @@ import ApiKeySection from './ApiKeySection';
 
 const aiFields = [{ name: 'key', placeholder: 'API key' }];
 
-export default function AiApiKeySection({ label }: { label: ReactNode }) {
+export default function AiApiKeySection({
+  label,
+  allowShare = false,
+}: {
+  label: ReactNode;
+  allowShare?: boolean;
+}) {
   return (
     <ApiKeySection
       label={label}
       queryKey="ai-key"
       getKeyPath={(id) => `/users/${id}/ai-key`}
+      sharePath={allowShare ? (id) => `/users/${id}/ai-key/share` : undefined}
       fields={aiFields}
       videoGuideUrl="https://www.youtube.com/watch?v=WjVf80HUvYg"
     />

--- a/frontend/src/components/forms/ApiKeySection.tsx
+++ b/frontend/src/components/forms/ApiKeySection.tsx
@@ -29,6 +29,7 @@ interface ApiKeySectionProps {
   balanceQueryKey?: string;
   getBalancePath?: (id: string) => string;
   whitelistHost?: string;
+  sharePath?: (id: string) => string;
 }
 
 const textSecurityStyle: CSSProperties & { WebkitTextSecurity: string } = {
@@ -44,6 +45,7 @@ export default function ApiKeySection({
   balanceQueryKey,
   getBalancePath,
   whitelistHost,
+  sharePath,
 }: ApiKeySectionProps) {
   const { user } = useUser();
   const toast = useToast();
@@ -57,13 +59,17 @@ export default function ApiKeySection({
     mode: 'onChange',
   });
   const id = user!.id;
-  const query = useQuery<Record<string, string> | null>({
+  type KeyData = {
+    [key: string]: string | boolean | undefined;
+    shared?: boolean;
+  };
+  const query = useQuery<KeyData | null>({
     queryKey: [queryKey, id],
     enabled: !!user,
     queryFn: async () => {
       try {
         const res = await api.get(getKeyPath(id));
-        return res.data as Record<string, string>;
+        return res.data as KeyData;
       } catch (err) {
         if (axios.isAxiosError(err) && err.response?.status === 404) return null;
         throw err;
@@ -72,8 +78,17 @@ export default function ApiKeySection({
   });
 
   useEffect(() => {
-    form.reset(query.data ?? defaultValues);
-  }, [query.data, defaultValues, form]);
+    const data = query.data
+      ? fields.reduce(
+          (acc, f) => ({
+            ...acc,
+            [f.name]: (query.data![f.name] as string | undefined) ?? '',
+          }),
+          {} as Record<string, string>,
+        )
+      : defaultValues;
+    form.reset(data);
+  }, [query.data, defaultValues, form, fields]);
 
   const [editing, setEditing] = useState(false);
   useEffect(() => {
@@ -105,6 +120,18 @@ export default function ApiKeySection({
       await api.delete(getKeyPath(id));
     },
     onSuccess: () => query.refetch(),
+  });
+
+  const shareMut = useMutation({
+    mutationFn: async (email: string) => {
+      await api.post(sharePath!(id), { email });
+    },
+  });
+
+  const revokeMut = useMutation({
+    mutationFn: async (email: string) => {
+      await api.delete(sharePath!(id), { data: { email } });
+    },
   });
 
   const balanceQuery = useQuery<{ totalUsd: number }>({
@@ -167,17 +194,24 @@ export default function ApiKeySection({
               {query.data ? 'Update' : 'Save'}
             </Button>
             {query.data && (
-              <Button
-                type="button"
-                variant="secondary"
-                onClick={() => {
-                  setEditing(false);
-                  form.reset(query.data ?? defaultValues);
-                }}
-                disabled={saveMut.isPending}
-              >
-                Cancel
-              </Button>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={() => {
+                    setEditing(false);
+                    const data = fields.reduce(
+                      (acc, f) => ({
+                        ...acc,
+                        [f.name]: (query.data?.[f.name] as string | undefined) ?? '',
+                      }),
+                      {} as Record<string, string>,
+                    );
+                    form.reset(data);
+                  }}
+                  disabled={saveMut.isPending}
+                >
+                  Cancel
+                </Button>
             )}
           </div>
         </div>
@@ -186,39 +220,80 @@ export default function ApiKeySection({
           <div className="flex gap-2">
             <input
               type="text"
-              value={query.data ? query.data[fields[0].name] ?? '' : ''}
+              value={
+                query.data
+                  ? ((query.data[fields[0].name] as string | undefined) ?? '')
+                  : ''
+              }
               disabled
               className="border rounded px-2 py-1 w-full"
               style={textSecurityStyle}
               data-lpignore="true"
               data-1p-ignore="true"
             />
-            <Button
-              type="button"
-              onClick={() => {
-                setEditing(true);
-                form.reset(defaultValues);
-              }}
-              disabled={delMut.isPending}
-            >
-              Edit
-            </Button>
-            <Button
-              type="button"
-              variant="danger"
-              onClick={() => {
-                if (
-                  window.confirm(
-                    'Deleting this key will stop all active agents. Continue?',
-                  )
-                ) {
-                  delMut.mutate();
-                }
-              }}
-              disabled={delMut.isPending}
-            >
-              Delete
-            </Button>
+            {!query.data?.shared && (
+              <>
+                <Button
+                  type="button"
+                  onClick={() => {
+                    setEditing(true);
+                    form.reset(defaultValues);
+                  }}
+                  disabled={delMut.isPending}
+                >
+                  Edit
+                </Button>
+                <Button
+                  type="button"
+                  variant="danger"
+                  onClick={() => {
+                    if (
+                      window.confirm(
+                        'Deleting this key will stop all active agents. Continue?',
+                      )
+                    ) {
+                      delMut.mutate();
+                    }
+                  }}
+                  disabled={delMut.isPending}
+                >
+                  Delete
+                </Button>
+              </>
+            )}
+            {query.data?.shared && (
+              <p className="text-sm text-gray-600 self-center">Shared by admin</p>
+            )}
+            {user?.role === 'admin' && sharePath && (
+              <>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={() => {
+                    const email = window.prompt('Enter email to share with');
+                    if (email) shareMut.mutate(email);
+                  }}
+                  disabled={
+                    delMut.isPending || shareMut.isPending || revokeMut.isPending
+                  }
+                >
+                  Share
+                </Button>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={() => {
+                    const email = window.prompt('Enter email to revoke');
+                    if (email) revokeMut.mutate(email);
+                  }}
+                  disabled={
+                    delMut.isPending || shareMut.isPending || revokeMut.isPending
+                  }
+                >
+                  Revoke
+                </Button>
+              </>
+            )}
           </div>
           {balanceQueryKey && (
             balanceQuery.isLoading ? (

--- a/frontend/src/routes/Keys.tsx
+++ b/frontend/src/routes/Keys.tsx
@@ -11,7 +11,7 @@ export default function Keys() {
         Your API keys are encrypted using AES-256 and stored only on our server. They are
         decrypted solely when needed to call providers and are never shared.
       </div>
-      <AiApiKeySection label="OpenAI API Key" />
+      <AiApiKeySection label="OpenAI API Key" allowShare />
       <ExchangeApiKeySection
         exchange="binance"
         label={


### PR DESCRIPTION
## Summary
- prevent shared OpenAI keys from being modified or viewed
- resolve shared key IDs for agents and shared usage
- hide edit/delete controls when using an admin's shared key
- define KeyData type and guard against null when loading keys
- ensure shared-key users can list models using admin's key
- expose share/revoke actions for admins on the Keys page
- draft agents and cancel orders when a shared OpenAI key is revoked
- validate share existence before revoking to avoid disabling unrelated users
- avoid drafting agents when revoking a share for users with personal keys

## Testing
- `npm --prefix backend test`
- `npm --prefix backend run build`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68beb4162a60832c99436e6aef1c9e4e