### PR TITLE
refactor: update responses API format

### DIFF
--- a/backend/src/services/news-analyst.ts
+++ b/backend/src/services/news-analyst.ts
@@ -1,5 +1,5 @@
 import { getNewsByToken } from '../repos/news.js';
-import { callAi, extractJson } from '../util/ai.js';
+import { callAi, extractJson, compactJson } from '../util/ai.js';
 import { analysisSchema, type AnalysisLog, type Analysis } from './types.js';
 
 export async function getTokenNewsSummary(
@@ -13,24 +13,20 @@ export async function getTokenNewsSummary(
   const prompt = { token, headlines };
   const body = {
     model,
-    input: prompt,
+    input: compactJson(prompt),
     instructions:
       `You are a crypto market news analyst. Using web search and the headlines in input, write a short report for a crypto trader about ${token}. Include a bullishness score from 0-10 and highlight key events.`,
-      tools: [{ type: 'web_search_preview' }],
-      max_output_tokens: 255,
-      text: {
-        response_format: {
-          type: 'json_schema',
-          json_schema: {
-            json_schema: {
-              name: 'analysis',
-              strict: true,
-              schema: analysisSchema,
-            },
-          },
-        },
+    tools: [{ type: 'web_search_preview' }],
+    max_output_tokens: 255,
+    text: {
+      format: {
+        type: 'json_schema',
+        name: 'analysis',
+        strict: true,
+        schema: analysisSchema,
       },
-    };
+    },
+  };
   const res = await callAi(body, apiKey);
   const analysis = extractJson<Analysis>(res);
   if (!analysis) throw new Error('missing news analysis');

--- a/backend/src/services/order-book-analyst.ts
+++ b/backend/src/services/order-book-analyst.ts
@@ -1,5 +1,5 @@
 import { fetchOrderBook } from './derivatives.js';
-import { callAi, extractJson } from '../util/ai.js';
+import { callAi, extractJson, compactJson } from '../util/ai.js';
 import { analysisSchema, type AnalysisLog, type Analysis } from './types.js';
 
 export async function getOrderBookAnalysis(
@@ -11,20 +11,16 @@ export async function getOrderBookAnalysis(
   const prompt = { pair, snapshot };
   const body = {
     model,
-    input: prompt,
+    input: compactJson(prompt),
     instructions:
       `You are a crypto market order book analyst. Using the order book snapshot in input, write a short report for a crypto trader about ${pair}. Include a liquidity imbalance score from 0-10.`,
     max_output_tokens: 255,
     text: {
-      response_format: {
+      format: {
         type: 'json_schema',
-        json_schema: {
-          json_schema: {
-            name: 'analysis',
-            strict: true,
-            schema: analysisSchema,
-          },
-        },
+        name: 'analysis',
+        strict: true,
+        schema: analysisSchema,
       },
     },
   };

--- a/backend/src/services/performance-analyst.ts
+++ b/backend/src/services/performance-analyst.ts
@@ -1,4 +1,4 @@
-import { callAi, extractJson } from '../util/ai.js';
+import { callAi, extractJson, compactJson } from '../util/ai.js';
 import { analysisSchema, type AnalysisLog, type Analysis } from './types.js';
 
 export async function getPerformanceAnalysis(
@@ -15,23 +15,19 @@ export async function getPerformanceAnalysis(
   if (reports.length === 0 && orders.length === 0) return { analysis: null };
   const body = {
     model,
-    input,
-      instructions:
+    input: compactJson(input),
+    instructions:
         'You are a performance analyst. Review the provided analyst reports and recent order outcomes to evaluate how well the trading team performed. Return a brief comment and a performance score from 0-10.',
-      max_output_tokens: 255,
-      text: {
-        response_format: {
-          type: 'json_schema',
-          json_schema: {
-            json_schema: {
-              name: 'analysis',
-              strict: true,
-              schema: analysisSchema,
-            },
-          },
-        },
+    max_output_tokens: 255,
+    text: {
+      format: {
+        type: 'json_schema',
+        name: 'analysis',
+        strict: true,
+        schema: analysisSchema,
       },
-    };
+    },
+  };
   const res = await callAi(body, apiKey);
   const analysis = extractJson<Analysis>(res);
   if (!analysis) throw new Error('missing performance analysis');

--- a/backend/src/services/technical-analyst.ts
+++ b/backend/src/services/technical-analyst.ts
@@ -1,5 +1,5 @@
 import { fetchTokenIndicators } from './indicators.js';
-import { callAi, extractJson } from '../util/ai.js';
+import { callAi, extractJson, compactJson } from '../util/ai.js';
 import { analysisSchema, type AnalysisLog, type Analysis } from './types.js';
 
 export async function getTechnicalOutlook(
@@ -12,23 +12,19 @@ export async function getTechnicalOutlook(
   const prompt = { token, timeframe, indicators };
   const body = {
     model,
-    input: prompt,
-      instructions:
+    input: compactJson(prompt),
+    instructions:
         `You are a crypto technical analyst. Using indicators in input, write a short outlook for a crypto trader about ${token} on timeframe ${timeframe}. Include a bullishness score from 0-10 and key signals.`,
-      max_output_tokens: 255,
-      text: {
-        response_format: {
-          type: 'json_schema',
-          json_schema: {
-            json_schema: {
-              name: 'analysis',
-              strict: true,
-              schema: analysisSchema,
-            },
-          },
-        },
+    max_output_tokens: 255,
+    text: {
+      format: {
+        type: 'json_schema',
+        name: 'analysis',
+        strict: true,
+        schema: analysisSchema,
       },
-    };
+    },
+  };
   const res = await callAi(body, apiKey);
   const analysis = extractJson<Analysis>(res);
   if (!analysis) throw new Error('missing technical analysis');

--- a/backend/src/util/ai.ts
+++ b/backend/src/util/ai.ts
@@ -132,12 +132,6 @@ const rebalanceResponseSchema = {
   };
 
 export async function callAi(body: any, apiKey: string): Promise<string> {
-  if (body && typeof body === 'object' && 'input' in body) {
-    const val = (body as any).input;
-    if (val !== null && typeof val !== 'string' && !Array.isArray(val)) {
-      (body as any).input = compactJson(val);
-    }
-  }
   const res = await fetch('https://api.openai.com/v1/responses', {
     method: 'POST',
     headers: {
@@ -182,17 +176,15 @@ export async function callTraderAgent(
 ): Promise<string> {
   const body = {
     model,
-    input,
+    input: compactJson(input),
     instructions: developerInstructions,
     tools: [{ type: 'web_search_preview' }],
-    response_format: {
-      type: 'json_schema',
-      json_schema: {
-        json_schema: {
-          name: 'rebalance_response',
-          strict: true,
-          schema: rebalanceResponseSchema,
-        },
+    text: {
+      format: {
+        type: 'json_schema',
+        name: 'rebalance_response',
+        strict: true,
+        schema: rebalanceResponseSchema,
       },
     },
   };

--- a/backend/test/callTraderAgent.test.ts
+++ b/backend/test/callTraderAgent.test.ts
@@ -37,8 +37,8 @@ describe('callTraderAgent structured output', () => {
       { shortReport: 'p1' },
       { rebalance: true, newAllocation: 50 },
     ]);
-    expect(body.response_format.type).toBe('json_schema');
-    const anyOf = body.response_format.json_schema.json_schema.schema.properties.result.anyOf;
+    expect(body.text.format.type).toBe('json_schema');
+    const anyOf = body.text.format.schema.properties.result.anyOf;
     expect(Array.isArray(anyOf)).toBe(true);
     expect(anyOf).toHaveLength(3);
     (globalThis as any).fetch = originalFetch;

--- a/backend/test/orderBookAnalyst.test.ts
+++ b/backend/test/orderBookAnalyst.test.ts
@@ -26,6 +26,7 @@ vi.mock('../src/util/ai.js', () => ({
   callAi: callAiMock,
   extractJson: (res: string) =>
     JSON.parse(JSON.parse(res).output[0].content[0].text),
+  compactJson: (v: unknown) => JSON.stringify(v),
 }));
 
 describe('order book analyst service', () => {


### PR DESCRIPTION
## Summary
- standardize all AI request bodies to use `text.format` with a JSON schema definition
- serialize prompts with `compactJson` and simplify AI utility logic
- update tests and mocks for the new request structure

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68c13b8c4dc8832ca40892e4809be1bb