### PR TITLE
Improve portfolio review token handling

### DIFF
--- a/frontend/src/components/forms/PortfolioReviewForm.tsx
+++ b/frontend/src/components/forms/PortfolioReviewForm.tsx
@@ -19,12 +19,14 @@ interface Props {
   onTokensChange?: (tokens: string[]) => void;
   balances: BalanceInfo[];
   accountBalances: BinanceAccount['balances'];
+  accountLoading: boolean;
 }
 
 export default function PortfolioReviewForm({
   onTokensChange,
   balances,
   accountBalances,
+  accountLoading,
 }: Props) {
   const { user } = useUser();
   const t = useTranslation();
@@ -66,6 +68,7 @@ export default function PortfolioReviewForm({
             autoPopulateTopTokens
             useEarn={useEarn}
             onUseEarnChange={setUseEarn}
+            accountLoading={accountLoading}
           />
           {!user && (
             <p className="text-sm text-gray-600 mb-2">{t('log_in_to_continue')}</p>

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -91,10 +91,7 @@ export const portfolioReviewSchema = z
 export type PortfolioReviewFormValues = z.infer<typeof portfolioReviewSchema>;
 
 export const portfolioReviewDefaults: PortfolioReviewFormValues = {
-  tokens: [
-    { token: 'USDT', minAllocation: 0 },
-    { token: 'BTC', minAllocation: 0 },
-  ],
+  tokens: [{ token: 'USDT', minAllocation: 0 }],
   risk: 'low',
   reviewInterval: '30m',
 };

--- a/frontend/src/lib/usePrerequisites.ts
+++ b/frontend/src/lib/usePrerequisites.ts
@@ -140,6 +140,7 @@ export function usePrerequisites(
     models: includeAiKey ? modelsQuery.data ?? [] : [],
     balances,
     accountBalances,
+    isAccountLoading: accountQuery.isLoading,
   } as const;
 }
 

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -258,12 +258,17 @@ function AgentBlock({
 export default function Dashboard() {
   const { user } = useUser();
   const [page, setPage] = useState(1);
-  const [tokens, setTokens] = useState(['USDT', 'BTC']);
+  const [tokens, setTokens] = useState(['USDT']);
   const [onlyActive, setOnlyActive] = useState(false);
   const queryClient = useQueryClient();
   const toast = useToast();
   const t = useTranslation();
-  const { hasBinanceKey, balances, accountBalances } = usePrerequisites(tokens, {
+  const {
+    hasBinanceKey,
+    balances,
+    accountBalances,
+    isAccountLoading,
+  } = usePrerequisites(tokens, {
     includeAiKey: false,
   });
 
@@ -367,6 +372,7 @@ export default function Dashboard() {
               balances={balances}
               accountBalances={accountBalances}
               onTokensChange={handleTokensChange}
+              accountLoading={isAccountLoading}
             />
           )}
         </div>

--- a/frontend/src/routes/PortfolioWorkflowDraft.tsx
+++ b/frontend/src/routes/PortfolioWorkflowDraft.tsx
@@ -63,8 +63,14 @@ export default function PortfolioWorkflowDraft({ draft }: Props) {
         }
       : undefined,
   });
-  const { hasOpenAIKey, hasBinanceKey, models, balances, accountBalances } =
-    usePrerequisites(tokenSymbols);
+  const {
+    hasOpenAIKey,
+    hasBinanceKey,
+    models,
+    balances,
+    accountBalances,
+    isAccountLoading,
+  } = usePrerequisites(tokenSymbols);
 
   const [name, setName] = useState(data?.name || '');
   const [agentInstructions, setAgentInstructions] = useState(
@@ -114,6 +120,7 @@ export default function PortfolioWorkflowDraft({ draft }: Props) {
             onTokensChange={setTokenSymbols}
             balances={balances}
             accountBalances={accountBalances}
+            accountLoading={isAccountLoading}
             useEarn={useEarn}
             onUseEarnChange={setUseEarn}
           />


### PR DESCRIPTION
## Summary
- align review form labels for total, earn, risk and interval
- preserve stablecoin selection when navigating away and back
- delay default USDT/BTC pair until Binance balances are loaded
- forward Binance account loading state to workflow fields

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4ddc1fcec832c9b60bdc872fb5e46