### PR TITLE
fix Google sign-in origin check

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -4,7 +4,7 @@
     header {
         Strict-Transport-Security "max-age=31536000; includeSubDomains"
         X-Content-Type-Options "nosniff"
-        Referrer-Policy "no-referrer"
+        Referrer-Policy "strict-origin-when-cross-origin"
         Content-Security-Policy "default-src 'self'; script-src 'self' https://accounts.google.com; style-src 'self' 'unsafe-inline' https://accounts.google.com; img-src 'self' data: https://accounts.google.com; connect-src 'self' https://api.binance.com https://accounts.google.com; font-src 'self' data:; frame-src https://accounts.google.com; frame-ancestors 'none'"
     }
 


### PR DESCRIPTION
## Summary
- relax Referrer-Policy to allow Google origin header

## Testing
- `pg_isready`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c79f06030c832c8facf82451dc9070