### PR TITLE
fix: prevent wallet balance overflow

### DIFF
--- a/frontend/src/components/WalletBalances.tsx
+++ b/frontend/src/components/WalletBalances.tsx
@@ -20,10 +20,12 @@ export default function WalletBalances({ balances, hasBinanceKey }: Props) {
     <div>
       <h3 className="text-md font-bold mb-2">{t('binance_balances')}</h3>
       {balances.map((b) => (
-        <p key={b.token} className="flex items-center gap-1">
-          <TokenDisplay token={b.token} className="font-bold" />
-          <span>:</span>
-          <span>{b.isLoading ? t('loading') : b.balance}</span>
+        <p key={b.token} className="flex flex-wrap items-center gap-1">
+          <TokenDisplay token={b.token} className="font-bold shrink-0" />
+          <span className="shrink-0">:</span>
+          <span className="break-all">
+            {b.isLoading ? t('loading') : b.balance}
+          </span>
         </p>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- prevent wallet balances from overlapping by allowing wrapping and breaking long numbers

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c05eb652f4832ca1b1718f79f80e86