### PR TITLE
Validate agent allocation against policy floor

### DIFF
--- a/backend/src/jobs/review-portfolio.ts
+++ b/backend/src/jobs/review-portfolio.ts
@@ -15,7 +15,7 @@ import {
   getOpenLimitOrdersForAgent,
   updateLimitOrderStatus,
 } from '../repos/limit-orders.js';
-import { parseExecLog } from '../util/parse-exec-log.js';
+import { parseExecLog, validateExecResponse } from '../util/parse-exec-log.js';
 import { callRebalancingAgent } from '../util/ai.js';
 import {
   fetchAccount,
@@ -506,20 +506,25 @@ async function executeAgent(
       response: text,
     });
     const parsed = parseExecLog(text);
+    const validationError = validateExecResponse(parsed.response, prompt.policy);
+    if (validationError) log.error({ err: validationError }, 'validation failed');
     const resultId = await insertReviewResult({
       agentId: row.id,
       log: parsed.text,
       rawLogId: logId,
-      ...(parsed.response
+      ...(parsed.response && !validationError
         ? {
             rebalance: parsed.response.rebalance,
             newAllocation: parsed.response.newAllocation,
             shortReport: parsed.response.shortReport,
           }
         : {}),
-      ...(parsed.error ? { error: parsed.error } : {}),
+      ...((parsed.error || validationError)
+        ? { error: parsed.error ?? { message: validationError } }
+        : {}),
     });
     if (
+      !validationError &&
       !row.manual_rebalance &&
       parsed.response?.rebalance &&
       parsed.response.newAllocation !== undefined

--- a/backend/src/util/parse-exec-log.ts
+++ b/backend/src/util/parse-exec-log.ts
@@ -121,3 +121,20 @@ export function parseExecLog(log: unknown): ParsedExecLog {
 
   return { text, response, error };
 }
+
+export function validateExecResponse(
+  response: ParsedExecLog['response'] | undefined,
+  policy: { floor: Record<string, number> },
+): string | undefined {
+  if (!response || response.newAllocation === undefined) return undefined;
+  const na = response.newAllocation;
+  if (typeof na !== 'number' || Number.isNaN(na) || na < 0 || na > 100)
+    return 'newAllocation must be between 0 and 100';
+  const tokens = Object.keys(policy.floor || {});
+  const [t1, t2] = tokens;
+  const floor1 = t1 ? policy.floor[t1] || 0 : 0;
+  const floor2 = t2 ? policy.floor[t2] || 0 : 0;
+  if (na < floor1 || na > 100 - floor2)
+    return 'newAllocation violates policy floor';
+  return undefined;
+}

--- a/backend/test/reviewPortfolio.test.ts
+++ b/backend/test/reviewPortfolio.test.ts
@@ -341,6 +341,96 @@ describe('reviewPortfolio', () => {
     expect(createRebalanceLimitOrder).not.toHaveBeenCalled();
   });
 
+  it('records error when newAllocation is out of range', async () => {
+    vi.mocked(callRebalancingAgent).mockClear();
+    vi.mocked(createRebalanceLimitOrder).mockClear();
+    vi.mocked(callRebalancingAgent).mockResolvedValueOnce(
+      JSON.stringify({
+        object: 'response',
+        output: [
+          {
+            id: 'msg_1',
+            content: [
+              {
+                text: JSON.stringify({
+                  result: { rebalance: true, newAllocation: 150, shortReport: 's' },
+                }),
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    await db.query('INSERT INTO users (id) VALUES ($1)', ['13']);
+    await db.query(
+      "INSERT INTO ai_api_keys (user_id, provider, api_key_enc) VALUES ($1, 'openai', $2)",
+      ['13', 'enc'],
+    );
+    await db.query(
+      "INSERT INTO agents (id, user_id, model, status, name, risk, review_interval, agent_instructions, manual_rebalance) VALUES ($1, $2, 'gpt', 'active', 'Agent13', 'low', '1h', 'inst', false)",
+      ['13', '13'],
+    );
+    await db.query(
+      "INSERT INTO agent_tokens (agent_id, token, min_allocation, position) VALUES ($1, 'BTC', 10, 1), ($1, 'ETH', 20, 2)",
+      ['13'],
+    );
+    const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
+    await reviewAgentPortfolio(log, '13');
+    expect(createRebalanceLimitOrder).not.toHaveBeenCalled();
+    const { rows } = await db.query(
+      'SELECT new_allocation, error FROM agent_review_result WHERE agent_id=$1',
+      ['13'],
+    );
+    const typed = rows as { new_allocation: number | null; error: string | null }[];
+    expect(typed[0].new_allocation).toBeNull();
+    expect(typed[0].error).not.toBeNull();
+  });
+
+  it('records error when newAllocation violates floor', async () => {
+    vi.mocked(callRebalancingAgent).mockClear();
+    vi.mocked(createRebalanceLimitOrder).mockClear();
+    vi.mocked(callRebalancingAgent).mockResolvedValueOnce(
+      JSON.stringify({
+        object: 'response',
+        output: [
+          {
+            id: 'msg_1',
+            content: [
+              {
+                text: JSON.stringify({
+                  result: { rebalance: true, newAllocation: 5, shortReport: 's' },
+                }),
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    await db.query('INSERT INTO users (id) VALUES ($1)', ['14']);
+    await db.query(
+      "INSERT INTO ai_api_keys (user_id, provider, api_key_enc) VALUES ($1, 'openai', $2)",
+      ['14', 'enc'],
+    );
+    await db.query(
+      "INSERT INTO agents (id, user_id, model, status, name, risk, review_interval, agent_instructions, manual_rebalance) VALUES ($1, $2, 'gpt', 'active', 'Agent14', 'low', '1h', 'inst', false)",
+      ['14', '14'],
+    );
+    await db.query(
+      "INSERT INTO agent_tokens (agent_id, token, min_allocation, position) VALUES ($1, 'BTC', 10, 1), ($1, 'ETH', 20, 2)",
+      ['14'],
+    );
+    const log = { child: () => log, info: () => {}, error: () => {} } as unknown as FastifyBaseLogger;
+    await reviewAgentPortfolio(log, '14');
+    expect(createRebalanceLimitOrder).not.toHaveBeenCalled();
+    const { rows } = await db.query(
+      'SELECT new_allocation, error FROM agent_review_result WHERE agent_id=$1',
+      ['14'],
+    );
+    const typed = rows as { new_allocation: number | null; error: string | null }[];
+    expect(typed[0].new_allocation).toBeNull();
+    expect(typed[0].error).not.toBeNull();
+  });
+
   it('omits indicators for stablecoins', async () => {
     vi.mocked(callRebalancingAgent).mockClear();
     vi.mocked(fetchTokenIndicators).mockClear();


### PR DESCRIPTION
## Summary
- add `validateExecResponse` to check newAllocation range and policy floor
- log and store validation errors in `executeAgent`
- test invalid and out-of-policy allocations are rejected

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test` *(fails: Cannot find package 'qrcode')*
- `npm --prefix backend run build` *(fails: Cannot find module 'qrcode')*

------
https://chatgpt.com/codex/tasks/task_e_68bfd768aed8832c838365a033831893