### PR TITLE
Compact prompt JSON before agent call

### DIFF
--- a/backend/src/util/ai.ts
+++ b/backend/src/util/ai.ts
@@ -90,6 +90,17 @@ export async function callAi(body: string, apiKey: string): Promise<string> {
   return await res.text();
 }
 
+function compactJson(value: unknown): string {
+  if (typeof value === 'string') {
+    try {
+      return JSON.stringify(JSON.parse(value));
+    } catch {
+      return value.trim();
+    }
+  }
+  return JSON.stringify(value);
+}
+
 export async function callRebalancingAgent(
   model: string,
   input: RebalancePrompt,
@@ -97,7 +108,7 @@ export async function callRebalancingAgent(
 ): Promise<string> {
   const body = JSON.stringify({
     model,
-    input: JSON.stringify(input),
+    input: compactJson(input),
     instructions: developerInstructions,
     tools: [{ type: 'web_search_preview' }],
     text: {

--- a/backend/test/callRebalancingAgent.test.ts
+++ b/backend/test/callRebalancingAgent.test.ts
@@ -30,10 +30,25 @@ describe('callRebalancingAgent structured output', () => {
     expect(body.instructions).toMatch(/determine the target allocation/i);
     const parsedInput = JSON.parse(body.input);
     expect(parsedInput.previous_responses).toEqual(['p1', 'p2']);
+    expect(body.input).not.toMatch(/":\s/);
+    expect(body.input).not.toMatch(/,\s/);
     expect(body.text.format.type).toBe('json_schema');
     const anyOf = body.text.format.schema.properties.result.anyOf;
     expect(Array.isArray(anyOf)).toBe(true);
     expect(anyOf).toHaveLength(3);
+    (globalThis as any).fetch = originalFetch;
+  });
+
+  it('removes extraneous whitespace from json input', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ text: async () => '' });
+    const originalFetch = globalThis.fetch;
+    (globalThis as any).fetch = fetchMock;
+    const { callRebalancingAgent } = await import('../src/util/ai.js');
+    const prompt = '{\n  "a": 1,\n  "b": 2\n}';
+    await callRebalancingAgent('gpt-test', prompt as any, 'key');
+    const [, opts] = fetchMock.mock.calls[0];
+    const body = JSON.parse(opts.body);
+    expect(body.input).toBe('{"a":1,"b":2}');
     (globalThis as any).fetch = originalFetch;
   });
 });


### PR DESCRIPTION
## Summary
- Compact JSON prompts before invoking AI agent to reduce token usage
- Add tests ensuring serialized prompts omit extraneous spaces

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf92405fc0832c8f882971790133ae