### PR TITLE
Wait for backend to finish startup before health check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,5 +162,11 @@ jobs:
             export VITE_GOOGLE_CLIENT_ID="${GOOGLE_CLIENT_ID}"
             export DB_CONNECTION_STR="${DB_CONNECTION_STR}"
             docker compose up -d --build
-            timeout 60s bash -c 'until curl -fsS -H "Host: ${DOMAIN}" http://localhost/api/health; do sleep 3; done'
+            timeout 60s bash -c 'until docker compose logs backend | grep -q "server started"; do sleep 3; done'
+            curl -fsS -H "Host: ${DOMAIN}" http://localhost/api/health
             docker compose ps
+            if docker compose ps | grep -q "Exit"; then
+              echo "A container failed to stay up"
+              docker compose logs
+              exit 1
+            fi


### PR DESCRIPTION
## Summary
- watch backend logs for `server started` during deploy to ensure the service finished booting before health check
- keep verifying containers stay running after startup

## Testing
- `DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6d3f2e654832c86259d6ce99746a9