### PR TITLE
Align workflow grid layout and toggle

### DIFF
--- a/frontend/src/components/forms/PortfolioWorkflowFields.tsx
+++ b/frontend/src/components/forms/PortfolioWorkflowFields.tsx
@@ -232,10 +232,10 @@ export default function PortfolioWorkflowFields({
           </button>
         )}
       </div>
-      <div className="grid grid-cols-[7rem_1fr] gap-x-4 gap-y-2 text-sm font-medium mt-2">
+      <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm font-medium mt-2">
         <span className="text-left">Total $:</span>
-        <span>{totalUsd.toFixed(2)}</span>
         <span className="text-left">{t('use_binance_earn')}</span>
+        <span>{totalUsd.toFixed(2)}</span>
         <Toggle
           label=""
           checked={useEarn}
@@ -244,6 +244,9 @@ export default function PortfolioWorkflowFields({
         />
         <label htmlFor="risk" className="text-left">
           {t('risk_tolerance')}
+        </label>
+        <label htmlFor="reviewInterval" className="text-left">
+          {t('review_interval')}
         </label>
         <Controller
           name="risk"
@@ -257,9 +260,6 @@ export default function PortfolioWorkflowFields({
             />
           )}
         />
-        <label htmlFor="reviewInterval" className="text-left">
-          {t('review_interval')}
-        </label>
         <Controller
           name="reviewInterval"
           control={control}

--- a/frontend/src/components/ui/Toggle.tsx
+++ b/frontend/src/components/ui/Toggle.tsx
@@ -20,7 +20,7 @@ export default function Toggle({
   const marginClass = labelPosition === 'top' ? 'mt-2' : 'ml-2';
   const sizeClass =
     size === 'sm'
-      ? "w-8 h-4 after:h-3 after:w-3 after:top-[1px] after:left-[1px] peer-checked:after:translate-x-4"
+      ? "w-8 h-4 after:h-3 after:w-3 after:top-[2px] after:left-[1px] peer-checked:after:translate-x-4"
       : "w-10 h-5 after:h-4 after:w-4 after:top-[2px] after:left-[2px] peer-checked:after:translate-x-5";
 
   return (


### PR DESCRIPTION
## Summary
- Reorder Portfolio Workflow summary grid so totals and risk stack in left column, Binance Earn and interval options stack on right
- Center small toggle knob vertically for consistent appearance

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c553fc4d24832c8e0ed4fed5a85792