### PR TITLE
chore: clean dist folders before copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM caddy:2.7-alpine
 ARG FRONTEND_BUILD_DIR=dist
 COPY Caddyfile /etc/caddy/Caddyfile
+RUN rm -rf /usr/share/caddy/*
 COPY frontend/${FRONTEND_BUILD_DIR}/ /usr/share/caddy/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,7 +4,9 @@ ENV NODE_ENV=production
 ENV PORT=3000
 EXPOSE 3000
 COPY package*.json ./
-RUN npm ci --omit=dev
+# Install production dependencies inside the image so native modules
+# are built against the Alpine base rather than the CI environment.
+RUN npm ci --omit=dev && rm -rf dist
 COPY dist ./dist
 RUN mkdir -p /data && chown -R node:node /app /data
 USER node


### PR DESCRIPTION
## Summary
- ensure Caddy image copies frontend build into a clean directory
- remove old backend build artifacts before copying compiled code
- document why backend Dockerfile installs dependencies during image build

## Testing
- `npm --prefix backend run build`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_68c6c6f73f54832c916b586573091fad