### PR TITLE
Include performance report in main trader prompt

### DIFF
--- a/backend/src/workflows/portfolio-review.ts
+++ b/backend/src/workflows/portfolio-review.ts
@@ -224,6 +224,8 @@ export async function runMainTrader(
     runOrderBookAnalyst(log, model, apiKey, runId, agentId),
   ]);
 
+  await runPerformanceAnalyzer(log, model, apiKey, timeframe, agentId, runId);
+
   await runWithCache(
     log,
     `portfolio:${model}:${portfolioId}:${runId}`,
@@ -252,7 +254,10 @@ export async function runMainTrader(
           : await getCache<Analysis>(`orderbook:${model}:${pair}:${runId}`);
         reports.push({ token, news, tech, orderbook });
       }
-      const prompt = { portfolioId, reports };
+      const performance = await getCache<Analysis>(
+        `performance:${model}:${agentId}:${runId}`,
+      );
+      const prompt = { portfolioId, reports, performance };
       const res = await callTraderAgent(model, prompt, apiKey);
       await insertReviewRawLog({ agentId, prompt, response: res });
       const decision = extractResult(res);

--- a/backend/test/mainTraderWorkflowStep.test.ts
+++ b/backend/test/mainTraderWorkflowStep.test.ts
@@ -35,6 +35,18 @@ vi.mock('../src/services/order-book-analyst.js', () => ({
   getOrderBookAnalysis: getOrderBookAnalysisMock,
 }));
 
+const getPerformanceAnalysisMock = vi.fn(() =>
+  Promise.resolve({ analysis: { comment: 'perf', score: 4 }, prompt: { a: 1 }, response: 'r' }),
+);
+vi.mock('../src/services/performance-analyst.js', () => ({
+  getPerformanceAnalysis: getPerformanceAnalysisMock,
+}));
+
+const getRecentLimitOrdersMock = vi.fn(() => Promise.resolve([]));
+vi.mock('../src/repos/limit-orders.js', () => ({
+  getRecentLimitOrders: getRecentLimitOrdersMock,
+}));
+
 const callTraderAgentMock = vi.fn(() =>
   Promise.resolve(
     JSON.stringify({
@@ -71,6 +83,8 @@ describe('main trader step', () => {
     getTokenNewsSummaryMock.mockClear();
     getTechnicalOutlookMock.mockClear();
     getOrderBookAnalysisMock.mockClear();
+    getPerformanceAnalysisMock.mockClear();
+    getRecentLimitOrdersMock.mockClear();
     callTraderAgentMock.mockClear();
     insertReviewRawLogMock.mockClear();
   });
@@ -91,6 +105,9 @@ describe('main trader step', () => {
     expect(decision?.rebalance).toBe(true);
     expect(callTraderAgentMock).toHaveBeenCalled();
     expect(insertReviewRawLogMock).toHaveBeenCalled();
+    expect(getPerformanceAnalysisMock).toHaveBeenCalled();
+    const promptArg = callTraderAgentMock.mock.calls[0][1];
+    expect(promptArg.performance.comment).toBe('perf');
     expect(getTokenNewsSummaryMock).not.toHaveBeenCalledWith('USDT');
     expect(getTokenNewsSummaryMock).not.toHaveBeenCalledWith('USDC');
     expect(getTechnicalOutlookMock).not.toHaveBeenCalledWith('USDT');


### PR DESCRIPTION
## Summary
- run performance analyzer before main trader
- include performance reports in main trader prompt
- cover performance report in main trader tests

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68c116f30040832c86c575f83cc5b0a2