### PR TITLE
Include cash token in portfolio stats and show order symbols

### DIFF
--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -219,6 +219,7 @@ export default async function agentRoutes(app: FastifyInstance) {
             side: planned.side,
             quantity: planned.quantity,
             price: planned.price,
+            symbol: planned.symbol,
             status: r.status,
             createdAt: r.created_at.getTime(),
             cancellationReason: r.cancellation_reason ?? undefined,

--- a/backend/test/agentExecLog.test.ts
+++ b/backend/test/agentExecLog.test.ts
@@ -54,6 +54,7 @@ describe('agent exec log routes', () => {
           side: 'BUY',
           quantity: 1,
           price: 100,
+          symbol: 'BTCETH',
           status: 'open',
           createdAt: expect.any(Number),
         },

--- a/frontend/src/components/AgentDetailsDesktop.tsx
+++ b/frontend/src/components/AgentDetailsDesktop.tsx
@@ -16,6 +16,7 @@ export default function AgentDetailsDesktop({ agent }: Props) {
   const [showPrompt, setShowPrompt] = useState(false);
   const t = useTranslation();
 
+  const tokens = [agent.cashToken, ...agent.tokens.map((t) => t.token)];
   return (
     <div>
       <h1 className="text-2xl font-bold mb-2 flex items-center gap-2">
@@ -29,14 +30,14 @@ export default function AgentDetailsDesktop({ agent }: Props) {
       </p>
       <p className="flex items-center gap-1 mt-2">
         <strong>{t('tokens')}:</strong>
-        {agent.tokens.map((t, i) => (
-          <span key={i} className="flex items-center gap-1">
+        {tokens.map((tok, i) => (
+          <span key={tok} className="flex items-center gap-1">
             {i > 0 && <span>/</span>}
-            <TokenDisplay token={t.token} />
+            <TokenDisplay token={tok} />
           </span>
         ))}
       </p>
-      <DerivativesSummary symbol={agent.tokens.map((t) => t.token).join('').toUpperCase()} />
+      <DerivativesSummary symbol={`${agent.tokens[0]?.token.toUpperCase() ?? ''}${agent.cashToken.toUpperCase()}`} />
       <div className="mt-2">
         <div className="flex items-center gap-1">
           <h2 className="text-l font-bold">{t('trading_instructions')}</h2>
@@ -58,10 +59,7 @@ export default function AgentDetailsDesktop({ agent }: Props) {
           </pre>
         )}
       </div>
-      <AgentPnl
-        tokens={agent.tokens.map((t) => t.token)}
-        startBalanceUsd={agent.startBalanceUsd}
-      />
+      <AgentPnl tokens={tokens} startBalanceUsd={agent.startBalanceUsd} />
     </div>
   );
 }

--- a/frontend/src/components/AgentDetailsMobile.tsx
+++ b/frontend/src/components/AgentDetailsMobile.tsx
@@ -10,6 +10,7 @@ interface Props {
 }
 
 export default function AgentDetailsMobile({ agent }: Props) {
+  const tokens = [agent.cashToken, ...agent.tokens.map((t) => t.token)];
   return (
     <div>
       <div className="mb-2 flex items-center justify-between">
@@ -20,18 +21,15 @@ export default function AgentDetailsMobile({ agent }: Props) {
         <FormattedDate date={agent.createdAt} />
       </p>
       <p className="flex items-center gap-1 mt-2">
-        {agent.tokens.map((t, i) => (
-          <span key={i} className="flex items-center gap-1">
+        {tokens.map((tok, i) => (
+          <span key={tok} className="flex items-center gap-1">
             {i > 0 && <span>/</span>}
-            <TokenDisplay token={t.token} />
+            <TokenDisplay token={tok} />
           </span>
         ))}
       </p>
-      <DerivativesSummary symbol={agent.tokens.map((t) => t.token).join('').toUpperCase()} />
-      <AgentPnlMobile
-        tokens={agent.tokens.map((t) => t.token)}
-        startBalanceUsd={agent.startBalanceUsd}
-      />
+      <DerivativesSummary symbol={`${agent.tokens[0]?.token.toUpperCase() ?? ''}${agent.cashToken.toUpperCase()}`} />
+      <AgentPnlMobile tokens={tokens} startBalanceUsd={agent.startBalanceUsd} />
     </div>
   );
 }

--- a/frontend/src/components/ExecTxCard.tsx
+++ b/frontend/src/components/ExecTxCard.tsx
@@ -37,6 +37,7 @@ export default function ExecTxCard({ agentId, logId, orders, onCancel }: Props) 
         <thead>
           <tr>
             <th className="pr-2">Time</th>
+            <th className="pr-2">Symbol</th>
             <th className="pr-2">Side</th>
             <th className="pr-2">Qty</th>
             <th className="pr-2">Price</th>
@@ -48,6 +49,7 @@ export default function ExecTxCard({ agentId, logId, orders, onCancel }: Props) 
           {orders.map((o) => (
             <tr key={o.id}>
               <td className="pr-2">{new Date(o.createdAt).toLocaleString()}</td>
+              <td className="pr-2">{o.symbol}</td>
               <td className="pr-2">{o.side}</td>
               <td className="pr-2">{o.quantity}</td>
               <td className="pr-2">{o.price}</td>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -5,6 +5,7 @@ export interface LimitOrder {
   side: string;
   quantity: number;
   price: number;
+  symbol: string;
   status: LimitOrderStatus;
   createdAt: number;
   cancellationReason?: string;

--- a/frontend/src/routes/AgentView.tsx
+++ b/frontend/src/routes/AgentView.tsx
@@ -143,7 +143,7 @@ export default function AgentView() {
                                 log={log}
                                 agentId={id!}
                                 manualRebalance={data.manualRebalance}
-                                tokens={data.tokens.map((t) => t.token)}
+                                tokens={[data.tokens[0]?.token, data.cashToken].filter(Boolean) as string[]}
                               />
                             </td>
                           </tr>
@@ -160,7 +160,7 @@ export default function AgentView() {
                             log={log}
                             agentId={id!}
                             manualRebalance={data.manualRebalance}
-                            tokens={data.tokens.map((t) => t.token)}
+                            tokens={[data.tokens[0]?.token, data.cashToken].filter(Boolean) as string[]}
                           />
                         </div>
                       ))}

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -23,6 +23,7 @@ interface Agent {
   userId: string;
   model: string;
   status: 'active' | 'inactive' | 'draft';
+  cashToken: string;
   tokens?: { token: string }[];
   startBalanceUsd?: number | null;
   reviewInterval: string;
@@ -36,9 +37,11 @@ function AgentRow({
   onDelete: (id: string) => void;
 }) {
   const t = useTranslation();
-  const { balance, isLoading } = useAgentBalanceUsd(
-    agent.tokens ? agent.tokens.map((t) => t.token) : [],
-  );
+  const tokenList = [
+    agent.cashToken,
+    ...(agent.tokens ? agent.tokens.map((t) => t.token) : []),
+  ];
+  const { balance, isLoading } = useAgentBalanceUsd(tokenList);
   const balanceText =
     balance === null ? '-' : isLoading ? t('loading') : `$${balance.toFixed(2)}`;
   const pnl =
@@ -86,12 +89,12 @@ function AgentRow({
   return (
     <tr key={agent.id}>
       <td>
-        {agent.tokens && agent.tokens.length ? (
+        {tokenList.length ? (
           <span className="inline-flex items-center gap-1">
-            {agent.tokens.map((t, i) => (
-              <span key={t.token} className="flex items-center gap-1">
+            {tokenList.map((tok, i) => (
+              <span key={tok} className="flex items-center gap-1">
                 {i > 0 && <span>/</span>}
-                <TokenDisplay token={t.token} />
+                <TokenDisplay token={tok} />
               </span>
             ))}
           </span>
@@ -143,9 +146,11 @@ function AgentBlock({
   onDelete: (id: string) => void;
 }) {
   const t = useTranslation();
-  const { balance, isLoading } = useAgentBalanceUsd(
-    agent.tokens ? agent.tokens.map((t) => t.token) : [],
-  );
+  const tokenList = [
+    agent.cashToken,
+    ...(agent.tokens ? agent.tokens.map((t) => t.token) : []),
+  ];
+  const { balance, isLoading } = useAgentBalanceUsd(tokenList);
   const balanceText =
     balance === null ? '-' : isLoading ? t('loading') : `$${balance.toFixed(2)}`;
   const pnl =
@@ -193,12 +198,12 @@ function AgentBlock({
   return (
     <div className="border rounded p-3 text-sm">
       <div className="mb-2 flex items-center gap-1 font-medium">
-        {agent.tokens && agent.tokens.length ? (
+        {tokenList.length ? (
           <span className="inline-flex items-center gap-1">
-            {agent.tokens.map((t, i) => (
-              <span key={t.token} className="flex items-center gap-1">
+            {tokenList.map((tok, i) => (
+              <span key={tok} className="flex items-center gap-1">
                 {i > 0 && <span>/</span>}
-                <TokenDisplay token={t.token} />
+                <TokenDisplay token={tok} />
               </span>
             ))}
           </span>


### PR DESCRIPTION
## Summary
- show cash token when listing portfolio tokens and calculate PnL using it
- return order symbol and display it in execution log table

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c63f3d27c8832cb2d5b2b4a6f467a9