### PR TITLE
fix: serialize Review API input

### DIFF
--- a/backend/src/util/ai.ts
+++ b/backend/src/util/ai.ts
@@ -122,7 +122,13 @@ const rebalanceResponseSchema = {
     additionalProperties: false,
   };
 
-export async function callAi(body: unknown, apiKey: string): Promise<string> {
+export async function callAi(body: any, apiKey: string): Promise<string> {
+  if (body && typeof body === 'object' && 'input' in body) {
+    const val = (body as any).input;
+    if (val !== null && typeof val !== 'string' && !Array.isArray(val)) {
+      (body as any).input = compactJson(val);
+    }
+  }
   const res = await fetch('https://api.openai.com/v1/responses', {
     method: 'POST',
     headers: {

--- a/backend/test/callTraderAgent.test.ts
+++ b/backend/test/callTraderAgent.test.ts
@@ -29,7 +29,9 @@ describe('callTraderAgent structured output', () => {
     expect(opts.body).toBe(JSON.stringify(body));
     expect(body.instructions).toMatch(/- Decide whether to rebalance/i);
     expect(body.instructions).toMatch(/On error, return \{error:"message"\}/i);
-    expect(body.input.previous_responses).toEqual([
+    expect(typeof body.input).toBe('string');
+    const parsed = JSON.parse(body.input);
+    expect(parsed.previous_responses).toEqual([
       { shortReport: 'p1' },
       { rebalance: true, newAllocation: 50 },
     ]);


### PR DESCRIPTION
## Summary
- serialize non-string `input` before calling OpenAI's Responses API
- update tests for stringified input

## Testing
- `pg_isready`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68c10ba47f0c832c985168cd9d942840