### PR TITLE
Cancel all orders when deleting portfolio workflow

### DIFF
--- a/backend/src/jobs/check-open-orders.ts
+++ b/backend/src/jobs/check-open-orders.ts
@@ -76,8 +76,8 @@ async function reconcileOrder(
       });
       await updateLimitOrderStatus(o.user_id, o.order_id, 'canceled');
     } catch (err) {
-      const msg = parseBinanceError(err);
-      if (msg && /UNKNOWN_ORDER/i.test(msg)) {
+      const { code } = parseBinanceError(err);
+      if (code === -2013) {
         await updateLimitOrderStatus(o.user_id, o.order_id, 'filled');
       } else {
         log.error({ err }, 'failed to cancel order');

--- a/backend/src/repos/limit-orders.ts
+++ b/backend/src/repos/limit-orders.ts
@@ -25,20 +25,6 @@ export async function insertLimitOrder(entry: LimitOrderEntry): Promise<void> {
   );
 }
 
-export async function cancelOpenLimitOrdersByAgent(
-  agentId: string,
-): Promise<void> {
-  await db.query(
-    `UPDATE limit_order e
-        SET status = 'canceled'
-       FROM agent_review_result r
-      WHERE e.status = 'open'
-        AND e.review_result_id = r.id
-        AND r.agent_id = $1`,
-    [agentId],
-  );
-}
-
 export async function getLimitOrdersByReviewResult(
   agentId: string,
   reviewResultId: string,

--- a/backend/src/routes/api-keys.ts
+++ b/backend/src/routes/api-keys.ts
@@ -62,11 +62,10 @@ async function cancelOrdersForAgent(agentId: string, log: FastifyBaseLogger) {
       await cancelOrder(o.user_id, { symbol, orderId: Number(o.order_id) });
       await updateLimitOrderStatus(o.user_id, o.order_id, 'canceled');
     } catch (err) {
-      const msg = parseBinanceError(err);
-      if (msg && /UNKNOWN_ORDER/i.test(msg))
+      const { code } = parseBinanceError(err);
+      if (code === -2013)
         await updateLimitOrderStatus(o.user_id, o.order_id, 'filled');
-      else
-        log.error({ err, orderId: o.order_id }, 'failed to cancel order');
+      else log.error({ err, orderId: o.order_id }, 'failed to cancel order');
     }
   }
 }

--- a/backend/src/routes/api-keys.ts
+++ b/backend/src/routes/api-keys.ts
@@ -1,4 +1,4 @@
-import type { FastifyInstance } from 'fastify';
+import type { FastifyInstance, FastifyBaseLogger } from 'fastify';
 import { z } from 'zod';
 import { RATE_LIMITS } from '../rate-limit.js';
 import {
@@ -20,7 +20,14 @@ import {
   draftAgentsByUser,
 } from '../repos/portfolio-workflow.js';
 import { removeWorkflowFromSchedule } from '../workflows/portfolio-review.js';
-import { cancelOpenOrders } from '../services/binance.js';
+import {
+  cancelOrder,
+  parseBinanceError,
+} from '../services/binance.js';
+import {
+  getOpenLimitOrdersForAgent,
+  updateLimitOrderStatus,
+} from '../repos/limit-orders.js';
 import { requireUserIdMatch, requireAdmin } from '../util/auth.js';
 import {
   ApiKeyType,
@@ -36,6 +43,33 @@ import { findUserByEmail } from '../repos/users.js';
 import { parseParams } from '../util/validation.js';
 
 const idParams = z.object({ id: z.string().regex(/^\d+$/) });
+
+async function cancelOrdersForAgent(agentId: string, log: FastifyBaseLogger) {
+  const openOrders = await getOpenLimitOrdersForAgent(agentId);
+  for (const o of openOrders) {
+    let symbol: string | undefined;
+    try {
+      const planned = JSON.parse(o.planned_json);
+      if (typeof planned.symbol === 'string') symbol = planned.symbol;
+    } catch (err) {
+      log.error({ err, orderId: o.order_id }, 'failed to parse planned order');
+    }
+    if (!symbol) {
+      await updateLimitOrderStatus(o.user_id, o.order_id, 'canceled');
+      continue;
+    }
+    try {
+      await cancelOrder(o.user_id, { symbol, orderId: Number(o.order_id) });
+      await updateLimitOrderStatus(o.user_id, o.order_id, 'canceled');
+    } catch (err) {
+      const msg = parseBinanceError(err);
+      if (msg && /UNKNOWN_ORDER/i.test(msg))
+        await updateLimitOrderStatus(o.user_id, o.order_id, 'filled');
+      else
+        log.error({ err, orderId: o.order_id }, 'failed to cancel order');
+    }
+  }
+}
 
 export default async function apiKeyRoutes(app: FastifyInstance) {
   app.post(
@@ -132,14 +166,10 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
       const agents = await getActivePortfolioWorkflowsByUser(id);
       for (const agent of agents) {
         removeWorkflowFromSchedule(agent.id);
-        const token1 = agent.tokens[0].token;
-        const token2 = agent.tokens[1].token;
         try {
-          await cancelOpenOrders(id, {
-            symbol: `${token1}${token2}`,
-          });
+          await cancelOrdersForAgent(agent.id, req.log);
         } catch (err) {
-          req.log.error({ err, agentId: agent.id }, 'failed to cancel open orders');
+          req.log.error({ err, agentId: agent.id }, 'failed to cancel orders');
         }
       }
       await draftAgentsByUser(id);
@@ -151,12 +181,10 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
           const tAgents = await getActivePortfolioWorkflowsByUser(targetId);
           for (const agent of tAgents) {
             removeWorkflowFromSchedule(agent.id);
-            const token1 = agent.tokens[0].token;
-            const token2 = agent.tokens[1].token;
             try {
-              await cancelOpenOrders(targetId, { symbol: `${token1}${token2}` });
+              await cancelOrdersForAgent(agent.id, req.log);
             } catch (err) {
-              req.log.error({ err, agentId: agent.id }, 'failed to cancel open orders');
+              req.log.error({ err, agentId: agent.id }, 'failed to cancel orders');
             }
           }
           await draftAgentsByUser(targetId);
@@ -209,12 +237,10 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
         const agents = await getActivePortfolioWorkflowsByUser(target.id);
         for (const agent of agents) {
           removeWorkflowFromSchedule(agent.id);
-          const token1 = agent.tokens[0].token;
-          const token2 = agent.tokens[1].token;
           try {
-            await cancelOpenOrders(target.id, { symbol: `${token1}${token2}` });
+            await cancelOrdersForAgent(agent.id, req.log);
           } catch (err) {
-            req.log.error({ err, agentId: agent.id }, 'failed to cancel open orders');
+            req.log.error({ err, agentId: agent.id }, 'failed to cancel orders');
           }
         }
         await draftAgentsByUser(target.id);
@@ -326,14 +352,10 @@ export default async function apiKeyRoutes(app: FastifyInstance) {
       const agents = await getActivePortfolioWorkflowsByUser(id);
       for (const agent of agents) {
         removeWorkflowFromSchedule(agent.id);
-        const token1 = agent.tokens[0].token;
-        const token2 = agent.tokens[1].token;
         try {
-          await cancelOpenOrders(id, {
-            symbol: `${token1}${token2}`,
-          });
+          await cancelOrdersForAgent(agent.id, req.log);
         } catch (err) {
-          req.log.error({ err, agentId: agent.id }, 'failed to cancel open orders');
+          req.log.error({ err, agentId: agent.id }, 'failed to cancel orders');
         }
       }
       await deactivateAgentsByUser(id);

--- a/backend/src/services/binance.ts
+++ b/backend/src/services/binance.ts
@@ -143,17 +143,22 @@ async function getUserCreds(id: string): Promise<UserCreds | null> {
   return { key, secret };
 }
 
-export function parseBinanceError(err: unknown): string | null {
+export function parseBinanceError(
+  err: unknown,
+): { code?: number; msg?: string } {
   if (err instanceof Error) {
     const match = err.message.match(/\{.+\}$/);
     if (match) {
       try {
         const body = JSON.parse(match[0]);
-        if (typeof body.msg === 'string') return body.msg;
+        const res: { code?: number; msg?: string } = {};
+        if (typeof body.code === 'number') res.code = body.code;
+        if (typeof body.msg === 'string') res.msg = body.msg;
+        return res;
       } catch {}
     }
   }
-  return null;
+  return {};
 }
 
 export async function fetchAccount(id: string) {

--- a/backend/src/services/rebalance.ts
+++ b/backend/src/services/rebalance.ts
@@ -101,8 +101,8 @@ export async function createRebalanceLimitOrder(opts: {
     });
     log.info({ step: 'createLimitOrder', orderId: res.orderId, order: params }, 'step success');
   } catch (err) {
-    const reason =
-      parseBinanceError(err) || (err instanceof Error ? err.message : 'unknown error');
+    const { msg } = parseBinanceError(err);
+    const reason = msg || (err instanceof Error ? err.message : 'unknown error');
     await insertLimitOrder({
       userId,
       planned: { ...params, manuallyEdited: manuallyEdited ?? false },
@@ -208,8 +208,8 @@ export async function createDecisionLimitOrders(opts: {
       });
       opts.log.info({ step: 'createLimitOrder', orderId: res.orderId }, 'step success');
     } catch (err) {
-      const reason =
-        parseBinanceError(err) || (err instanceof Error ? err.message : 'unknown error');
+      const { msg } = parseBinanceError(err);
+      const reason = msg || (err instanceof Error ? err.message : 'unknown error');
       await insertLimitOrder({
         userId: opts.userId,
         planned,

--- a/backend/src/workflows/portfolio-review.ts
+++ b/backend/src/workflows/portfolio-review.ts
@@ -109,8 +109,8 @@ async function cleanupOpenOrders(
           await updateLimitOrderStatus(o.user_id, o.order_id, 'canceled');
           log.info({ orderId: o.order_id }, 'canceled stale order');
         } catch (err) {
-          const msg = parseBinanceError(err);
-          if (msg && /UNKNOWN_ORDER/i.test(msg)) {
+          const { code } = parseBinanceError(err);
+          if (code === -2013) {
             await updateLimitOrderStatus(o.user_id, o.order_id, 'filled');
           } else {
             log.error({ err }, 'failed to cancel order');

--- a/backend/test/agents.test.ts
+++ b/backend/test/agents.test.ts
@@ -158,7 +158,7 @@ describe('agent routes', () => {
     const execId = await insertReviewResult({ portfolioId: id, log: '' });
     await insertLimitOrder({
       userId,
-      planned: {},
+      planned: { symbol: 'BTCETH' },
       status: 'open',
       reviewResultId: execId,
       orderId: '123',

--- a/backend/test/agents.test.ts
+++ b/backend/test/agents.test.ts
@@ -13,7 +13,7 @@ import {
   insertLimitOrder,
   getLimitOrdersByReviewResult,
 } from './repos/limit-orders.js';
-import { cancelOpenOrders } from '../src/services/binance.js';
+import { cancelOrder } from '../src/services/binance.js';
 import { authCookies } from './helpers.js';
 
 vi.mock('../src/workflows/portfolio-review.js', () => ({
@@ -25,7 +25,7 @@ vi.mock('../src/services/binance.js', async () => {
   const actual = await vi.importActual<typeof import('../src/services/binance.js')>(
     '../src/services/binance.js',
   );
-  return { ...actual, cancelOpenOrders: vi.fn().mockResolvedValue(undefined) };
+  return { ...actual, cancelOrder: vi.fn().mockResolvedValue(undefined) };
 });
 
 
@@ -174,7 +174,10 @@ describe('agent routes', () => {
     expect(deletedStatus).toBe('retired');
     expect(await getAgent(id)).toBeUndefined();
     expect(await getActivePortfolioWorkflowById(id)).toBeUndefined();
-    expect(cancelOpenOrders).toHaveBeenCalledWith(userId, { symbol: 'BTCETH' });
+    expect(cancelOrder).toHaveBeenCalledWith(userId, {
+      symbol: 'BTCETH',
+      orderId: 123,
+    });
     const execOrders = await getLimitOrdersByReviewResult(execId);
     expect(execOrders[0].status).toBe('canceled');
 

--- a/backend/test/deleteWorkflowOrders.test.ts
+++ b/backend/test/deleteWorkflowOrders.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+import buildServer from '../src/server.js';
+import { insertUserWithKeys } from './repos/users.js';
+import { insertAgent } from './repos/portfolio-workflow.js';
+import { insertReviewResult } from './repos/agent-review-result.js';
+import { insertLimitOrder } from './repos/limit-orders.js';
+import { getLimitOrdersByReviewResult } from '../src/repos/limit-orders.js';
+import { authCookies } from './helpers.js';
+
+vi.mock('../src/workflows/portfolio-review.js', () => ({
+  reviewAgentPortfolio: vi.fn(() => Promise.resolve()),
+  removeWorkflowFromSchedule: vi.fn(),
+}));
+
+const { cancelOpenOrders } = vi.hoisted(() => ({
+  cancelOpenOrders: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../src/services/binance.js', async () => {
+  const actual = await vi.importActual<typeof import('../src/services/binance.js')>(
+    '../src/services/binance.js',
+  );
+  return { ...actual, cancelOpenOrders };
+});
+
+describe('delete workflow cancels all orders', () => {
+  it('cancels open orders for all symbols', async () => {
+    const app = await buildServer();
+    const userId = await insertUserWithKeys('multi');
+    const agent = await insertAgent({
+      userId,
+      model: 'm',
+      status: 'active',
+      startBalance: null,
+      name: 'A',
+      tokens: [
+        { token: 'BTC', minAllocation: 10 },
+        { token: 'ETH', minAllocation: 20 },
+        { token: 'SOL', minAllocation: 30 },
+      ],
+      risk: 'low',
+      reviewInterval: '1h',
+      agentInstructions: 'inst',
+      manualRebalance: false,
+      useEarn: false,
+    });
+    const rrId = await insertReviewResult({ portfolioId: agent.id, log: '' });
+    await insertLimitOrder({
+      userId,
+      planned: { symbol: 'BTCETH' },
+      status: 'open',
+      reviewResultId: rrId,
+      orderId: '1',
+    });
+    await insertLimitOrder({
+      userId,
+      planned: { symbol: 'ETHSOL' },
+      status: 'open',
+      reviewResultId: rrId,
+      orderId: '2',
+    });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/portfolio-workflows/${agent.id}`,
+      cookies: authCookies(userId),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(cancelOpenOrders).toHaveBeenCalledWith(userId, { symbol: 'BTCETH' });
+    expect(cancelOpenOrders).toHaveBeenCalledWith(userId, { symbol: 'ETHSOL' });
+    expect(cancelOpenOrders).toHaveBeenCalledTimes(2);
+    const orders = await getLimitOrdersByReviewResult(agent.id, rrId);
+    expect(orders.map((o) => o.status)).toEqual(['canceled', 'canceled']);
+    await app.close();
+  });
+});

--- a/backend/test/deleteWorkflowOrders.test.ts
+++ b/backend/test/deleteWorkflowOrders.test.ts
@@ -12,15 +12,15 @@ vi.mock('../src/workflows/portfolio-review.js', () => ({
   removeWorkflowFromSchedule: vi.fn(),
 }));
 
-const { cancelOpenOrders } = vi.hoisted(() => ({
-  cancelOpenOrders: vi.fn().mockResolvedValue(undefined),
+const { cancelOrder } = vi.hoisted(() => ({
+  cancelOrder: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../src/services/binance.js', async () => {
   const actual = await vi.importActual<typeof import('../src/services/binance.js')>(
     '../src/services/binance.js',
   );
-  return { ...actual, cancelOpenOrders };
+  return { ...actual, cancelOrder };
 });
 
 describe('delete workflow cancels all orders', () => {
@@ -66,9 +66,15 @@ describe('delete workflow cancels all orders', () => {
       cookies: authCookies(userId),
     });
     expect(res.statusCode).toBe(200);
-    expect(cancelOpenOrders).toHaveBeenCalledWith(userId, { symbol: 'BTCETH' });
-    expect(cancelOpenOrders).toHaveBeenCalledWith(userId, { symbol: 'ETHSOL' });
-    expect(cancelOpenOrders).toHaveBeenCalledTimes(2);
+    expect(cancelOrder).toHaveBeenCalledWith(userId, {
+      symbol: 'BTCETH',
+      orderId: 1,
+    });
+    expect(cancelOrder).toHaveBeenCalledWith(userId, {
+      symbol: 'ETHSOL',
+      orderId: 2,
+    });
+    expect(cancelOrder).toHaveBeenCalledTimes(2);
     const orders = await getLimitOrdersByReviewResult(agent.id, rrId);
     expect(orders.map((o) => o.status)).toEqual(['canceled', 'canceled']);
     await app.close();

--- a/backend/test/reviewPortfolio.test.ts
+++ b/backend/test/reviewPortfolio.test.ts
@@ -103,7 +103,7 @@ vi.mock('../src/services/binance.js', () => ({
     minNotional: 0,
   }),
   cancelOrder: vi.fn().mockResolvedValue(undefined),
-  parseBinanceError: vi.fn().mockReturnValue(null),
+  parseBinanceError: vi.fn().mockReturnValue({}),
   fetchFearGreedIndex: vi
     .fn()
     .mockResolvedValue({ value: 50, classification: 'Neutral' }),


### PR DESCRIPTION
## Summary
- Cancel open limit orders on Binance for each symbol when a portfolio workflow is deleted
- Update tests to include symbol metadata and verify cancellation of all order symbols
- Add regression test ensuring deletion cancels open orders across multiple pairs

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6f2a9f264832ca711eec9e3200a6e