### PR TITLE
feat: improve portfolio review logging

### DIFF
--- a/backend/src/agents/news-analyst.ts
+++ b/backend/src/agents/news-analyst.ts
@@ -19,7 +19,11 @@ export function getTokenNewsSummaryCached(
 ): Promise<AnalysisLog> {
   const now = Date.now();
   const cached = cache.get(token);
-  if (cached && cached.expires > now) return cached.promise;
+  if (cached && cached.expires > now) {
+    log.info({ token }, 'news summary cache hit');
+    return cached.promise;
+  }
+  log.info({ token }, 'news summary cache miss');
   const promise = getTokenNewsSummary(token, model, apiKey, log);
   cache.set(token, { promise, expires: now + CACHE_MS });
   promise.catch(() => cache.delete(token));

--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -341,7 +341,7 @@ export default async function agentRoutes(app: FastifyInstance) {
           positions,
           newAllocation: result.newAllocation,
           reviewResultId: logId,
-          log,
+          log: log.child({ execLogId: logId }),
           price: finalPrice,
           quantity: finalQuantity,
           manuallyEdited: body?.manuallyEdited,


### PR DESCRIPTION
## Summary
- add exec-level step logging for portfolio reviews
- log cache hit/miss for analyst helpers
- ensure limit order creation logs include run metadata

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4c84ea2f8832c95bbbb38989b60dd