### PR TITLE
chore(frontend): remove unused error messages helper

### DIFF
--- a/frontend/src/lib/errorMessages.ts
+++ b/frontend/src/lib/errorMessages.ts
@@ -1,5 +1,0 @@
-export const ERROR_MESSAGES = {};
-
-export function lengthMessage(field: string, max: number) {
-  return `${field} too long (max ${max})`;
-}


### PR DESCRIPTION
## Summary
- remove unused `errorMessages.ts` from the frontend library

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5601e09c0832caaa94c9425d64e31