### PR TITLE
fix: gate web search behind flag

### DIFF
--- a/backend/src/services/news-analyst.ts
+++ b/backend/src/services/news-analyst.ts
@@ -17,7 +17,14 @@ export async function getTokenNewsSummary(
     `You are a crypto market news analyst. Using web search and the headlines in input, write a short report for a crypto trader about ${token}. Include a bullishness score from 0-10 and highlight key events.`;
   const fallback: Analysis = { comment: 'Analysis unavailable', score: 0 };
   try {
-    const res = await callAi(model, instructions, analysisSchema, prompt, apiKey);
+    const res = await callAi(
+      model,
+      instructions,
+      analysisSchema,
+      prompt,
+      apiKey,
+      true,
+    );
     const analysis = extractJson<Analysis>(res);
     if (!analysis) {
       log.error({ token, response: res }, 'news analyst returned invalid response');

--- a/backend/src/util/ai.ts
+++ b/backend/src/util/ai.ts
@@ -137,12 +137,12 @@ export async function callAi(
   schema: unknown,
   input: unknown,
   apiKey: string,
+  webSearch = false,
 ): Promise<string> {
-  const body = {
+  const body: Record<string, unknown> = {
     model,
     input: compactJson(input),
     instructions: developerInstructions,
-    tools: [{ type: 'web_search_preview' }],
     text: {
       format: {
         type: 'json_schema',
@@ -152,6 +152,7 @@ export async function callAi(
       },
     },
   };
+  if (webSearch) body.tools = [{ type: 'web_search_preview' }];
   const res = await fetch('https://api.openai.com/v1/responses', {
     method: 'POST',
     headers: {

--- a/backend/src/workflows/portfolio-review.ts
+++ b/backend/src/workflows/portfolio-review.ts
@@ -268,7 +268,14 @@ export async function runMainTrader(
         `performance:${model}:${agentId}:${runId}`,
       );
       const prompt = { portfolioId, reports, performance };
-      const res = await callAi(model, developerInstructions, rebalanceResponseSchema, prompt, apiKey);
+      const res = await callAi(
+        model,
+        developerInstructions,
+        rebalanceResponseSchema,
+        prompt,
+        apiKey,
+        true,
+      );
       await insertReviewRawLog({ agentId, prompt, response: res });
       const decision = extractResult(res);
       if (!decision) {


### PR DESCRIPTION
## Summary
- replace tools array with `webSearch` boolean in `callAi`
- enable web search for news analyst and main trader
- adjust tests for optional web search

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test --silent` *(fails: password authentication failed for user "postgres")*
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68c18d19a488832cbe6d8a9298ee0a24