### PR TITLE
refactor(previous responses): store minimal fields

### DIFF
--- a/backend/src/util/ai.ts
+++ b/backend/src/util/ai.ts
@@ -16,6 +16,13 @@ export interface RebalancePosition {
   value_usdt: number;
 }
 
+export interface PreviousResponse {
+  rebalance?: boolean;
+  newAllocation?: number;
+  shortReport?: string;
+  error?: unknown;
+}
+
 export interface RebalancePrompt {
   instructions: string;
   config: {
@@ -36,7 +43,7 @@ export interface RebalancePrompt {
     market_timeseries?: Record<string, MarketTimeseries>;
     fearGreedIndex?: { value: number; classification: string };
   };
-  previous_responses?: string[];
+  previous_responses?: PreviousResponse[];
 }
 
 const rebalanceResponseSchema = {

--- a/backend/test/callRebalancingAgent.test.ts
+++ b/backend/test/callRebalancingAgent.test.ts
@@ -20,7 +20,10 @@ describe('callRebalancingAgent structured output', () => {
         },
       },
       marketData: { currentPrice: 1 },
-      previous_responses: ['p1', 'p2'],
+      previous_responses: [
+        { shortReport: 'p1' },
+        { rebalance: true, newAllocation: 50 },
+      ],
     };
     await callRebalancingAgent('gpt-test', prompt, 'key');
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -30,7 +33,10 @@ describe('callRebalancingAgent structured output', () => {
     expect(body.instructions).toMatch(/assist a real trader/i);
     expect(body.instructions).toMatch(/determine the target allocation/i);
     const parsedInput = JSON.parse(body.input);
-    expect(parsedInput.previous_responses).toEqual(['p1', 'p2']);
+    expect(parsedInput.previous_responses).toEqual([
+      { shortReport: 'p1' },
+      { rebalance: true, newAllocation: 50 },
+    ]);
     expect(body.input).not.toMatch(/":\s/);
     expect(body.input).not.toMatch(/,\s/);
     expect(body.text.format.type).toBe('json_schema');

--- a/backend/test/reviewPortfolio.test.ts
+++ b/backend/test/reviewPortfolio.test.ts
@@ -126,7 +126,7 @@ describe('reviewPortfolio', () => {
     await reviewAgentPortfolio(log, '1');
     expect(callRebalancingAgent).toHaveBeenCalledTimes(1);
     const args = (callRebalancingAgent as any).mock.calls[0];
-    const prev = args[1].previous_responses.map((s: string) => JSON.parse(s));
+    const prev = args[1].previous_responses;
     expect(prev).toEqual([
       { rebalance: true, newAllocation: 5, shortReport: 'short-5' },
       { rebalance: true, newAllocation: 4, shortReport: 'short-4' },


### PR DESCRIPTION
## Summary
- model previous prompt responses with only `rebalance`, `newAllocation`, `shortReport`, and `error`
- parse recent agent review results into minimal objects instead of JSON strings
- update RebalancePrompt interface and tests for new structure

## Testing
- `pg_isready`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68bfbe670bec832cbbce254a7f15ad22