### PR TITLE
fix: update fear & greed index source

### DIFF
--- a/backend/src/services/binance.ts
+++ b/backend/src/services/binance.ts
@@ -393,7 +393,7 @@ export async function fetchMarketTimeseries(symbol: string) {
 export type FearGreedIndex = { value: number; classification: string };
 
 export async function fetchFearGreedIndex(): Promise<FearGreedIndex> {
-  const res = await fetch('https://fapi.binance.com/fapi/v1/fngIndex');
+  const res = await fetch('https://api.alternative.me/fng/');
   if (!res.ok) {
     const body = await res.text();
     throw new Error(
@@ -401,8 +401,8 @@ export async function fetchFearGreedIndex(): Promise<FearGreedIndex> {
     );
   }
   const json = (await res.json()) as any;
-  const value = Number(json?.value ?? json?.data?.[0]?.value);
+  const value = Number(json?.data?.[0]?.value ?? json?.value);
   const classification =
-    json?.value_classification ?? json?.data?.[0]?.value_classification ?? '';
+    json?.data?.[0]?.value_classification ?? json?.value_classification ?? '';
   return { value, classification };
 }

--- a/backend/test/fearGreedIndex.test.ts
+++ b/backend/test/fearGreedIndex.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchFearGreedIndex } from '../src/services/binance.js';
+
+describe('fetchFearGreedIndex', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('parses value and classification', async () => {
+    const mockJson = {
+      data: [{ value: '55', value_classification: 'Greed' }],
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => mockJson });
+    vi.stubGlobal('fetch', fetchMock as any);
+    const res = await fetchFearGreedIndex();
+    expect(fetchMock).toHaveBeenCalledWith('https://api.alternative.me/fng/');
+    expect(res).toEqual({ value: 55, classification: 'Greed' });
+  });
+
+  it('throws on non-ok response', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: false, status: 500, text: async () => 'err' });
+    vi.stubGlobal('fetch', fetchMock as any);
+    await expect(fetchFearGreedIndex()).rejects.toThrow(
+      'failed to fetch fear & greed index: 500 err',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- switch fear & greed index fetch to alternative.me endpoint
- add tests ensuring index parsing and error handling

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf9012ea78832c86afd585324a8056