### PR TITLE
Add cancellation reasons for missing orders

### DIFF
--- a/backend/src/jobs/check-open-orders.ts
+++ b/backend/src/jobs/check-open-orders.ts
@@ -74,7 +74,12 @@ async function reconcileOrder(
         symbol,
         orderId: Number(o.order_id),
       });
-      await updateLimitOrderStatus(o.user_id, o.order_id, 'canceled');
+      await updateLimitOrderStatus(
+        o.user_id,
+        o.order_id,
+        'canceled',
+        'agent inactive',
+      );
     } catch (err) {
       const msg = parseBinanceError(err);
       if (msg && /UNKNOWN_ORDER/i.test(msg)) {

--- a/backend/src/repos/limit-orders.ts
+++ b/backend/src/repos/limit-orders.ts
@@ -27,15 +27,16 @@ export async function insertLimitOrder(entry: LimitOrderEntry): Promise<void> {
 
 export async function cancelOpenLimitOrdersByAgent(
   agentId: string,
+  reason?: string,
 ): Promise<void> {
   await db.query(
     `UPDATE limit_order e
-        SET status = 'canceled'
+        SET status = 'canceled', cancellation_reason = COALESCE($2, cancellation_reason)
        FROM agent_review_result r
       WHERE e.status = 'open'
         AND e.review_result_id = r.id
         AND r.agent_id = $1`,
-    [agentId],
+    [agentId, reason ?? null],
   );
 }
 

--- a/backend/src/workflows/portfolio-review.ts
+++ b/backend/src/workflows/portfolio-review.ts
@@ -106,7 +106,12 @@ async function cleanupOpenOrders(
             symbol: planned.symbol,
             orderId: Number(o.order_id),
           });
-          await updateLimitOrderStatus(o.user_id, o.order_id, 'canceled');
+          await updateLimitOrderStatus(
+            o.user_id,
+            o.order_id,
+            'canceled',
+            'could not fill within interval',
+          );
           log.info({ orderId: o.order_id }, 'canceled stale order');
         } catch (err) {
           const msg = parseBinanceError(err);

--- a/backend/test/agentExecLog.test.ts
+++ b/backend/test/agentExecLog.test.ts
@@ -108,6 +108,7 @@ describe('agent exec log routes', () => {
     });
     let row = await getLimitOrder('2');
     expect(row?.status).toBe('canceled');
+    expect(row?.cancellation_reason).toBe('canceled by user');
     res = await app.inject({
       method: 'POST',
       url: `/api/portfolio-workflows/${agent.id}/exec-log/${reviewResultId}/orders/2/cancel`,
@@ -116,6 +117,7 @@ describe('agent exec log routes', () => {
     expect(res.statusCode).toBe(403);
     row = await getLimitOrder('2');
     expect(row?.status).toBe('canceled');
+    expect(row?.cancellation_reason).toBe('canceled by user');
     spy.mockRestore();
     await app.close();
   });

--- a/backend/test/openOrdersCleanup.test.ts
+++ b/backend/test/openOrdersCleanup.test.ts
@@ -101,6 +101,7 @@ describe('cleanup open orders', () => {
     expect(cancelOrder).toHaveBeenCalledTimes(1);
     const orders = await getLimitOrdersByReviewResult(agent.id, rrId);
     expect(orders[0].status).toBe('canceled');
+    expect(orders[0].cancellation_reason).toBe('could not fill within interval');
   });
 
   it('cancels multiple open orders in parallel', async () => {
@@ -159,9 +160,23 @@ describe('cleanup open orders', () => {
     resolves.forEach((r) => r());
     await runPromise;
     const orders = await getLimitOrdersByReviewResult(agent.id, rrId);
-    expect(orders.map((o) => ({ order_id: o.order_id, status: o.status }))).toEqual([
-      { order_id: '123', status: 'canceled' },
-      { order_id: '456', status: 'canceled' },
+    expect(
+      orders.map((o) => ({
+        order_id: o.order_id,
+        status: o.status,
+        cancellation_reason: o.cancellation_reason,
+      })),
+    ).toEqual([
+      {
+        order_id: '123',
+        status: 'canceled',
+        cancellation_reason: 'could not fill within interval',
+      },
+      {
+        order_id: '456',
+        status: 'canceled',
+        cancellation_reason: 'could not fill within interval',
+      },
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- Include cancellation reasons when users cancel orders
- Mark stale orders with "could not fill within interval" during review
- Track reasons for agent or workflow-level order cancellations

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c778971540832cbc516700232da223