### PR TITLE
Refactor logging for request lifecycle

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -10,12 +10,32 @@ import { RATE_LIMITS } from './rate-limit.js';
 import { errorResponse } from './util/errorMessages.js';
 import { fetchOutputIp } from './util/output-ip.js';
 import { migrate } from './db/index.js';
+import { tryGetUserId } from './util/auth.js';
+
+function sanitize(obj: unknown): unknown {
+  if (!obj || typeof obj !== 'object') return obj;
+  const forbidden = ['password', 'token', 'key', 'secret'];
+  const result: any = Array.isArray(obj) ? [] : {};
+  for (const [k, v] of Object.entries(obj as any)) {
+    if (forbidden.includes(k.toLowerCase())) continue;
+    result[k] = sanitize(v);
+  }
+  return result;
+}
 
 export default async function buildServer(
   routesDir: string = path.join(new URL('.', import.meta.url).pathname, 'routes'),
 ): Promise<FastifyInstance> {
   await migrate();
-  const app = Fastify({ logger: true });
+  const app = Fastify({
+    logger: {
+      formatters: {
+        level: (label) => ({ level: label.toUpperCase() }),
+      },
+    },
+    disableRequestLogging: true,
+  });
+
 
   await app.register(cookie);
   await app.register(csrf, {
@@ -58,6 +78,32 @@ export default async function buildServer(
       app.register(route.default, { prefix: '/api' });
     }
   }
+
+  app.addHook('preHandler', (req, _reply, done) => {
+    const userId = tryGetUserId(req);
+    const workflowId =
+      (req.params as any)?.workflowId ??
+      (req.body as any)?.workflowId ??
+      (req.query as any)?.workflowId;
+    (req as any).logContext = { userId, workflowId };
+    const params = sanitize({ params: req.params, query: req.query, body: req.body });
+    req.log.info({ userId, workflowId, params }, 'request start');
+    done();
+  });
+
+  app.addHook('onResponse', (req, reply, done) => {
+    const ctx = (req as any).logContext ?? {};
+    if (reply.statusCode < 400) {
+      req.log.info({ ...ctx, statusCode: reply.statusCode }, 'request success');
+    }
+    done();
+  });
+
+  app.setErrorHandler((err, req, reply) => {
+    const ctx = (req as any).logContext ?? {};
+    req.log.error({ err, ...ctx }, 'request error');
+    reply.code((err as any).statusCode || 500).send(err);
+  });
 
   app.log.info('Server initialized');
   return app;

--- a/backend/src/util/auth.ts
+++ b/backend/src/util/auth.ts
@@ -22,6 +22,17 @@ export function requireUserId(
   }
 }
 
+export function tryGetUserId(req: FastifyRequest): string | null {
+  const token = req.cookies?.session as string | undefined;
+  if (!token) return null;
+  try {
+    const payload = jwt.verify(token, env.KEY_PASSWORD) as { id: string };
+    return payload.id;
+  } catch {
+    return null;
+  }
+}
+
 export async function requireAdmin(
   req: FastifyRequest,
   reply: FastifyReply,


### PR DESCRIPTION
## Summary
- format logs with string levels (INFO/DEBUG/ERROR) and disable framework request logs
- add global request hooks capturing user/workflow IDs, sanitized params, and success/error
- expose helper to read user ID without enforcing auth

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4c4fadb98832ca48f57d07e5143b7