### PR TITLE
Fix analyst service response_format blocks and server route path

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -12,7 +12,7 @@ import { fetchOutputIp } from './util/output-ip.js';
 import { migrate } from './db/index.js';
 
 export default async function buildServer(
-  routesDir: string = path.join(process.cwd(), 'src/routes'),
+  routesDir: string = path.join(new URL('.', import.meta.url).pathname, 'routes'),
 ): Promise<FastifyInstance> {
   await migrate();
   const app = Fastify({ logger: true });

--- a/backend/src/services/news-analyst.ts
+++ b/backend/src/services/news-analyst.ts
@@ -16,20 +16,21 @@ export async function getTokenNewsSummary(
     input: prompt,
     instructions:
       `You are a crypto market news analyst. Using web search and the headlines in input, write a short report for a crypto trader about ${token}. Include a bullishness score from 0-10 and highlight key events.`,
-    tools: [{ type: 'web_search_preview' }],
-    max_output_tokens: 255,
-    text: {
-    response_format: {
-      type: 'json_schema',
-      json_schema: {
-        json_schema: {
-          name: 'analysis',
-          strict: true,
-          schema: analysisSchema,
+      tools: [{ type: 'web_search_preview' }],
+      max_output_tokens: 255,
+      text: {
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            json_schema: {
+              name: 'analysis',
+              strict: true,
+              schema: analysisSchema,
+            },
+          },
         },
       },
-    },
-  };
+    };
   const res = await callAi(body, apiKey);
   const analysis = extractJson<Analysis>(res);
   if (!analysis) throw new Error('missing news analysis');

--- a/backend/src/services/order-book-analyst.ts
+++ b/backend/src/services/order-book-analyst.ts
@@ -16,13 +16,14 @@ export async function getOrderBookAnalysis(
       `You are a crypto market order book analyst. Using the order book snapshot in input, write a short report for a crypto trader about ${pair}. Include a liquidity imbalance score from 0-10.`,
     max_output_tokens: 255,
     text: {
-    response_format: {
-      type: 'json_schema',
-      json_schema: {
+      response_format: {
+        type: 'json_schema',
         json_schema: {
-          name: 'analysis',
-          strict: true,
-          schema: analysisSchema,
+          json_schema: {
+            name: 'analysis',
+            strict: true,
+            schema: analysisSchema,
+          },
         },
       },
     },

--- a/backend/src/services/performance-analyst.ts
+++ b/backend/src/services/performance-analyst.ts
@@ -16,21 +16,22 @@ export async function getPerformanceAnalysis(
   const body = {
     model,
     input,
-    instructions:
-      'You are a performance analyst. Review the provided analyst reports and recent order outcomes to evaluate how well the trading team performed. Return a brief comment and a performance score from 0-10.',
-    max_output_tokens: 255,
-    text: {
-    response_format: {
-      type: 'json_schema',
-      json_schema: {
-        json_schema: {
-          name: 'analysis',
-          strict: true,
-          schema: analysisSchema,
+      instructions:
+        'You are a performance analyst. Review the provided analyst reports and recent order outcomes to evaluate how well the trading team performed. Return a brief comment and a performance score from 0-10.',
+      max_output_tokens: 255,
+      text: {
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            json_schema: {
+              name: 'analysis',
+              strict: true,
+              schema: analysisSchema,
+            },
+          },
         },
       },
-    },
-  };
+    };
   const res = await callAi(body, apiKey);
   const analysis = extractJson<Analysis>(res);
   if (!analysis) throw new Error('missing performance analysis');

--- a/backend/src/services/technical-analyst.ts
+++ b/backend/src/services/technical-analyst.ts
@@ -13,21 +13,22 @@ export async function getTechnicalOutlook(
   const body = {
     model,
     input: prompt,
-    instructions:
-      `You are a crypto technical analyst. Using indicators in input, write a short outlook for a crypto trader about ${token} on timeframe ${timeframe}. Include a bullishness score from 0-10 and key signals.`,
-    max_output_tokens: 255,
-    text: {
-    response_format: {
-      type: 'json_schema',
-      json_schema: {
-        json_schema: {
-          name: 'analysis',
-          strict: true,
-          schema: analysisSchema,
+      instructions:
+        `You are a crypto technical analyst. Using indicators in input, write a short outlook for a crypto trader about ${token} on timeframe ${timeframe}. Include a bullishness score from 0-10 and key signals.`,
+      max_output_tokens: 255,
+      text: {
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            json_schema: {
+              name: 'analysis',
+              strict: true,
+              schema: analysisSchema,
+            },
+          },
         },
       },
-    },
-  };
+    };
   const res = await callAi(body, apiKey);
   const analysis = extractJson<Analysis>(res);
   if (!analysis) throw new Error('missing technical analysis');


### PR DESCRIPTION
## Summary
- properly close `text.response_format` objects in order-book, news, performance, and technical analyst services
- locate backend routes relative to server source file instead of process cwd to support testing

## Testing
- `npm --prefix backend run build`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test KEY_PASSWORD=dummy GOOGLE_CLIENT_ID=dummy npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_68c13743a8f8832cbca534599332d773