### PR TITLE
Fix PnL calculation and parse detailed AI orders

### DIFF
--- a/backend/src/agents/main-trader.ts
+++ b/backend/src/agents/main-trader.ts
@@ -84,7 +84,7 @@ export async function collectPromptData(
     return {
       symbol: planned.symbol,
       side: planned.side,
-      amount: planned.quantity,
+      quantity: planned.quantity,
       datetime: o.created_at.toISOString(),
       status: o.status,
     } as const;
@@ -111,6 +111,7 @@ export async function collectPromptData(
 
 export interface MainTraderOrder {
   pair: string;
+  token: string;
   side: string;
   quantity: number;
 }

--- a/backend/src/util/ai.ts
+++ b/backend/src/util/ai.ts
@@ -7,7 +7,7 @@ export const developerInstructions = [
   '- Know every team member, their role, and ensure decisions follow the overall trading strategy.',
   '- Decide which limit orders to place based on portfolio, market data, and analyst reports.',
   '- Verify limit orders meet minNotional to avoid cancellations, especially for small amounts.',
-  '- Return {orders:[{pair:"TOKEN1TOKEN2",side:"BUY"|"SELL",quantity:number},...],shortReport}.',
+  '- Return {orders:[{pair:"TOKEN1TOKEN2",token:"TOKEN",side:"BUY"|"SELL",quantity:number},...],shortReport}.',
   '- shortReport ≤255 chars.',
   '- On error, return {error:"message"}.',
 ].join('\n');
@@ -47,7 +47,7 @@ export interface RebalancePosition {
 }
 
 export interface PreviousResponse {
-  orders?: { pair: string; side: string; quantity: number }[];
+  orders?: { pair: string; token: string; side: string; quantity: number }[];
   shortReport?: string;
   error?: unknown;
 }
@@ -70,7 +70,7 @@ export interface RebalancePrompt {
   prev_orders?: {
     symbol: string;
     side: string;
-    amount: number;
+    quantity: number;
     datetime: string;
     status: string;
   }[];
@@ -107,10 +107,11 @@ export const rebalanceResponseSchema = {
                   type: 'object',
                   properties: {
                     pair: { type: 'string' },
+                    token: { type: 'string' },
                     side: { type: 'string', enum: ['BUY', 'SELL'] },
                     quantity: { type: 'number' },
                   },
-                  required: ['pair', 'side', 'quantity'],
+                  required: ['pair', 'token', 'side', 'quantity'],
                   additionalProperties: false,
                 },
               },

--- a/backend/src/util/parse-exec-log.ts
+++ b/backend/src/util/parse-exec-log.ts
@@ -106,18 +106,28 @@ export function validateExecResponse(
 ): string | undefined {
   if (!response) return undefined;
   for (const o of response.orders || []) {
-    if (typeof o.pair !== 'string' || typeof o.side !== 'string')
+    if (
+      typeof o.pair !== 'string' ||
+      typeof o.token !== 'string' ||
+      typeof o.side !== 'string'
+    )
       return 'invalid order';
-    let valid = false;
+    let base = '';
+    let quote = '';
     for (const sym of TOKEN_SYMBOLS) {
       if (o.pair.startsWith(sym)) {
         const rest = o.pair.slice(sym.length);
-        if (allowedTokens.includes(sym) && allowedTokens.includes(rest)) {
-          valid = true;
+        if (TOKEN_SYMBOLS.includes(rest)) {
+          base = sym;
+          quote = rest;
+          break;
         }
       }
     }
-    if (!valid) return 'invalid pair';
+    if (!base || !quote) return 'invalid pair';
+    if (!allowedTokens.includes(base) || !allowedTokens.includes(quote))
+      return 'invalid pair';
+    if (o.token !== base && o.token !== quote) return 'invalid token';
     if (typeof o.quantity !== 'number' || o.quantity <= 0)
       return 'invalid quantity';
   }

--- a/backend/test/agentExecLog.test.ts
+++ b/backend/test/agentExecLog.test.ts
@@ -261,7 +261,7 @@ describe('agent exec log routes', () => {
           content: [
             {
               type: 'output_text',
-              text: '{"result":{"orders":[{"pair":"BTCUSDT","side":"SELL","quantity":1}],"shortReport":"s"}}',
+              text: '{"result":{"orders":[{"pair":"BTCUSDT","token":"BTC","side":"SELL","quantity":1}],"shortReport":"s"}}',
             },
           ],
         },
@@ -293,7 +293,7 @@ describe('agent exec log routes', () => {
 
     const parsedLog = parseExecLog(body.items[0].log);
     expect(parsedLog.response).toMatchObject({
-      orders: [{ pair: 'BTCUSDT', side: 'SELL', quantity: 1 }],
+      orders: [{ pair: 'BTCUSDT', token: 'BTC', side: 'SELL', quantity: 1 }],
       shortReport: 's',
     });
 

--- a/backend/test/callAi.test.ts
+++ b/backend/test/callAi.test.ts
@@ -21,7 +21,12 @@ describe('callAi structured output', () => {
       marketData: { currentPrice: 1, minNotional: 10 },
       previous_responses: [
         { shortReport: 'p1' },
-        { rebalance: true, newAllocation: 50 },
+        {
+          orders: [
+            { pair: 'BTCUSDT', token: 'BTC', side: 'BUY', quantity: 1 },
+          ],
+          shortReport: 'p2',
+        },
       ],
     };
     await callAi('gpt-test', developerInstructions, rebalanceResponseSchema, prompt, 'key');
@@ -35,7 +40,10 @@ describe('callAi structured output', () => {
     const parsed = JSON.parse(body.input);
     expect(parsed.previous_responses).toEqual([
       { shortReport: 'p1' },
-      { rebalance: true, newAllocation: 50 },
+      {
+        orders: [{ pair: 'BTCUSDT', token: 'BTC', side: 'BUY', quantity: 1 }],
+        shortReport: 'p2',
+      },
     ]);
     expect(body.tools).toBeUndefined();
     expect(body.text.format.type).toBe('json_schema');

--- a/backend/test/collectPromptData.test.ts
+++ b/backend/test/collectPromptData.test.ts
@@ -79,7 +79,7 @@ describe('collectPromptData', () => {
     expect(prompt?.prev_orders?.[0]).toMatchObject({
       symbol: 'BTCUSDT',
       side: 'BUY',
-      amount: 1,
+      quantity: 1,
       datetime: '2025-01-01T00:00:00.000Z',
       status: 'filled',
     });

--- a/backend/test/mainTraderWorkflowStep.test.ts
+++ b/backend/test/mainTraderWorkflowStep.test.ts
@@ -10,7 +10,17 @@ const callAiMock = vi.fn(() =>
           content: [
             {
               text: JSON.stringify({
-                result: { rebalance: true, newAllocation: 50, shortReport: 'ok' },
+                result: {
+                  orders: [
+                    {
+                      pair: 'BTCUSDT',
+                      token: 'BTC',
+                      side: 'SELL',
+                      quantity: 1,
+                    },
+                  ],
+                  shortReport: 'ok',
+                },
               }),
             },
           ],
@@ -54,7 +64,9 @@ describe('main trader step', () => {
       },
       prompt,
     );
-    expect(decision?.rebalance).toBe(true);
+    expect(decision?.orders).toEqual([
+      { pair: 'BTCUSDT', token: 'BTC', side: 'SELL', quantity: 1 },
+    ]);
     expect(callAiMock).toHaveBeenCalled();
   });
 });

--- a/backend/test/reviewPortfolio.test.ts
+++ b/backend/test/reviewPortfolio.test.ts
@@ -153,7 +153,10 @@ function createLogger(): FastifyBaseLogger {
 describe('reviewPortfolio', () => {
   it('saves decision and logs', async () => {
     await setupAgent('1', ['BTC']);
-    const decision = { orders: [{ pair: 'BTCUSDT', side: 'SELL', quantity: 1 }], shortReport: 'ok' };
+    const decision = {
+      orders: [{ pair: 'BTCUSDT', token: 'BTC', side: 'SELL', quantity: 1 }],
+      shortReport: 'ok',
+    };
     runMainTrader.mockResolvedValue(decision);
     const log = createLogger();
     await reviewAgentPortfolio(log, '1');
@@ -177,7 +180,13 @@ describe('reviewPortfolio', () => {
 
   it('calls createDecisionLimitOrders when orders requested', async () => {
     await setupAgent('2', ['BTC', 'ETH']);
-    const decision = { orders: [{ pair: 'BTCUSDT', side: 'BUY', quantity: 1 }, { pair: 'ETHBTC', side: 'SELL', quantity: 0.5 }], shortReport: 's' };
+    const decision = {
+      orders: [
+        { pair: 'BTCUSDT', token: 'BTC', side: 'BUY', quantity: 1 },
+        { pair: 'ETHBTC', token: 'ETH', side: 'SELL', quantity: 0.5 },
+      ],
+      shortReport: 's',
+    };
     runMainTrader.mockResolvedValue(decision);
     const log = createLogger();
     await reviewAgentPortfolio(log, '2');
@@ -189,7 +198,10 @@ describe('reviewPortfolio', () => {
 
   it('skips createDecisionLimitOrders when manualRebalance is enabled', async () => {
     await setupAgent('3', ['BTC'], true);
-    const decision = { orders: [{ pair: 'BTCUSDT', side: 'BUY', quantity: 1 }], shortReport: 's' };
+    const decision = {
+      orders: [{ pair: 'BTCUSDT', token: 'BTC', side: 'BUY', quantity: 1 }],
+      shortReport: 's',
+    };
     runMainTrader.mockResolvedValue(decision);
     const log = createLogger();
     await reviewAgentPortfolio(log, '3');
@@ -198,7 +210,10 @@ describe('reviewPortfolio', () => {
 
   it('records error when pair is invalid', async () => {
     await setupAgent('4', ['BTC']);
-    const decision = { orders: [{ pair: 'FOO', side: 'BUY', quantity: 1 }], shortReport: 's' };
+    const decision = {
+      orders: [{ pair: 'FOO', token: 'BTC', side: 'BUY', quantity: 1 }],
+      shortReport: 's',
+    };
     runMainTrader.mockResolvedValue(decision);
     const log = createLogger();
     await reviewAgentPortfolio(log, '4');
@@ -212,7 +227,10 @@ describe('reviewPortfolio', () => {
 
   it('records error when quantity is invalid', async () => {
     await setupAgent('5', ['BTC']);
-    const decision = { orders: [{ pair: 'BTCUSDT', side: 'BUY', quantity: 0 }], shortReport: 's' };
+    const decision = {
+      orders: [{ pair: 'BTCUSDT', token: 'BTC', side: 'BUY', quantity: 0 }],
+      shortReport: 's',
+    };
     runMainTrader.mockResolvedValue(decision);
     const log = createLogger();
     await reviewAgentPortfolio(log, '5');

--- a/frontend/src/lib/useAgentBalanceUsd.ts
+++ b/frontend/src/lib/useAgentBalanceUsd.ts
@@ -5,6 +5,9 @@ import { useUser } from './useUser';
 
 export function useAgentBalanceUsd(tokens: string[]) {
   const { user } = useUser();
+  const uniqTokens = Array.from(
+    new Set(tokens.map((t) => t.toUpperCase())),
+  );
   const { data: binanceKey } = useQuery<string | null>({
     queryKey: ['binance-key', user?.id],
     enabled: !!user,
@@ -19,10 +22,10 @@ export function useAgentBalanceUsd(tokens: string[]) {
     },
   });
 
-  const enabled = !!user && !!binanceKey && tokens.length > 0;
+  const enabled = !!user && !!binanceKey && uniqTokens.length > 0;
   const balanceQueries = useQueries({
     queries: enabled
-      ? tokens.map((token) => ({
+      ? uniqTokens.map((token) => ({
           queryKey: ['binance-balance-usd', user?.id, token.toUpperCase()],
           enabled,
           queryFn: async () => {


### PR DESCRIPTION
## Summary
- Use `quantity` instead of `amount` in AI order developer instructions, schema, and previous order summaries
- Validate and execute AI orders based on the `quantity` field
- Note that `rebalance` is determined from order presence when saving review results

## Testing
- `npm --prefix frontend run lint`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c570bdcf7c832c9cfec5a8efc5b519