### PR TITLE
fix: send cash token separately in agent requests

### DIFF
--- a/frontend/src/components/AgentStartButton.tsx
+++ b/frontend/src/components/AgentStartButton.tsx
@@ -61,11 +61,12 @@ export default function AgentStartButton({
         toast.show(t('agent_started_success'), 'success');
         navigate('/');
       } else {
+        const [cashToken, ...positions] = agentData.tokens;
         const res = await api.post('/portfolio-workflows', {
-          userId: user.id,
           model,
           name: agentData.name,
-          tokens: agentData.tokens.map((t) => ({
+          cash: cashToken.token.toUpperCase(),
+          tokens: positions.map((t) => ({
             token: t.token.toUpperCase(),
             minAllocation: t.minAllocation,
           })),

--- a/frontend/src/components/AgentUpdateModal.tsx
+++ b/frontend/src/components/AgentUpdateModal.tsx
@@ -40,7 +40,7 @@ export default function AgentUpdateModal({
     agentInstructions: agent.agentInstructions,
   });
 
-  const tokens = data.tokens.map((t) => t.token);
+  const tokens = [agent.cashToken, ...data.tokens.map((t) => t.token)];
   const { hasOpenAIKey, hasBinanceKey, models, balances } =
     usePrerequisites(tokens);
   const [model, setModel] = useState(agent.model || '');
@@ -70,10 +70,10 @@ export default function AgentUpdateModal({
   const updateMut = useMutation({
     mutationFn: async () => {
       await api.put(`/portfolio-workflows/${agent.id}`, {
-        userId: agent.userId,
         model,
         status: agent.status,
         name: agent.name,
+        cash: agent.cashToken.toUpperCase(),
         tokens: data.tokens.map((t) => ({
           token: t.token.toUpperCase(),
           minAllocation: t.minAllocation,

--- a/frontend/src/lib/useAgentData.ts
+++ b/frontend/src/lib/useAgentData.ts
@@ -10,6 +10,7 @@ export interface Agent {
   status: 'active' | 'inactive' | 'draft';
   createdAt: number;
   name: string;
+  cashToken: string;
   tokens: { token: string; minAllocation: number }[];
   risk: PortfolioReviewFormValues['risk'];
   reviewInterval: PortfolioReviewFormValues['reviewInterval'];

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -288,7 +288,6 @@ export default function Dashboard() {
         params: {
           page,
           pageSize: 10,
-          userId: user!.id,
           status: onlyActive ? 'active' : undefined,
         },
       });

--- a/frontend/src/routes/PortfolioWorkflowDraft.tsx
+++ b/frontend/src/routes/PortfolioWorkflowDraft.tsx
@@ -189,38 +189,26 @@ export default function PortfolioWorkflowDraft({ draft }: Props) {
               setIsSavingDraft(true);
               try {
                 const values = methods.getValues();
+                const [cashToken, ...positions] = values.tokens;
+                const payload = {
+                  model,
+                  name,
+                  cash: cashToken.token.toUpperCase(),
+                  tokens: positions.map((t) => ({
+                    token: t.token.toUpperCase(),
+                    minAllocation: t.minAllocation,
+                  })),
+                  risk: values.risk,
+                  reviewInterval: values.reviewInterval,
+                  agentInstructions,
+                  manualRebalance,
+                  useEarn,
+                  status: 'draft',
+                };
                 if (draft) {
-                  await api.put(`/portfolio-workflows/${draft.id}`, {
-                    userId: draft.userId,
-                    model,
-                    name,
-                    tokens: values.tokens.map((t) => ({
-                      token: t.token.toUpperCase(),
-                      minAllocation: t.minAllocation,
-                    })),
-                    risk: values.risk,
-                    reviewInterval: values.reviewInterval,
-                    agentInstructions,
-                    manualRebalance,
-                    useEarn,
-                    status: 'draft',
-                  });
+                  await api.put(`/portfolio-workflows/${draft.id}`, payload);
                 } else {
-                  await api.post('/portfolio-workflows', {
-                    userId: user.id,
-                    model,
-                    name,
-                    tokens: values.tokens.map((t) => ({
-                      token: t.token.toUpperCase(),
-                      minAllocation: t.minAllocation,
-                    })),
-                    risk: values.risk,
-                    reviewInterval: values.reviewInterval,
-                    agentInstructions,
-                    manualRebalance,
-                    useEarn,
-                    status: 'draft',
-                  });
+                  await api.post('/portfolio-workflows', payload);
                 }
                 setIsSavingDraft(false);
                 toast.show(t('draft_saved_successfully'), 'success');

--- a/frontend/src/routes/PortfolioWorkflowPreview.tsx
+++ b/frontend/src/routes/PortfolioWorkflowPreview.tsx
@@ -328,36 +328,25 @@ export default function PortfolioWorkflowPreview({ draft }: Props) {
               if (!user) return;
               setIsSavingDraft(true);
               try {
+                const [cashToken, ...positions] = workflowData.tokens;
+                const payload = {
+                  model,
+                  name: workflowData.name,
+                  cash: cashToken.token.toUpperCase(),
+                  tokens: positions.map((t) => ({
+                    token: t.token.toUpperCase(),
+                    minAllocation: t.minAllocation,
+                  })),
+                  risk: workflowData.risk,
+                  reviewInterval: workflowData.reviewInterval,
+                  agentInstructions: workflowData.agentInstructions,
+                  manualRebalance: workflowData.manualRebalance,
+                  status: 'draft',
+                };
                 if (isDraft) {
-                  await api.put(`/portfolio-workflows/${draft!.id}`, {
-                    userId: draft!.userId,
-                    model,
-                    name: workflowData.name,
-                    tokens: workflowData.tokens.map((t) => ({
-                      token: t.token.toUpperCase(),
-                      minAllocation: t.minAllocation,
-                    })),
-                    risk: workflowData.risk,
-                    reviewInterval: workflowData.reviewInterval,
-                    agentInstructions: workflowData.agentInstructions,
-                    manualRebalance: workflowData.manualRebalance,
-                    status: 'draft',
-                  });
+                  await api.put(`/portfolio-workflows/${draft!.id}`, payload);
                 } else {
-                  await api.post('/portfolio-workflows', {
-                    userId: user.id,
-                    model,
-                    name: workflowData.name,
-                    tokens: workflowData.tokens.map((t) => ({
-                      token: t.token.toUpperCase(),
-                      minAllocation: t.minAllocation,
-                    })),
-                    risk: workflowData.risk,
-                    reviewInterval: workflowData.reviewInterval,
-                    agentInstructions: workflowData.agentInstructions,
-                    manualRebalance: workflowData.manualRebalance,
-                    status: 'draft',
-                  });
+                  await api.post('/portfolio-workflows', payload);
                 }
                 setIsSavingDraft(false);
                 toast.show(t('draft_saved_successfully'), 'success');


### PR DESCRIPTION
## Summary
- remove userId from agent creation and draft requests
- stop including userId in agent updates and dashboard listing
- send cash token separately from positions to satisfy backend validation
- include cash token when updating agents and fetching agent data

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c55940cae8832cb49157beb3bce135