### PR TITLE
Move prompt view icon before log view icon

### DIFF
--- a/frontend/src/components/ExecLogItem.tsx
+++ b/frontend/src/components/ExecLogItem.tsx
@@ -147,6 +147,10 @@ export default function ExecLogItem({ log, agentId, manualRebalance, tokens }: P
                   )}
                 </span>
               </div>
+              <FileText
+                className="h-4 w-4 cursor-pointer flex-shrink-0"
+                onClick={handleShowPrompt}
+              />
               <Eye
                 className="h-4 w-4 cursor-pointer"
                 onClick={() => setShowJson(true)}
@@ -158,12 +162,24 @@ export default function ExecLogItem({ log, agentId, manualRebalance, tokens }: P
               </Modal>
             </div>
           )}
-          {hasResponse && <ExecSuccessItem response={response} />}
+          {hasResponse && (
+            <ExecSuccessItem
+              response={response}
+              promptIcon={
+                <FileText
+                  className="h-4 w-4 cursor-pointer flex-shrink-0"
+                  onClick={handleShowPrompt}
+                />
+              }
+            />
+          )}
         </div>
-        <FileText
-          className="h-4 w-4 cursor-pointer ml-2 flex-shrink-0"
-          onClick={handleShowPrompt}
-        />
+        {!hasError && !hasResponse && (
+          <FileText
+            className="ml-2 h-4 w-4 cursor-pointer flex-shrink-0"
+            onClick={handleShowPrompt}
+          />
+        )}
         {manualRebalance && !!response?.rebalance && !hasOrders && (
           <Button
             variant="secondary"

--- a/frontend/src/components/ExecSuccessItem.tsx
+++ b/frontend/src/components/ExecSuccessItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { Eye } from 'lucide-react';
 import Modal from './ui/Modal';
 
@@ -13,9 +13,10 @@ interface Props {
     newAllocation?: number;
     shortReport: string;
   };
+  promptIcon?: ReactNode;
 }
 
-export default function ExecSuccessItem({ response }: Props) {
+export default function ExecSuccessItem({ response, promptIcon }: Props) {
   const [showJson, setShowJson] = useState(false);
   const { rebalance, newAllocation, shortReport } = response;
   const color = rebalance
@@ -33,6 +34,7 @@ export default function ExecSuccessItem({ response }: Props) {
           <span className="ml-1">(new allocation: {newAllocation})</span>
         )}
       </div>
+      {promptIcon}
       <Eye
         className="h-4 w-4 cursor-pointer"
         onClick={() => setShowJson(true)}


### PR DESCRIPTION
## Summary
- Display prompt icon to the left of log view icon in execution log entries
- Introduce optional promptIcon slot in ExecSuccessItem for flexible icon placement

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf866ae200832c9c7a2f694831526c