### PR TITLE
Refine Binance service error handling

### DIFF
--- a/backend/src/services/limit-order.ts
+++ b/backend/src/services/limit-order.ts
@@ -1,4 +1,9 @@
-import { cancelOrder, fetchOrder, parseBinanceError } from './binance.js';
+import {
+  cancelOrder,
+  fetchOrder,
+  BinanceApiError,
+  BINANCE_ORDER_NOT_FOUND_CODE,
+} from './binance.js';
 import { updateLimitOrderStatus } from '../repos/limit-orders.js';
 
 export async function cancelLimitOrder(
@@ -22,8 +27,10 @@ export async function cancelLimitOrder(
     );
     return 'canceled';
   } catch (err) {
-    const { code } = parseBinanceError(err);
-    if (code === -2013) {
+    if (
+      err instanceof BinanceApiError &&
+      err.code === BINANCE_ORDER_NOT_FOUND_CODE
+    ) {
       try {
         const order = await fetchOrder(userId, {
           symbol: opts.symbol,

--- a/backend/src/services/rebalance.ts
+++ b/backend/src/services/rebalance.ts
@@ -5,7 +5,7 @@ import {
   fetchPairData,
   fetchPairInfo,
   createLimitOrder,
-  parseBinanceError,
+  BinanceApiError,
 } from './binance.js';
 import { TOKEN_SYMBOLS } from '../util/tokens.js';
 
@@ -110,8 +110,12 @@ export async function createRebalanceLimitOrder(opts: {
     });
     log.info({ step: 'createLimitOrder', orderId: res.orderId, order: params }, 'step success');
   } catch (err) {
-    const { msg } = parseBinanceError(err);
-    const reason = msg || (err instanceof Error ? err.message : 'unknown error');
+    const reason =
+      err instanceof BinanceApiError
+        ? err.binanceMsg ?? err.message
+        : err instanceof Error
+          ? err.message
+          : 'unknown error';
     await insertLimitOrder({
       userId,
       planned: { ...params, manuallyEdited: manuallyEdited ?? false },
@@ -327,8 +331,12 @@ export async function createDecisionLimitOrders(opts: {
       });
       opts.log.info({ step: 'createLimitOrder', orderId: res.orderId }, 'step success');
     } catch (err) {
-      const { msg } = parseBinanceError(err);
-      const reason = msg || (err instanceof Error ? err.message : 'unknown error');
+      const reason =
+        err instanceof BinanceApiError
+          ? err.binanceMsg ?? err.message
+          : err instanceof Error
+            ? err.message
+            : 'unknown error';
       await insertLimitOrder({
         userId: opts.userId,
         planned,

--- a/backend/test/agentExecLog.test.ts
+++ b/backend/test/agentExecLog.test.ts
@@ -667,11 +667,14 @@ describe('agent exec log routes', () => {
       pricePrecision: 8,
       minNotional: 0,
     } as any);
-    vi.spyOn(binance, 'createLimitOrder').mockRejectedValue(
-      new Error(
-        'failed to create order: 401 {"code":-2015,"msg":"Invalid API-key, IP, or permissions for action."}',
-      ),
-    );
+    vi
+      .spyOn(binance, 'createLimitOrder')
+      .mockRejectedValue(
+        new binance.BinanceApiError('failed to create order', 401, {
+          code: -2015,
+          msg: 'Invalid API-key, IP, or permissions for action.',
+        }),
+      );
     const res = await app.inject({
       method: 'POST',
       url: `/api/portfolio-workflows/${agent.id}/exec-log/${reviewResultId}/rebalance`,

--- a/backend/test/reviewPortfolio.test.ts
+++ b/backend/test/reviewPortfolio.test.ts
@@ -85,30 +85,36 @@ vi.mock('../src/util/crypto.js', () => ({
   decrypt: vi.fn().mockReturnValue('key'),
 }));
 
-vi.mock('../src/services/binance.js', () => ({
-  fetchAccount: vi.fn().mockResolvedValue({
-    balances: [
-      { asset: 'BTC', free: '1', locked: '0.5' },
-      { asset: 'ETH', free: '2', locked: '0' },
-    ],
-  }),
-  fetchPairData: vi.fn().mockResolvedValue({ symbol: 'BTCUSDT', currentPrice: 100 }),
-  fetchMarketTimeseries: vi.fn().mockResolvedValue(sampleTimeseries),
-  fetchPairInfo: vi.fn().mockResolvedValue({
-    symbol: 'BTCETH',
-    baseAsset: 'BTC',
-    quoteAsset: 'ETH',
-    quantityPrecision: 8,
-    pricePrecision: 8,
-    minNotional: 0,
-  }),
-  cancelOrder: vi.fn().mockResolvedValue(undefined),
-  parseBinanceError: vi.fn().mockReturnValue({}),
-  fetchFearGreedIndex: vi
-    .fn()
-    .mockResolvedValue({ value: 50, classification: 'Neutral' }),
-  fetchOrder: vi.fn().mockResolvedValue(undefined),
-}));
+vi.mock('../src/services/binance.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('../src/services/binance.js')
+  >('../src/services/binance.js');
+  return {
+    fetchAccount: vi.fn().mockResolvedValue({
+      balances: [
+        { asset: 'BTC', free: '1', locked: '0.5' },
+        { asset: 'ETH', free: '2', locked: '0' },
+      ],
+    }),
+    fetchPairData: vi.fn().mockResolvedValue({ symbol: 'BTCUSDT', currentPrice: 100 }),
+    fetchMarketTimeseries: vi.fn().mockResolvedValue(sampleTimeseries),
+    fetchPairInfo: vi.fn().mockResolvedValue({
+      symbol: 'BTCETH',
+      baseAsset: 'BTC',
+      quoteAsset: 'ETH',
+      quantityPrecision: 8,
+      pricePrecision: 8,
+      minNotional: 0,
+    }),
+    cancelOrder: vi.fn().mockResolvedValue(undefined),
+    fetchFearGreedIndex: vi
+      .fn()
+      .mockResolvedValue({ value: 50, classification: 'Neutral' }),
+    fetchOrder: vi.fn().mockResolvedValue(undefined),
+    BinanceApiError: actual.BinanceApiError,
+    BINANCE_ORDER_NOT_FOUND_CODE: actual.BINANCE_ORDER_NOT_FOUND_CODE,
+  };
+});
 
 vi.mock('../src/services/indicators.js', () => ({
   fetchTokenIndicators: vi.fn().mockResolvedValue(sampleIndicators),


### PR DESCRIPTION
## Summary
- introduce a BinanceApiError helper so REST failures expose codes and messages without string parsing
- update Binance service calls to parse error responses directly and retry invalid symbols using error codes
- adjust limit order/rebalance workflows and related tests to consume the new error objects

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68c91f610638832c8fd9531fe383c5d3