### PR TITLE
Use spot order book and remove futures metrics

### DIFF
--- a/backend/src/services/derivatives.ts
+++ b/backend/src/services/derivatives.ts
@@ -1,31 +1,6 @@
-export async function fetchOpenInterest(symbol: string) {
-  const res = await fetch(
-    `https://fapi.binance.com/fapi/v1/openInterest?symbol=${symbol}`,
-  );
-  if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`failed to fetch open interest: ${res.status} ${body}`);
-  }
-  const json = (await res.json()) as { openInterest: string };
-  return Number(json.openInterest);
-}
-
-export async function fetchFundingRate(symbol: string) {
-  const res = await fetch(
-    `https://fapi.binance.com/fapi/v1/fundingRate?symbol=${symbol}&limit=1`,
-  );
-  if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`failed to fetch funding rate: ${res.status} ${body}`);
-  }
-  const json = (await res.json()) as { fundingRate: string }[];
-  const latest = json[0];
-  return Number(latest?.fundingRate ?? 0);
-}
-
 export async function fetchOrderBook(symbol: string) {
   const res = await fetch(
-    `https://fapi.binance.com/fapi/v1/depth?symbol=${symbol}&limit=5`,
+    `https://api.binance.com/api/v3/depth?symbol=${symbol}&limit=5`,
   );
   if (!res.ok) {
     const body = await res.text();

--- a/backend/src/util/ai.ts
+++ b/backend/src/util/ai.ts
@@ -85,8 +85,6 @@ export interface RebalancePrompt {
     indicators?: Record<string, TokenMetrics>;
     market_timeseries?: Record<string, MarketTimeseries>;
     fearGreedIndex?: { value: number; classification: string };
-    openInterest?: number;
-    fundingRate?: number;
   };
   previous_reports?: PreviousReport[];
   reports?: {

--- a/backend/test/derivatives.test.ts
+++ b/backend/test/derivatives.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fetchOrderBook } from '../src/services/derivatives.js';
+
+describe('fetchOrderBook', () => {
+  it('uses spot order book endpoint', async () => {
+    const mock = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          bids: [['1', '1']],
+          asks: [['2', '1']],
+        }),
+      } as any);
+
+    await fetchOrderBook('BTCUSDT');
+
+    expect(mock).toHaveBeenCalledWith(
+      'https://api.binance.com/api/v3/depth?symbol=BTCUSDT&limit=5',
+    );
+
+    mock.mockRestore();
+  });
+});
+


### PR DESCRIPTION
## Summary
- switch technical analyst to spot order book data
- remove unused open interest and funding rate methods

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6eafb29c4832cb21dfe0e373e5bed