### PR TITLE
feat: include cancellation reason in previous reports

### DIFF
--- a/backend/src/agents/main-trader.ts
+++ b/backend/src/agents/main-trader.ts
@@ -89,6 +89,9 @@ export async function collectPromptData(
         quantity: planned.quantity,
         status: o.status,
         datetime: o.created_at.toISOString(),
+        ...(o.cancellation_reason
+          ? { cancellationReason: o.cancellation_reason }
+          : {}),
       } as const;
     });
     const report: PreviousReport = {

--- a/backend/src/util/ai.ts
+++ b/backend/src/util/ai.ts
@@ -57,6 +57,7 @@ export interface PreviousReport {
     quantity: number;
     status: string;
     datetime: string;
+    cancellationReason?: string;
   }[];
   shortReport?: string;
   error?: unknown;

--- a/backend/test/collectPromptData.test.ts
+++ b/backend/test/collectPromptData.test.ts
@@ -37,7 +37,7 @@ vi.mock('../src/repos/limit-orders.js', () => ({
         status: 'filled',
         created_at: new Date(`2025-01-0${i}T00:00:00.000Z`),
         order_id: String(i),
-        cancellation_reason: null,
+        cancellation_reason: 'price limit',
       },
     ];
   }),
@@ -102,6 +102,7 @@ describe('collectPromptData', () => {
           quantity: 1,
           status: 'filled',
           datetime: '2025-01-01T00:00:00.000Z',
+          cancellationReason: 'price limit',
         },
       ],
       shortReport: 'p1',


### PR DESCRIPTION
## Summary
- expose order cancellation reason in PreviousReport entries
- propagate cancellation reasons from limit orders when building prompts
- cover cancellation reason in collectPromptData tests

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6a08ba954832ca29ddbeda20b6ed4