### PR TITLE
Refactor AI prompt portfolio keys and weights

### DIFF
--- a/backend/src/util/ai.ts
+++ b/backend/src/util/ai.ts
@@ -49,25 +49,22 @@ export interface PreviousResponse {
 
 export interface RebalancePrompt {
   instructions: string;
-  config: {
-    policy: { floorPercents: Record<string, number> };
-    currentStatePortfolio: {
-      ts: string;
-      positions: RebalancePosition[];
-      currentWeights: Record<string, number>;
-    };
-    /**
-     * Summary of recent limit orders placed by the agent. Only essential
-     * attributes are included to minimize token usage in the prompt.
-     */
-    previousLimitOrders?: {
-      symbol: string;
-      side: string;
-      amount: number;
-      datetime: string;
-      status: string;
-    }[];
+  policy: { floor: Record<string, number> };
+  portfolio: {
+    ts: string;
+    positions: RebalancePosition[];
   };
+  /**
+   * Summary of recent limit orders placed by the agent. Only essential
+   * attributes are included to minimize token usage in the prompt.
+   */
+  prev_orders?: {
+    symbol: string;
+    side: string;
+    amount: number;
+    datetime: string;
+    status: string;
+  }[];
   marketData: {
     currentPrice: number;
     indicators?: Record<string, TokenMetrics>;

--- a/backend/test/callRebalancingAgent.test.ts
+++ b/backend/test/callRebalancingAgent.test.ts
@@ -9,15 +9,12 @@ describe('callRebalancingAgent structured output', () => {
     const { callRebalancingAgent } = await import('../src/util/ai.js');
     const prompt: RebalancePrompt = {
       instructions: 'inst',
-      config: {
-        policy: { floorPercents: { USDT: 20 } },
-        currentStatePortfolio: {
-          ts: new Date().toISOString(),
-          positions: [
-            { sym: 'USDT', qty: 1, price_usdt: 1, value_usdt: 1 },
-          ],
-          currentWeights: { USDT: 1 },
-        },
+      policy: { floor: { USDT: 20 } },
+      portfolio: {
+        ts: new Date().toISOString(),
+        positions: [
+          { sym: 'USDT', qty: 1, price_usdt: 1, value_usdt: 1 },
+        ],
       },
       marketData: { currentPrice: 1 },
       previous_responses: [


### PR DESCRIPTION
## Summary
- Flatten rebalance prompt structure by moving policy, portfolio, and prev_orders to the top level
- Update portfolio review job to build and consume flattened prompt
- Adjust unit tests for new prompt layout

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test` *(skipped: tests hang or require database)*
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68bfc2965bc4832cb94b007fd7cd51b6