### PR TITLE
Update workflow edit button labels

### DIFF
--- a/frontend/src/lib/i18n.tsx
+++ b/frontend/src/lib/i18n.tsx
@@ -143,7 +143,7 @@ const translations: Record<Lang, Record<string, string>> = {
       'Trading portfolio workflow will use all available balance for {tokens} in your Binance Spot wallet. Move excess funds to futures wallet before trading.',
     dont_move_funds_warning:
       "DON'T MOVE FUNDS FROM SPOT WALLET DURING TRADING! It will confuse the trading agent and may lead to unexpected results.",
-    update_agent: 'Update Workflow',
+    update_agent: 'Edit Workflow',
     failed_update_agent: 'Failed to update portfolio workflow',
     update_running_agent_prompt: 'Update running portfolio workflow?',
     update_agent_prompt: 'Update portfolio workflow?',
@@ -311,7 +311,7 @@ const translations: Record<Lang, Record<string, string>> = {
       'Торговое управление портфолио использует весь доступный баланс для {tokens} на вашем Binance Spot кошельке. Перед началом торговли переместите лишние средства на фьючерсный кошелёк.',
     dont_move_funds_warning:
       'НЕ ПЕРЕВОДИТЕ СРЕДСТВА СО SPOT-КОШЕЛКА ВО ВРЕМЯ ТОРГОВЛИ! Это собьёт торгового агента и может привести к непредсказуемым результатам.',
-    update_agent: 'Обновить портфолио',
+    update_agent: 'Редактировать портфолио',
     failed_update_agent: 'Не удалось обновить портфолио',
     update_running_agent_prompt: 'Обновить активное портфолио?',
     update_agent_prompt: 'Обновить портфолио?',

--- a/frontend/src/routes/AgentView.tsx
+++ b/frontend/src/routes/AgentView.tsx
@@ -77,7 +77,10 @@ export default function AgentView() {
         </div>
         {isActive ? (
           <div className="mt-4 flex gap-2">
-            <Button onClick={() => setShowUpdate(true)}>{t('update_agent')}</Button>
+            <Button onClick={() => setShowUpdate(true)}>
+              <span className="hidden md:inline">{t('update_agent')}</span>
+              <span className="md:hidden">{t('edit')}</span>
+            </Button>
             <Button
               disabled={stopMut.isPending}
               loading={stopMut.isPending}
@@ -95,7 +98,10 @@ export default function AgentView() {
           </div>
         ) : (
           <div className="mt-4 flex gap-2">
-            <Button onClick={() => setShowUpdate(true)}>{t('update_agent')}</Button>
+            <Button onClick={() => setShowUpdate(true)}>
+              <span className="hidden md:inline">{t('update_agent')}</span>
+              <span className="md:hidden">{t('edit')}</span>
+            </Button>
             {hasOpenAIKey && hasBinanceKey && (
               <Button
                 disabled={startMut.isPending}


### PR DESCRIPTION
## Summary
- rename the workflow action button label to "Edit Workflow"
- shorten the label to "Edit" on mobile screens for better fit

## Testing
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68c97435e940832cb7e2b72eb58c470a