### PR TITLE
chore: remove unused HTTP mocks

### DIFF
--- a/frontend/src/lib/mocks.ts
+++ b/frontend/src/lib/mocks.ts
@@ -1,7 +1,0 @@
-import axios from './axios';
-
-export function setupMocks() {
-  if (import.meta.env.VITE_USE_MOCKS !== 'true') return;
-
-  axios.interceptors.request.use(async (config) => config);
-}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,12 +4,9 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import queryClient from './lib/queryClient';
-import { setupMocks } from './lib/mocks';
 import { UserProvider } from './lib/UserProvider';
 import { ToastProvider } from './components/Toast';
 import './index.css';
-
-setupMocks();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- remove unused `setupMocks` call from frontend entrypoint
- delete stub `lib/mocks.ts`

## Testing
- `npm --prefix frontend run lint`
- `timeout 5 npm --prefix frontend run dev` *(terminates after server starts)*

------
https://chatgpt.com/codex/tasks/task_e_68c5602f7904832cadfdd1471c41efe0