### PR TITLE
feat: restrict shared AI keys to single model

### DIFF
--- a/backend/src/db/migrations/002_add_model_to_ai_api_key_shares.sql
+++ b/backend/src/db/migrations/002_add_model_to_ai_api_key_shares.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ai_api_key_shares ADD COLUMN model TEXT;

--- a/backend/src/util/agents.ts
+++ b/backend/src/util/agents.ts
@@ -4,6 +4,7 @@ import {
   findIdenticalDraftAgent,
   findActiveTokenConflicts,
 } from '../repos/agents.js';
+import { getAiKeyRow } from '../repos/api-keys.js';
 import {
   errorResponse,
   lengthMessage,
@@ -78,6 +79,12 @@ async function validateAgentInput(
   } else if (body.model.length > 50) {
     log.error('model too long');
     return { code: 400, body: errorResponse(lengthMessage('model', 50)) };
+  } else {
+    const keyRow = await getAiKeyRow(body.userId);
+    if (!keyRow?.own && keyRow?.shared?.model && body.model !== keyRow.shared.model) {
+      log.error('model not allowed');
+      return { code: 400, body: errorResponse('model not allowed') };
+    }
   }
   if (body.status === AgentStatus.Draft) {
     const dupDraft = await findIdenticalDraftAgent(

--- a/backend/test/apiKeys.test.ts
+++ b/backend/test/apiKeys.test.ts
@@ -139,7 +139,7 @@ describe('AI API key routes', () => {
       method: 'POST',
       url: `/api/users/${adminId}/ai-key/share`,
       cookies: authCookies(adminId),
-      payload: { email: 'user@example.com' },
+      payload: { email: 'user@example.com', model: 'gpt-5' },
     });
     expect(res.statusCode).toBe(200);
 
@@ -195,7 +195,7 @@ describe('AI API key routes', () => {
       method: 'DELETE',
       url: `/api/users/${adminId}/ai-key/share`,
       cookies: authCookies(adminId),
-      payload: { email: 'user@example.com' },
+      payload: { email: 'user@example.com', model: 'gpt-5' },
     });
     expect(res.statusCode).toBe(200);
 
@@ -455,7 +455,7 @@ describe('key deletion effects on agents', () => {
     const bs = encrypt('skey', process.env.KEY_PASSWORD!);
     await setAiKey(adminId, ai);
     await setBinanceKey(userId, bk, bs);
-    await shareAiKey(adminId, userId);
+    await shareAiKey(adminId, userId, 'gpt-5');
     const agent = await insertAgent({
       userId,
       model: 'gpt-5',
@@ -504,7 +504,7 @@ describe('key deletion effects on agents', () => {
     const bs = encrypt('skey', process.env.KEY_PASSWORD!);
     await setAiKey(adminId, ai);
     await setBinanceKey(userId, bk, bs);
-    await shareAiKey(adminId, userId);
+    await shareAiKey(adminId, userId, 'gpt-5');
     const agent = await insertAgent({
       userId,
       model: 'gpt-5',
@@ -561,7 +561,7 @@ describe('key deletion effects on agents', () => {
     await setAiKey(adminId, aiAdmin);
     await setAiKey(userId, aiUser);
     await setBinanceKey(userId, bk, bs);
-    await shareAiKey(adminId, userId);
+    await shareAiKey(adminId, userId, 'gpt-5');
     const agent = await insertAgent({
       userId,
       model: 'gpt-5',

--- a/backend/test/models.test.ts
+++ b/backend/test/models.test.ts
@@ -106,12 +106,9 @@ describe('model routes', () => {
     const userId = await insertUser('6');
     const key = 'aikeyshared123456';
     await setAiKey(adminId, encrypt(key, process.env.KEY_PASSWORD!));
-    await shareAiKey(adminId, userId);
+    await shareAiKey(adminId, userId, 'gpt-5');
 
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ data: [{ id: 'gpt-5' }, { id: 'other' }] }),
-    });
+    const fetchMock = vi.fn();
     const originalFetch = globalThis.fetch;
     (globalThis as any).fetch = fetchMock;
 
@@ -122,9 +119,7 @@ describe('model routes', () => {
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ models: ['gpt-5'] });
-    expect(fetchMock).toHaveBeenCalledWith('https://api.openai.com/v1/models', {
-      headers: { Authorization: `Bearer ${key}` },
-    });
+    expect(fetchMock).not.toHaveBeenCalled();
 
     (globalThis as any).fetch = originalFetch;
     await app.close();

--- a/frontend/src/components/forms/ApiKeySection.tsx
+++ b/frontend/src/components/forms/ApiKeySection.tsx
@@ -123,8 +123,8 @@ export default function ApiKeySection({
   });
 
   const shareMut = useMutation({
-    mutationFn: async (email: string) => {
-      await api.post(sharePath!(id), { email });
+    mutationFn: async ({ email, model }: { email: string; model: string }) => {
+      await api.post(sharePath!(id), { email, model });
     },
   });
 
@@ -269,9 +269,21 @@ export default function ApiKeySection({
                 <Button
                   type="button"
                   variant="secondary"
-                  onClick={() => {
+                  onClick={async () => {
                     const email = window.prompt('Enter email to share with');
-                    if (email) shareMut.mutate(email);
+                    if (!email) return;
+                    try {
+                      const res = await api.get(`/users/${user!.id}/models`);
+                      const models = res.data.models as string[];
+                      const model = window.prompt(
+                        `Select model: ${models.join(', ')}`,
+                      );
+                      if (model && models.includes(model)) {
+                        shareMut.mutate({ email, model });
+                      }
+                    } catch {
+                      toast.show('Failed to fetch models');
+                    }
                   }}
                   disabled={
                     delMut.isPending || shareMut.isPending || revokeMut.isPending

--- a/frontend/src/components/forms/SharedAiApiKeySection.tsx
+++ b/frontend/src/components/forms/SharedAiApiKeySection.tsx
@@ -10,13 +10,13 @@ const textSecurityStyle: CSSProperties & { WebkitTextSecurity: string } = {
 
 export default function SharedAiApiKeySection({ label }: { label: ReactNode }) {
   const { user } = useUser();
-  const query = useQuery<{ key: string } | null>({
+  const query = useQuery<{ key: string; model?: string } | null>({
     queryKey: ['ai-key-shared', user?.id],
     enabled: !!user,
     queryFn: async () => {
       try {
         const res = await api.get(`/users/${user!.id}/ai-key/shared`);
-        return res.data as { key: string };
+        return res.data as { key: string; model?: string };
       } catch (err) {
         if (axios.isAxiosError(err) && err.response?.status === 404) return null;
         throw err;
@@ -39,7 +39,9 @@ export default function SharedAiApiKeySection({ label }: { label: ReactNode }) {
           data-lpignore="true"
           data-1p-ignore="true"
         />
-        <p className="text-sm text-gray-600 self-center">Shared by admin</p>
+        <p className="text-sm text-gray-600 self-center">
+          Shared by admin{query.data.model ? ` (${query.data.model})` : ''}
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow admins to specify a model when sharing an OpenAI key
- limit model list for shared keys and validate usage server-side
- display shared model in key UI and restrict share action to chosen model

## Testing
- `KEY_PASSWORD=test GOOGLE_CLIENT_ID=test DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix frontend run lint`
- `KEY_PASSWORD=test GOOGLE_CLIENT_ID=test DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf8257646c832caf3f283670a873fb