### PR TITLE
refactor: streamline portfolio workflow routes

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -73,10 +73,9 @@ export default async function buildServer(
   await fetchOutputIp();
 
   for (const file of fs.readdirSync(routesDir)) {
-    if (file.endsWith('.js') || (file.endsWith('.ts') && !file.endsWith('.d.ts'))) {
-      const route = await import(pathToFileURL(path.join(routesDir, file)).href);
-      app.register(route.default, { prefix: '/api' });
-    }
+    if (!file.endsWith('.js')) continue;
+    const route = await import(pathToFileURL(path.join(routesDir, file)).href);
+    app.register(route.default, { prefix: '/api' });
   }
 
   app.addHook('preHandler', (req, _reply, done) => {


### PR DESCRIPTION
## Summary
- rename agents routes to portfolio-workflows for clarity
- extract shared manual rebalance logic into reusable helper
- simplify rebalance and preview endpoints
- load only compiled route files to prevent duplicate registration errors

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test` *(fails: connect ECONNREFUSED 127.0.0.1:5432)*
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68c69a31411c832c96f6e9bb344a1167