### PR TITLE
Add RSI and Stochastic indicators

### DIFF
--- a/backend/src/jobs/review-portfolio.ts
+++ b/backend/src/jobs/review-portfolio.ts
@@ -465,6 +465,9 @@ function flattenIndicators(ind?: TokenIndicators) {
     volume_z_24h: ind.volume.z_24h,
     corr_BTC_30d: ind.corr.BTC_30d,
     regime_BTC: ind.regime.BTC,
+    osc_rsi_14: ind.osc.rsi_14,
+    osc_stoch_k: ind.osc.stoch_k,
+    osc_stoch_d: ind.osc.stoch_d,
   };
 }
 

--- a/backend/test/indicators.test.ts
+++ b/backend/test/indicators.test.ts
@@ -41,6 +41,9 @@ describe('fetchTokenIndicators', () => {
     expect(data.volume.z_1h).toBeCloseTo(1.8, 1);
     expect(data.corr.BTC_30d).toBeCloseTo(1, 5);
     expect(data.regime.BTC).toBe('trend');
+    expect(data.osc.rsi_14).toBeCloseTo(100, 5);
+    expect(data.osc.stoch_k).toBeCloseTo(96.43, 2);
+    expect(data.osc.stoch_d).toBeCloseTo(96.43, 2);
   });
 });
 

--- a/backend/test/openOrdersCleanup.test.ts
+++ b/backend/test/openOrdersCleanup.test.ts
@@ -11,6 +11,7 @@ const sampleIndicators = {
   volume: { z_1h: 0, z_24h: 0 },
   corr: { BTC_30d: 0 },
   regime: { BTC: 'range' },
+  osc: { rsi_14: 0, stoch_k: 0, stoch_d: 0 },
 };
 
 vi.mock('../src/util/ai.js', () => ({

--- a/backend/test/reviewPortfolio.test.ts
+++ b/backend/test/reviewPortfolio.test.ts
@@ -11,6 +11,7 @@ const sampleIndicators = {
   volume: { z_1h: 0, z_24h: 0 },
   corr: { BTC_30d: 0 },
   regime: { BTC: 'range' },
+  osc: { rsi_14: 0, stoch_k: 0, stoch_d: 0 },
 };
 
 const sampleTimeseries = {
@@ -38,6 +39,9 @@ const flatIndicators = {
   volume_z_24h: 0,
   corr_BTC_30d: 0,
   regime_BTC: 'range',
+  osc_rsi_14: 0,
+  osc_stoch_k: 0,
+  osc_stoch_d: 0,
 };
 
 const flatTimeseries = {


### PR DESCRIPTION
## Summary
- add helper functions for 14‑period RSI and Stochastic oscillators
- expose new oscillator metrics in token indicator service and prompt builder
- extend tests to assert RSI and Stochastic values

## Testing
- `npm --prefix backend run build`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_68bfd708dc08832cb5643b978333de8e