### PR TITLE
feat: enrich trader prompt with order book and sentiment

### DIFF
--- a/backend/src/agents/types.ts
+++ b/backend/src/agents/types.ts
@@ -55,6 +55,11 @@ export interface MarketTimeseries {
   ret_24m: number;
 }
 
+export interface OrderBookSnapshot {
+  bid: [number, number];
+  ask: [number, number];
+}
+
 export interface RebalancePosition {
   sym: string;
   qty: number;
@@ -98,6 +103,7 @@ export interface RebalancePrompt {
     indicators?: Record<string, TokenMetrics>;
     market_timeseries?: Record<string, MarketTimeseries>;
     fearGreedIndex?: { value: number; classification: string };
+    orderBooks?: Record<string, OrderBookSnapshot>;
     openInterest?: number;
     fundingRate?: number;
   };


### PR DESCRIPTION
## Summary
- include per-token order books and Fear & Greed index when building the technical analyst prompt
- surface order book snapshots and sentiment in marketData for main trader
- test technical analyst step for injecting order books and Fear & Greed data

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6f935c61c832cbda67c22a36568db