### PR TITLE
Remove stale backend files during deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,7 @@ jobs:
           passphrase: ${{ secrets.DO_SSH_PASSPHRASE }}
           source: "backend,frontend,docker-compose.yml,Dockerfile,Caddyfile"
           target: "~/prompt-swap"
+          rm: true
 
       - name: Deploy with Docker Compose
         uses: appleboy/ssh-action@25ce8cbbcb08177468c7ff7ec5cbfa236f9341e1 # v1.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM caddy:2.7-alpine
 ARG FRONTEND_BUILD_DIR=dist
 COPY Caddyfile /etc/caddy/Caddyfile
-RUN rm -rf /usr/share/caddy/*
 COPY frontend/${FRONTEND_BUILD_DIR}/ /usr/share/caddy/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,7 +6,7 @@ EXPOSE 3000
 COPY package*.json ./
 # Install production dependencies inside the image so native modules
 # are built against the Alpine base rather than the CI environment.
-RUN npm ci --omit=dev && rm -rf dist
+RUN npm ci --omit=dev
 COPY dist ./dist
 RUN mkdir -p /data && chown -R node:node /app /data
 USER node


### PR DESCRIPTION
## Summary
- delete existing remote files before copying build artifacts to avoid leftover routes like `agents`
- drop redundant cleanup commands from Dockerfiles now that deployment wipes targets

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix frontend run lint`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6d5c5f484832c9321bbd89e622761