### PR TITLE
Fix layout for risk tolerance and review interval

### DIFF
--- a/frontend/src/components/forms/PortfolioWorkflowFields.tsx
+++ b/frontend/src/components/forms/PortfolioWorkflowFields.tsx
@@ -263,6 +263,9 @@ export default function PortfolioWorkflowFields({
         <label htmlFor="risk" className="text-left">
           {t('risk_tolerance')}
         </label>
+        <label htmlFor="reviewInterval" className="text-left">
+          {t('review_interval')}
+        </label>
         <Controller
           name="risk"
           control={control}
@@ -275,9 +278,6 @@ export default function PortfolioWorkflowFields({
             />
           )}
         />
-        <label htmlFor="reviewInterval" className="text-left">
-          {t('review_interval')}
-        </label>
         <Controller
           name="reviewInterval"
           control={control}

--- a/frontend/src/routes/PortfolioWorkflowPreview.tsx
+++ b/frontend/src/routes/PortfolioWorkflowPreview.tsx
@@ -251,13 +251,11 @@ export default function PortfolioWorkflowPreview({ draft }: Props) {
               .toFixed(5);
           })()}
         </div>
-        <div className="mt-4 space-y-1">
-          <p>
-            <strong>{t('risk_tolerance')}:</strong> {workflowData.risk}
-          </p>
-          <p>
-            <strong>{t('review_interval')}:</strong> {workflowData.reviewInterval}
-          </p>
+        <div className="mt-4 grid grid-cols-2 grid-rows-2 gap-x-4 gap-y-1 text-sm">
+          <span className="font-medium">{t('risk_tolerance')}</span>
+          <span className="font-medium">{t('review_interval')}</span>
+          <span>{workflowData.risk}</span>
+          <span>{workflowData.reviewInterval}</span>
         </div>
       </div>
       <AgentInstructions


### PR DESCRIPTION
## Summary
- separate labels and values into distinct rows for risk tolerance and review interval fields
- align risk tolerance and review interval preview with label-first layout

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c561bddca4832ca810f094098be5e9