### PR TITLE
fix: preserve side for quote-asset orders

### DIFF
--- a/backend/src/services/rebalance.ts
+++ b/backend/src/services/rebalance.ts
@@ -137,12 +137,11 @@ export async function createDecisionLimitOrders(opts: {
     if (!a || !b) continue;
     const info = await fetchPairInfo(a, b);
     const { currentPrice } = await fetchPairData(a, b);
-    let side = o.side as any;
+    const side = o.side as 'BUY' | 'SELL';
     let quantity: number;
     if (o.token === info.baseAsset) {
       quantity = o.quantity;
     } else if (o.token === info.quoteAsset) {
-      side = o.side === 'BUY' ? 'SELL' : 'BUY';
       quantity = o.quantity / currentPrice;
     } else {
       continue;


### PR DESCRIPTION
## Summary
- avoid flipping BUY/SELL when decision quantity is expressed in quote currency
- add regression test for createDecisionLimitOrders

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5817bf470832ca10010929b10789e