### PR TITLE
feat: analyze token news before rebalancing

### DIFF
--- a/backend/src/jobs/review-portfolio.ts
+++ b/backend/src/jobs/review-portfolio.ts
@@ -38,6 +38,7 @@ import {
   fetchTokenIndicators,
   type TokenIndicators,
 } from '../services/indicators.js';
+import { getTokenNewsSummary } from '../services/news-analyst.js';
 import { isStablecoin } from '../util/tokens.js';
 import type { RebalancePrompt, PreviousResponse } from '../util/ai.js';
 
@@ -152,7 +153,7 @@ async function prepareAgents(
       continue;
     }
 
-    const prompt = await buildPrompt(row, balances, log, cache);
+    const prompt = await buildPrompt(row, balances, log, cache, key);
     if (!prompt) {
       runningAgents.delete(row.id);
       continue;
@@ -236,6 +237,7 @@ async function buildPrompt(
   balances: { token1Balance: number; token2Balance: number },
   log: FastifyBaseLogger,
   cache: PromptCache,
+  apiKey: string,
 ): Promise<RebalancePrompt | undefined> {
   try {
     const {
@@ -257,6 +259,28 @@ async function buildPrompt(
       price2,
     );
     const prevOrders = await buildPreviousOrders(row.id);
+    const token1 = row.tokens[0].token;
+    const token2 = row.tokens[1].token;
+    const [news1, news2] = await Promise.all([
+      getTokenNewsSummary(token1, row.model, apiKey),
+      getTokenNewsSummary(token2, row.model, apiKey),
+    ]);
+    const marketData = assembleMarketData(
+      row,
+      pairData,
+      ind1,
+      ind2,
+      ts1,
+      ts2,
+      cache.fearGreed,
+      openInterest,
+      fundingRate,
+      orderBook,
+    );
+    const news: Record<string, string> = {};
+    if (news1) news[token1] = news1;
+    if (news2) news[token2] = news2;
+    if (Object.keys(news).length) (marketData as any).newsReports = news;
     return {
       instructions: row.agent_instructions,
       policy: { floor },
@@ -265,18 +289,7 @@ async function buildPrompt(
         positions,
       },
       ...prevOrders,
-      marketData: assembleMarketData(
-        row,
-        pairData,
-        ind1,
-        ind2,
-        ts1,
-        ts2,
-        cache.fearGreed,
-        openInterest,
-        fundingRate,
-        orderBook,
-      ),
+      marketData,
     };
   } catch (err) {
     const msg = 'failed to fetch market data';

--- a/backend/src/repos/news.ts
+++ b/backend/src/repos/news.ts
@@ -18,3 +18,24 @@ export async function insertNews(items: NewsItem[]) {
     params as any[],
   );
 }
+
+export interface NewsRow {
+  title: string;
+  link: string;
+  pub_date: string | null;
+}
+
+export async function getNewsByToken(
+  token: string,
+  limit = 20,
+): Promise<NewsRow[]> {
+  const { rows } = await db.query(
+    `SELECT title, link, pub_date
+       FROM news
+      WHERE tokens @> ARRAY[$1]::text[]
+   ORDER BY pub_date DESC NULLS LAST
+      LIMIT $2`,
+    [token, limit],
+  );
+  return rows as NewsRow[];
+}

--- a/backend/src/services/news-analyst.ts
+++ b/backend/src/services/news-analyst.ts
@@ -1,0 +1,66 @@
+import { getNewsByToken } from '../repos/news.js';
+import { callAi } from '../util/ai.js';
+
+interface CacheEntry {
+  summary?: string;
+  expires: number;
+  promise?: Promise<string>;
+}
+
+const FIVE_MINUTES = 5 * 60 * 1000;
+const cache = new Map<string, CacheEntry>();
+
+function getCacheKey(keyType: string, token: string) {
+  return `${keyType}:${token}`;
+}
+
+function extractText(res: string): string {
+  try {
+    const json = JSON.parse(res);
+    const outputs = Array.isArray((json as any).output) ? (json as any).output : [];
+    const msg = outputs.find((o: any) => o.type === 'message' || o.id?.startsWith('msg_'));
+    const text = msg?.content?.[0]?.text;
+    return typeof text === 'string' ? text.trim() : '';
+  } catch {
+    return '';
+  }
+}
+
+export async function getTokenNewsSummary(
+  token: string,
+  model: string,
+  apiKey: string,
+  keyType = 'openai',
+): Promise<string> {
+  const now = Date.now();
+  const cacheKey = getCacheKey(keyType, token);
+  const existing = cache.get(cacheKey);
+  if (existing) {
+    if (existing.summary && existing.expires > now) return existing.summary;
+    if (existing.promise) return existing.promise;
+  }
+  const promise = (async () => {
+    const items = await getNewsByToken(token, 10);
+    if (!items.length) return '';
+    const headlines = items
+      .map((i) => `- ${i.title} (${i.link})`)
+      .join('\n');
+    const body = {
+      model,
+      input: `You are a crypto market news analyst. Using web search and the headlines below, write a short report for a crypto trader about ${token}. Include a bullishness score from 0-10 and highlight key events:\n${headlines}`,
+      tools: [{ type: 'web_search_preview' }],
+      text: { max_output_tokens: 255 },
+    };
+    const res = await callAi(body, apiKey);
+    return extractText(res);
+  })();
+  cache.set(cacheKey, { promise, expires: now + FIVE_MINUTES });
+  try {
+    const summary = await promise;
+    cache.set(cacheKey, { summary, expires: Date.now() + FIVE_MINUTES });
+    return summary;
+  } catch (err) {
+    cache.delete(cacheKey);
+    throw err;
+  }
+}

--- a/backend/src/util/ai.ts
+++ b/backend/src/util/ai.ts
@@ -73,6 +73,10 @@ export interface RebalancePrompt {
     openInterest?: number;
     fundingRate?: number;
     orderBook?: { bid: [number, number]; ask: [number, number] };
+    /**
+     * News analyst report for each token.
+     */
+    newsReports?: Record<string, string>;
   };
   previous_responses?: PreviousResponse[];
 }

--- a/backend/test/newsAnalyst.test.ts
+++ b/backend/test/newsAnalyst.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { db } from '../src/db/index.js';
+import { getTokenNewsSummary } from '../src/services/news-analyst.js';
+
+const responseJson = JSON.stringify({
+  object: 'response',
+  output: [
+    {
+      id: 'msg_1',
+      content: [{ type: 'output_text', text: 'summary text' }],
+    },
+  ],
+});
+
+describe('news analyst', () => {
+  it('caches summary by token', async () => {
+    await db.query(
+      "INSERT INTO news (title, link, pub_date, tokens) VALUES ('t', 'l', NOW(), ARRAY['BTC'])",
+    );
+    const fetchMock = vi.fn().mockResolvedValue({ text: async () => responseJson });
+    const orig = globalThis.fetch;
+    (globalThis as any).fetch = fetchMock;
+    const s1 = await getTokenNewsSummary('BTC', 'gpt', 'key');
+    const s2 = await getTokenNewsSummary('BTC', 'gpt', 'key');
+    expect(s1).toBe('summary text');
+    expect(s2).toBe('summary text');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    (globalThis as any).fetch = orig;
+  });
+
+  it('dedupes concurrent requests', async () => {
+    await db.query(
+      "INSERT INTO news (title, link, pub_date, tokens) VALUES ('t', 'l', NOW(), ARRAY['ETH'])",
+    );
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+      return { text: async () => responseJson };
+    });
+    const orig = globalThis.fetch;
+    (globalThis as any).fetch = fetchMock;
+    const [r1, r2] = await Promise.all([
+      getTokenNewsSummary('ETH', 'gpt', 'key'),
+      getTokenNewsSummary('ETH', 'gpt', 'key'),
+    ]);
+    expect(r1).toBe('summary text');
+    expect(r2).toBe('summary text');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    (globalThis as any).fetch = orig;
+  });
+});

--- a/backend/test/reviewPortfolio.test.ts
+++ b/backend/test/reviewPortfolio.test.ts
@@ -89,6 +89,11 @@ vi.mock('../src/services/indicators.js', () => ({
 vi.mock('../src/services/rebalance.js', () => ({
   createRebalanceLimitOrder: vi.fn().mockResolvedValue(undefined),
 }));
+vi.mock('../src/services/news-analyst.js', () => ({
+  getTokenNewsSummary: vi
+    .fn()
+    .mockImplementation((token: string) => Promise.resolve(`${token} news`)),
+}));
 
 let reviewAgentPortfolio: (log: FastifyBaseLogger, agentId: string) => Promise<void>;
 let reviewPortfolios: (
@@ -203,6 +208,7 @@ describe('reviewPortfolio', () => {
       fearGreedIndex: { value: 50, classification: 'Neutral' },
       indicators: { BTC: flatIndicators, ETH: flatIndicators },
       market_timeseries: { BTCUSDT: flatTimeseries, ETHUSDT: flatTimeseries },
+      newsReports: { BTC: 'BTC news', ETH: 'ETH news' },
     });
     expect(JSON.stringify(args[1].marketData)).not.toContain('minute_60');
     expect(fetchTokenIndicators).toHaveBeenCalledTimes(2);
@@ -467,6 +473,7 @@ describe('reviewPortfolio', () => {
       fearGreedIndex: { value: 50, classification: 'Neutral' },
       indicators: { ETH: flatIndicators },
       market_timeseries: { ETHUSDT: flatTimeseries },
+      newsReports: { USDT: 'USDT news', ETH: 'ETH news' },
     });
     expect(JSON.stringify(args[1].marketData)).not.toContain('minute_60');
     expect(fetchTokenIndicators).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- refine news analyst prompt with web search and bullishness scoring
- expose per-token news reports in market data
- adjust portfolio review tests for news report field

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test KEY_PASSWORD=secret GOOGLE_CLIENT_ID=foo npm --prefix backend test` *(fails: agentStartAsync.test.ts timeout)*
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0193fba30832cb7f5b08952d61194