### PR TITLE
Limit portfolios to four tokens

### DIFF
--- a/frontend/src/components/forms/PortfolioWorkflowFields.tsx
+++ b/frontend/src/components/forms/PortfolioWorkflowFields.tsx
@@ -77,7 +77,7 @@ export default function PortfolioWorkflowFields({
     if (topTokens.length > 0) {
       const newTokens = [stable, ...topTokens]
         .filter((t): t is string => Boolean(t))
-        .slice(0, 5);
+        .slice(0, 4);
       replace(
         newTokens.map((t) => ({
           token: t,
@@ -235,7 +235,7 @@ export default function PortfolioWorkflowFields({
             </div>
           );
         })}
-        {fields.length < 5 && (
+        {fields.length < 4 && (
           <button
             type="button"
             onClick={handleAddToken}

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -55,7 +55,7 @@ export const portfolioReviewSchema = z
         }),
       )
       .min(2)
-      .max(5),
+      .max(4),
     risk: z.enum(['low', 'medium', 'high']),
     reviewInterval: z.enum([
       '10m',

--- a/frontend/src/routes/PortfolioWorkflowPreview.tsx
+++ b/frontend/src/routes/PortfolioWorkflowPreview.tsx
@@ -220,12 +220,12 @@ export default function PortfolioWorkflowPreview({ draft }: Props) {
               </div>
             );
           })}
-          {workflowData.tokens.length < 5 && (
+          {workflowData.tokens.length < 4 && (
             <button
               type="button"
               onClick={handleAddToken}
               className="flex items-center gap-1 text-blue-600"
-            >
+          >
               <Plus className="w-4 h-4" />
             </button>
           )}


### PR DESCRIPTION
## Summary
- Cap portfolio review form to four tokens
- Align token add UI and preview with four-token maximum

## Testing
- `pg_isready`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6a7acff04832ca190a813c1c354a1