### PR TITLE
Fix open order reconciliation to verify Binance status

### DIFF
--- a/backend/src/jobs/check-open-orders.ts
+++ b/backend/src/jobs/check-open-orders.ts
@@ -3,7 +3,12 @@ import {
   getAllOpenLimitOrders,
   updateLimitOrderStatus,
 } from '../repos/limit-orders.js';
-import { fetchOpenOrders, type OpenOrder } from '../services/binance.js';
+import {
+  fetchOpenOrders,
+  fetchOrder,
+  parseBinanceError,
+  type OpenOrder,
+} from '../services/binance.js';
 import { cancelLimitOrder } from '../services/limit-order.js';
 
 interface Order {
@@ -16,6 +21,14 @@ interface Order {
 interface GroupedOrder extends Order {
   planned: { symbol: string };
 }
+
+const CLOSED_ORDER_STATUSES = new Set([
+  'CANCELED',
+  'PENDING_CANCEL',
+  'EXPIRED',
+  'REJECTED',
+  'EXPIRED_IN_MATCH',
+]);
 
 export default async function checkOpenOrders(log: FastifyBaseLogger) {
   const orders = await getAllOpenLimitOrders();
@@ -53,6 +66,48 @@ async function reconcileGroup(log: FastifyBaseLogger, list: GroupedOrder[]) {
   }
 }
 
+async function resolveClosedStatus(
+  log: FastifyBaseLogger,
+  order: GroupedOrder,
+  symbol: string,
+): Promise<'filled' | 'canceled' | null> {
+  const orderId = Number(order.order_id);
+  if (!Number.isFinite(orderId)) {
+    log.error(
+      { orderId: order.order_id },
+      'invalid order id while reconciling limit order',
+    );
+    return null;
+  }
+
+  try {
+    const res = await fetchOrder(order.user_id, { symbol, orderId });
+    if (!res || !res.status) {
+      log.error(
+        { orderId: order.order_id },
+        'missing Binance order status while reconciling',
+      );
+      return null;
+    }
+    const status = res.status.toUpperCase();
+    if (status === 'FILLED') return 'filled';
+    if (CLOSED_ORDER_STATUSES.has(status)) return 'canceled';
+    log.error(
+      { orderId: order.order_id, status },
+      'unexpected Binance order status while reconciling',
+    );
+    return null;
+  } catch (err) {
+    const { code } = parseBinanceError(err);
+    if (code === -2013) return 'canceled';
+    log.error(
+      { err, orderId: order.order_id },
+      'failed to fetch Binance order while reconciling',
+    );
+    return null;
+  }
+}
+
 async function reconcileOrder(
   log: FastifyBaseLogger,
   o: GroupedOrder,
@@ -61,7 +116,12 @@ async function reconcileOrder(
 ) {
   const exists = open.some((r) => String(r.orderId) === o.order_id);
   if (!exists) {
-    await updateLimitOrderStatus(o.user_id, o.order_id, 'filled');
+    const status = await resolveClosedStatus(log, o, symbol);
+    if (status === 'filled') {
+      await updateLimitOrderStatus(o.user_id, o.order_id, 'filled');
+    } else if (status === 'canceled') {
+      await updateLimitOrderStatus(o.user_id, o.order_id, 'canceled');
+    }
     return;
   }
   if (o.agent_status !== 'active') {

--- a/backend/test/checkOpenOrders.test.ts
+++ b/backend/test/checkOpenOrders.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import checkOpenOrders from '../src/jobs/check-open-orders.js';
+import { insertUser } from './repos/users.js';
+import { insertAgent } from './repos/portfolio-workflow.js';
+import { insertReviewResult } from './repos/agent-review-result.js';
+import {
+  insertLimitOrder,
+  getLimitOrder,
+} from './repos/limit-orders.js';
+import { mockLogger } from './helpers.js';
+
+const { fetchOpenOrders, fetchOrder, parseBinanceError } = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(),
+  fetchOrder: vi.fn(),
+  parseBinanceError: vi.fn(),
+}));
+
+vi.mock('../src/services/binance.js', () => ({
+  fetchOpenOrders,
+  fetchOrder,
+  parseBinanceError,
+}));
+
+vi.mock('../src/services/limit-order.js', () => ({
+  cancelLimitOrder: vi.fn(),
+}));
+
+describe('checkOpenOrders job', () => {
+  beforeEach(() => {
+    fetchOpenOrders.mockReset();
+    fetchOrder.mockReset();
+    parseBinanceError.mockReset();
+    fetchOpenOrders.mockResolvedValue([]);
+    parseBinanceError.mockReturnValue({});
+  });
+
+  async function setupOrder(orderId = '123') {
+    const userId = await insertUser('user-1');
+    const agent = await insertAgent({
+      userId,
+      model: 'gpt',
+      status: 'active',
+      startBalance: null,
+      name: 'A',
+      tokens: [
+        { token: 'SOL', minAllocation: 10 },
+        { token: 'USDT', minAllocation: 10 },
+      ],
+      risk: 'low',
+      reviewInterval: '1h',
+      agentInstructions: 'inst',
+      manualRebalance: false,
+      useEarn: false,
+    });
+    const reviewResultId = await insertReviewResult({
+      portfolioId: agent.id,
+      log: 'log',
+      rebalance: true,
+      newAllocation: 50,
+      shortReport: 's',
+    });
+    await insertLimitOrder({
+      userId,
+      planned: { symbol: 'SOLUSDT', side: 'BUY', quantity: 0.1, price: 10 },
+      status: 'open',
+      reviewResultId,
+      orderId,
+    });
+    return { orderId };
+  }
+
+  it('marks missing orders as canceled when Binance reports cancellation', async () => {
+    const { orderId } = await setupOrder();
+    fetchOrder.mockResolvedValueOnce({ status: 'CANCELED' });
+
+    await checkOpenOrders(mockLogger());
+
+    const order = await getLimitOrder(orderId);
+    expect(order?.status).toBe('canceled');
+  });
+
+  it('marks missing orders as filled when Binance reports filled status', async () => {
+    const { orderId } = await setupOrder('456');
+    fetchOrder.mockResolvedValueOnce({ status: 'FILLED' });
+
+    await checkOpenOrders(mockLogger());
+
+    const order = await getLimitOrder(orderId);
+    expect(order?.status).toBe('filled');
+  });
+
+  it('marks missing orders as canceled when Binance returns unknown order error', async () => {
+    const { orderId } = await setupOrder('789');
+    fetchOrder.mockRejectedValueOnce(new Error('err'));
+    parseBinanceError.mockReturnValueOnce({ code: -2013 });
+
+    await checkOpenOrders(mockLogger());
+
+    const order = await getLimitOrder(orderId);
+    expect(order?.status).toBe('canceled');
+  });
+});


### PR DESCRIPTION
## Summary
- fetch the Binance order status before reconciling missing open orders so fills and cancellations are recorded correctly
- guard against invalid order ids and treat Binance closed statuses as cancellations when reconciling
- add unit tests that cover filled, canceled, and unknown-order responses for the open-order check job

## Testing
- DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test
- npm --prefix backend run build

------
https://chatgpt.com/codex/tasks/task_e_68c996ae2638832cb1d8aa9f3e7d8b1f