### PR TITLE
Handle cancel responses reporting fills

### DIFF
--- a/backend/src/repos/limit-orders.ts
+++ b/backend/src/repos/limit-orders.ts
@@ -104,7 +104,7 @@ export async function updateLimitOrderStatus(
   cancellationReason?: string,
 ) {
   await db.query(
-    `UPDATE limit_order SET status = $3, cancellation_reason = COALESCE($4, cancellation_reason) WHERE user_id = $1 AND order_id = $2`,
+    `UPDATE limit_order SET status = $3, cancellation_reason = $4 WHERE user_id = $1 AND order_id = $2`,
     [userId, orderId, status, cancellationReason ?? null],
   );
 }

--- a/backend/src/services/limit-order.ts
+++ b/backend/src/services/limit-order.ts
@@ -1,0 +1,32 @@
+import { cancelOrder, parseBinanceError } from './binance.js';
+import { updateLimitOrderStatus } from '../repos/limit-orders.js';
+
+export async function cancelLimitOrder(
+  userId: string,
+  opts: { symbol: string; orderId: string; reason: string },
+): Promise<'canceled' | 'filled'> {
+  try {
+    const res = await cancelOrder(userId, {
+      symbol: opts.symbol,
+      orderId: Number(opts.orderId),
+    });
+    if (res && res.status === 'FILLED') {
+      await updateLimitOrderStatus(userId, opts.orderId, 'filled');
+      return 'filled';
+    }
+    await updateLimitOrderStatus(
+      userId,
+      opts.orderId,
+      'canceled',
+      opts.reason,
+    );
+    return 'canceled';
+  } catch (err) {
+    const { code } = parseBinanceError(err);
+    if (code === -2013) {
+      await updateLimitOrderStatus(userId, opts.orderId, 'filled');
+      return 'filled';
+    }
+    throw err;
+  }
+}

--- a/backend/test/limitOrderStatus.test.ts
+++ b/backend/test/limitOrderStatus.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { insertUser } from './repos/users.js';
+import { insertAgent } from './repos/portfolio-workflow.js';
+import { insertReviewResult } from '../src/repos/agent-review-result.js';
+import {
+  insertLimitOrder,
+  getLimitOrder,
+} from './repos/limit-orders.js';
+import { updateLimitOrderStatus } from '../src/repos/limit-orders.js';
+
+/**
+ * Regression test for an issue where cancellation reason persisted
+ * after an order was filled.
+ */
+describe('updateLimitOrderStatus', () => {
+  it('clears cancellation reason when order is filled', async () => {
+    const userId = await insertUser('24');
+    const agent = await insertAgent({
+      userId,
+      model: 'gpt',
+      status: 'active',
+      startBalance: null,
+      name: 'A',
+      tokens: [
+        { token: 'BTC', minAllocation: 10 },
+        { token: 'ETH', minAllocation: 20 },
+      ],
+      risk: 'low',
+      reviewInterval: '1h',
+      agentInstructions: 'inst',
+      manualRebalance: false,
+      useEarn: true,
+    });
+    const reviewResultId = await insertReviewResult({
+      portfolioId: agent.id,
+      log: '',
+    });
+    await insertLimitOrder({
+      userId,
+      planned: { side: 'BUY', quantity: 1, price: 100, symbol: 'BTCETH' },
+      status: 'open',
+      reviewResultId,
+      orderId: '42',
+    });
+    await updateLimitOrderStatus(
+      userId,
+      '42',
+      'canceled',
+      'Could not fill within interval',
+    );
+    let row = await getLimitOrder('42');
+    expect(row?.status).toBe('canceled');
+    expect(row?.cancellation_reason).toBe('Could not fill within interval');
+    await updateLimitOrderStatus(userId, '42', 'filled');
+    row = await getLimitOrder('42');
+    expect(row?.status).toBe('filled');
+    expect(row?.cancellation_reason).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- handle Binance cancel responses that report orders already filled
- use shared helper to update limit-order status consistently across jobs and routes
- add regression tests for filled cancels

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7b63a8744832ca5cee31febd6ccdd