### PR TITLE
Compact prompt JSON before agent call

### DIFF
--- a/backend/test/callRebalancingAgent.test.ts
+++ b/backend/test/callRebalancingAgent.test.ts
@@ -26,14 +26,30 @@ describe('callRebalancingAgent structured output', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [, opts] = fetchMock.mock.calls[0];
     const body = JSON.parse(opts.body);
+    expect(opts.body).toBe(JSON.stringify(body));
     expect(body.instructions).toMatch(/assist a real trader/i);
     expect(body.instructions).toMatch(/determine the target allocation/i);
     const parsedInput = JSON.parse(body.input);
     expect(parsedInput.previous_responses).toEqual(['p1', 'p2']);
+    expect(body.input).not.toMatch(/":\s/);
+    expect(body.input).not.toMatch(/,\s/);
     expect(body.text.format.type).toBe('json_schema');
     const anyOf = body.text.format.schema.properties.result.anyOf;
     expect(Array.isArray(anyOf)).toBe(true);
     expect(anyOf).toHaveLength(3);
+    (globalThis as any).fetch = originalFetch;
+  });
+
+  it('removes extraneous whitespace from json input', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ text: async () => '' });
+    const originalFetch = globalThis.fetch;
+    (globalThis as any).fetch = fetchMock;
+    const { callRebalancingAgent } = await import('../src/util/ai.js');
+    const prompt = '{\n  "a": 1,\n  "b": 2\n}';
+    await callRebalancingAgent('gpt-test', prompt as any, 'key');
+    const [, opts] = fetchMock.mock.calls[0];
+    const body = JSON.parse(opts.body);
+    expect(body.input).toBe('{"a":1,"b":2}');
     (globalThis as any).fetch = originalFetch;
   });
 });


### PR DESCRIPTION
## Summary
- Minify full AI request payload by serializing via `compactJson`
- Build `callRebalancingAgent` body as object with compact prompt string
- Extend tests to confirm body serialization has no extraneous whitespace

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf92405fc0832c8f882971790133ae