### PR TITLE
feat: filter outdated RSS news items

### DIFF
--- a/backend/test/news.test.ts
+++ b/backend/test/news.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from 'vitest';
-import { tagTokens } from '../src/services/news.js';
+import { describe, it, expect, vi } from 'vitest';
+import Parser from 'rss-parser';
+
+import { tagTokens, isRecent, fetchNews, FEEDS } from '../src/services/news.js';
 import { insertNews } from '../src/repos/news.js';
 import { db } from '../src/db/index.js';
 
@@ -7,6 +9,43 @@ describe('tagTokens', () => {
   it('detects token tags case-insensitively', () => {
     const res = tagTokens('Bitcoin and HeDeRa rally while eth falls');
     expect(res.sort()).toEqual(['BTC', 'HBAR', 'ETH'].sort());
+  });
+});
+
+describe('isRecent', () => {
+  it('filters out items older than 24 hours', () => {
+    const now = new Date('2023-01-02T00:00:00Z');
+    const recent = new Date(now.getTime() - 23 * 60 * 60 * 1000).toISOString();
+    const old = new Date(now.getTime() - 25 * 60 * 60 * 1000).toISOString();
+    expect(isRecent(recent, now)).toBe(true);
+    expect(isRecent(old, now)).toBe(false);
+  });
+
+  it('returns false for invalid or missing dates', () => {
+    expect(isRecent(undefined)).toBe(false);
+    expect(isRecent('not a date')).toBe(false);
+  });
+});
+
+describe('fetchNews', () => {
+  it('returns only recent items with token matches', async () => {
+    const now = new Date('2023-01-02T00:00:00Z');
+    const recent = new Date(now.getTime() - 23 * 60 * 60 * 1000).toISOString();
+    const old = new Date(now.getTime() - 25 * 60 * 60 * 1000).toISOString();
+    const parseURL = vi.spyOn(Parser.prototype, 'parseURL');
+    parseURL.mockResolvedValue({ items: [] });
+    parseURL.mockResolvedValueOnce({
+      items: [
+        { title: 'BTC surges', link: 'https://example.com/btc', pubDate: recent },
+        { title: 'ETH old', link: 'https://example.com/eth', pubDate: old },
+        { title: 'General news', link: 'https://example.com/general', pubDate: recent },
+      ],
+    });
+    const res = await fetchNews(now);
+    expect(parseURL).toHaveBeenCalledTimes(FEEDS.length);
+    expect(res).toHaveLength(1);
+    expect(res[0]).toMatchObject({ link: 'https://example.com/btc', tokens: ['BTC'] });
+    parseURL.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary
- restrict RSS feeds to CoinDesk, CoinTelegraph, Bitcoinist, CryptoPotato, and News.Bitcoin.com
- export feed list and update tests to cover all sources
- ensure feed parser skips articles older than 24 hours

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`
- `npm --prefix backend audit --audit-level=high`


------
https://chatgpt.com/codex/tasks/task_e_68c00787e514832c94e9246422ae18f9