### PR TITLE
refactor: update responses API format

### DIFF
--- a/backend/src/services/news-analyst.ts
+++ b/backend/src/services/news-analyst.ts
@@ -16,21 +16,17 @@ export async function getTokenNewsSummary(
     input: prompt,
     instructions:
       `You are a crypto market news analyst. Using web search and the headlines in input, write a short report for a crypto trader about ${token}. Include a bullishness score from 0-10 and highlight key events.`,
-      tools: [{ type: 'web_search_preview' }],
-      max_output_tokens: 255,
-      text: {
-        response_format: {
-          type: 'json_schema',
-          json_schema: {
-            json_schema: {
-              name: 'analysis',
-              strict: true,
-              schema: analysisSchema,
-            },
-          },
-        },
+    tools: [{ type: 'web_search_preview' }],
+    max_output_tokens: 255,
+    text: {
+      format: 'json_schema',
+      json_schema: {
+        name: 'analysis',
+        strict: true,
+        schema: analysisSchema,
       },
-    };
+    },
+  };
   const res = await callAi(body, apiKey);
   const analysis = extractJson<Analysis>(res);
   if (!analysis) throw new Error('missing news analysis');

--- a/backend/src/services/order-book-analyst.ts
+++ b/backend/src/services/order-book-analyst.ts
@@ -16,15 +16,11 @@ export async function getOrderBookAnalysis(
       `You are a crypto market order book analyst. Using the order book snapshot in input, write a short report for a crypto trader about ${pair}. Include a liquidity imbalance score from 0-10.`,
     max_output_tokens: 255,
     text: {
-      response_format: {
-        type: 'json_schema',
-        json_schema: {
-          json_schema: {
-            name: 'analysis',
-            strict: true,
-            schema: analysisSchema,
-          },
-        },
+      format: 'json_schema',
+      json_schema: {
+        name: 'analysis',
+        strict: true,
+        schema: analysisSchema,
       },
     },
   };

--- a/backend/src/services/performance-analyst.ts
+++ b/backend/src/services/performance-analyst.ts
@@ -16,22 +16,18 @@ export async function getPerformanceAnalysis(
   const body = {
     model,
     input,
-      instructions:
+    instructions:
         'You are a performance analyst. Review the provided analyst reports and recent order outcomes to evaluate how well the trading team performed. Return a brief comment and a performance score from 0-10.',
-      max_output_tokens: 255,
-      text: {
-        response_format: {
-          type: 'json_schema',
-          json_schema: {
-            json_schema: {
-              name: 'analysis',
-              strict: true,
-              schema: analysisSchema,
-            },
-          },
-        },
+    max_output_tokens: 255,
+    text: {
+      format: 'json_schema',
+      json_schema: {
+        name: 'analysis',
+        strict: true,
+        schema: analysisSchema,
       },
-    };
+    },
+  };
   const res = await callAi(body, apiKey);
   const analysis = extractJson<Analysis>(res);
   if (!analysis) throw new Error('missing performance analysis');

--- a/backend/src/services/technical-analyst.ts
+++ b/backend/src/services/technical-analyst.ts
@@ -13,22 +13,18 @@ export async function getTechnicalOutlook(
   const body = {
     model,
     input: prompt,
-      instructions:
+    instructions:
         `You are a crypto technical analyst. Using indicators in input, write a short outlook for a crypto trader about ${token} on timeframe ${timeframe}. Include a bullishness score from 0-10 and key signals.`,
-      max_output_tokens: 255,
-      text: {
-        response_format: {
-          type: 'json_schema',
-          json_schema: {
-            json_schema: {
-              name: 'analysis',
-              strict: true,
-              schema: analysisSchema,
-            },
-          },
-        },
+    max_output_tokens: 255,
+    text: {
+      format: 'json_schema',
+      json_schema: {
+        name: 'analysis',
+        strict: true,
+        schema: analysisSchema,
       },
-    };
+    },
+  };
   const res = await callAi(body, apiKey);
   const analysis = extractJson<Analysis>(res);
   if (!analysis) throw new Error('missing technical analysis');

--- a/backend/src/util/ai.ts
+++ b/backend/src/util/ai.ts
@@ -185,14 +185,12 @@ export async function callTraderAgent(
     input,
     instructions: developerInstructions,
     tools: [{ type: 'web_search_preview' }],
-    response_format: {
-      type: 'json_schema',
+    text: {
+      format: 'json_schema',
       json_schema: {
-        json_schema: {
-          name: 'rebalance_response',
-          strict: true,
-          schema: rebalanceResponseSchema,
-        },
+        name: 'rebalance_response',
+        strict: true,
+        schema: rebalanceResponseSchema,
       },
     },
   };

--- a/backend/test/callTraderAgent.test.ts
+++ b/backend/test/callTraderAgent.test.ts
@@ -37,8 +37,8 @@ describe('callTraderAgent structured output', () => {
       { shortReport: 'p1' },
       { rebalance: true, newAllocation: 50 },
     ]);
-    expect(body.response_format.type).toBe('json_schema');
-    const anyOf = body.response_format.json_schema.json_schema.schema.properties.result.anyOf;
+    expect(body.text.format).toBe('json_schema');
+    const anyOf = body.text.json_schema.schema.properties.result.anyOf;
     expect(Array.isArray(anyOf)).toBe(true);
     expect(anyOf).toHaveLength(3);
     (globalThis as any).fetch = originalFetch;


### PR DESCRIPTION
## Summary
- adapt AI service calls to use `text.format` per Responses API update
- adjust trader agent test expectations for new `text` JSON schema structure

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test` *(fails: connect ECONNREFUSED 127.0.0.1:5432)*
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68c13b8c4dc8832ca40892e4809be1bb