### PR TITLE
Add typing rules to agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,10 @@ relevant directory to save time.
 
 ### General
 - Pin all `package.json` dependencies to exact versions. Do not use `^` or `~` ranges.
+- Typing rules:
+  - Keep shared types for a directory in a `types.ts` file within that folder.
+  - When a type is used only inside a single file, define the interface at the top of that file.
+  - Use `interface` declarations for object shapes instead of `type` aliases.
 
 ## Backend
 


### PR DESCRIPTION
## Summary
- document how to store shared types in per-folder `types.ts` files
- note that file-local types should live at the top of the module
- specify that interfaces should be used for object shapes

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c98a5d025c832c995a1a248a0c8348