### PR TITLE
fix: ignore locked balances in portfolio

### DIFF
--- a/backend/src/agents/main-trader.ts
+++ b/backend/src/agents/main-trader.ts
@@ -34,12 +34,12 @@ export async function collectPromptData(
   const routes: RebalancePrompt['routes'] = [];
 
   const balCash = account.balances.find((b) => b.asset === cash);
-  const cashQty = balCash ? Number(balCash.free) + Number(balCash.locked) : 0;
+  const cashQty = balCash ? Number(balCash.free) : 0;
   positions.push({ sym: cash, qty: cashQty, price_usdt: 1, value_usdt: cashQty });
 
   for (const t of row.tokens) {
     const bal = account.balances.find((b) => b.asset === t.token);
-    const qty = bal ? Number(bal.free) + Number(bal.locked) : undefined;
+    const qty = bal ? Number(bal.free) : undefined;
     if (qty === undefined) {
       log.error('failed to fetch token balances');
       return undefined;


### PR DESCRIPTION
## Summary
- ensure portfolio positions use only free balances
- adjust test to assert locked funds are ignored

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test` (fails: connect ECONNREFUSED)
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6eb576c78832cb74e44ad0358cedf