### PR TITLE
Fix cancel order status when Binance reports missing order

### DIFF
--- a/backend/test/collectPromptData.test.ts
+++ b/backend/test/collectPromptData.test.ts
@@ -51,6 +51,7 @@ vi.mock('../src/services/binance.js', () => ({
         minNotional: 10,
       });
     }),
+  fetchOrder: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../src/repos/agent-review-result.js', () => ({

--- a/backend/test/indicators.test.ts
+++ b/backend/test/indicators.test.ts
@@ -5,6 +5,7 @@ import { fetchPairData } from '../src/services/binance.js';
 vi.mock('../src/services/binance.js', () => ({
   fetchPairData: vi.fn(),
   fetchPairInfo: vi.fn().mockResolvedValue({ minNotional: 0 }),
+  fetchOrder: vi.fn().mockResolvedValue(undefined),
 }));
 
 describe('fetchTokenIndicators', () => {

--- a/backend/test/openOrdersCleanup.test.ts
+++ b/backend/test/openOrdersCleanup.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { insertUser } from './repos/users.js';
 import { insertAgent } from './repos/portfolio-workflow.js';
 import { insertReviewResult } from './repos/agent-review-result.js';
@@ -30,9 +30,10 @@ vi.mock('../src/util/crypto.js', () => ({
   decrypt: vi.fn().mockReturnValue('key'),
 }));
 
-const { cancelOrder, parseBinanceError } = vi.hoisted(() => ({
+const { cancelOrder, parseBinanceError, fetchOrder } = vi.hoisted(() => ({
   cancelOrder: vi.fn().mockResolvedValue(undefined),
   parseBinanceError: vi.fn().mockReturnValue({}),
+  fetchOrder: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock('../src/services/binance.js', () => ({
   fetchAccount: vi.fn().mockResolvedValue({
@@ -53,6 +54,7 @@ vi.mock('../src/services/binance.js', () => ({
   }),
   cancelOrder,
   parseBinanceError,
+  fetchOrder,
 }));
 
 vi.mock('../src/services/indicators.js', () => ({
@@ -64,6 +66,15 @@ vi.mock('../src/services/rebalance.js', () => ({
 }));
 
 describe('cleanup open orders', () => {
+  beforeEach(() => {
+    cancelOrder.mockReset();
+    cancelOrder.mockResolvedValue(undefined);
+    parseBinanceError.mockReset();
+    parseBinanceError.mockReturnValue({});
+    fetchOrder.mockReset();
+    fetchOrder.mockResolvedValue(undefined);
+  });
+
   it('cancels open orders before running agent', async () => {
     const userId = await insertUser('1');
     await setAiKey(userId, 'enc');
@@ -105,7 +116,6 @@ describe('cleanup open orders', () => {
   });
 
   it('cancels multiple open orders in parallel', async () => {
-    cancelOrder.mockReset();
     const resolves: (() => void)[] = [];
     cancelOrder.mockImplementation(
       () =>
@@ -166,9 +176,10 @@ describe('cleanup open orders', () => {
     ]);
   });
 
-  it('marks order filled when Binance reports unknown order', async () => {
+  it('marks order filled when Binance reports unknown order with filled status', async () => {
     cancelOrder.mockRejectedValueOnce(new Error('err'));
     parseBinanceError.mockReturnValueOnce({ code: -2013 });
+    fetchOrder.mockResolvedValueOnce({ status: 'FILLED' });
     const userId = await insertUser('1');
     await setAiKey(userId, 'enc');
     const agent = await insertAgent({
@@ -205,6 +216,50 @@ describe('cleanup open orders', () => {
     await reviewAgentPortfolio(log, agent.id);
     const orders = await getLimitOrdersByReviewResult(agent.id, rrId);
     expect(orders[0].status).toBe('filled');
+    expect(orders[0].cancellation_reason).toBeNull();
+  });
+
+  it('marks order canceled when Binance reports unknown order with canceled status', async () => {
+    cancelOrder.mockRejectedValueOnce(new Error('err'));
+    parseBinanceError.mockReturnValueOnce({ code: -2013 });
+    fetchOrder.mockResolvedValueOnce({ status: 'CANCELED' });
+    const userId = await insertUser('1');
+    await setAiKey(userId, 'enc');
+    const agent = await insertAgent({
+      userId,
+      model: 'gpt',
+      status: 'active',
+      startBalance: null,
+      name: 'A',
+      tokens: [
+        { token: 'BTC', minAllocation: 10 },
+        { token: 'ETH', minAllocation: 20 },
+      ],
+      risk: 'low',
+      reviewInterval: '1h',
+      agentInstructions: 'inst',
+      manualRebalance: false,
+      useEarn: false,
+    });
+    const rrId = await insertReviewResult({
+      portfolioId: agent.id,
+      log: 'log',
+      rebalance: true,
+      newAllocation: 50,
+      shortReport: 's',
+    });
+    await insertLimitOrder({
+      userId,
+      planned: { symbol: 'BTCETH', side: 'BUY', quantity: 1, price: 1 },
+      status: 'open',
+      reviewResultId: rrId,
+      orderId: '123',
+    });
+    const log = mockLogger();
+    await reviewAgentPortfolio(log, agent.id);
+    const orders = await getLimitOrdersByReviewResult(agent.id, rrId);
+    expect(orders[0].status).toBe('canceled');
+    expect(orders[0].cancellation_reason).toBe('Could not fill within interval');
   });
 
   it('marks order filled when cancel returns FILLED', async () => {

--- a/backend/test/rebalance.test.ts
+++ b/backend/test/rebalance.test.ts
@@ -17,6 +17,7 @@ vi.mock('../src/services/binance.js', () => ({
     minNotional: 0,
   }),
   createLimitOrder: vi.fn().mockResolvedValue({ orderId: 1 }),
+  fetchOrder: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { createRebalanceLimitOrder, createDecisionLimitOrders } from '../src/services/rebalance.js';

--- a/backend/test/reviewPortfolio.test.ts
+++ b/backend/test/reviewPortfolio.test.ts
@@ -107,6 +107,7 @@ vi.mock('../src/services/binance.js', () => ({
   fetchFearGreedIndex: vi
     .fn()
     .mockResolvedValue({ value: 50, classification: 'Neutral' }),
+  fetchOrder: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../src/services/indicators.js', () => ({

--- a/backend/test/technicalAnalyst.test.ts
+++ b/backend/test/technicalAnalyst.test.ts
@@ -34,6 +34,7 @@ vi.mock('../src/services/derivatives.js', () => ({
 }));
 vi.mock('../src/services/binance.js', () => ({
   fetchFearGreedIndex: fetchFearGreedIndexMock,
+  fetchOrder: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock('../src/repos/agent-review-raw-log.js', () => ({
   insertReviewRawLog: insertReviewRawLogMock,


### PR DESCRIPTION
## Summary
- add a Binance fetchOrder helper so we can retrieve the final status of an order after a cancel attempt
- update cancelLimitOrder to resolve -2013 errors by checking the fetched order status and recording canceled vs filled accordingly
- extend the open orders cleanup test suite (and supporting mocks) to cover the new behavior and ensure cancellation reasons persist

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test` *(fails: connect ECONNREFUSED)*
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68c914d312f8832c9bdef598acaf4bbe