### PR TITLE
Normalize repo outputs to camelCase

### DIFF
--- a/backend/src/agents/main-trader.ts
+++ b/backend/src/agents/main-trader.ts
@@ -161,15 +161,15 @@ export async function collectPromptData(
   for (const r of prevRows) {
     const ordersRows = await getLimitOrdersByReviewResult(row.id, r.id);
     const orders = ordersRows.map((o) => {
-      const planned = JSON.parse(o.planned_json);
+      const planned = JSON.parse(o.plannedJson);
       return {
         symbol: planned.symbol,
         side: planned.side,
         quantity: planned.quantity,
         status: o.status,
-        datetime: o.created_at.toISOString(),
-        ...(o.cancellation_reason
-          ? { cancellationReason: o.cancellation_reason }
+        datetime: o.createdAt.toISOString(),
+        ...(o.cancellationReason
+          ? { cancellationReason: o.cancellationReason }
           : {}),
       } as const;
     });

--- a/backend/src/repos/exchange-api-keys.ts
+++ b/backend/src/repos/exchange-api-keys.ts
@@ -1,4 +1,5 @@
 import { db } from '../db/index.js';
+import { convertKeysToCamelCase } from '../util/objectCase.js';
 import type {
   BinanceApiKey,
   BinanceApiKeyUpsert,
@@ -8,26 +9,25 @@ export async function getBinanceKeyRow(
   id: string,
 ): Promise<BinanceApiKey | undefined> {
   const { rows } = await db.query(
-    `SELECT ek.id AS "id",
-            ek.api_key_enc AS "binanceApiKeyEnc",
-            ek.api_secret_enc AS "binanceApiSecretEnc"
+    `SELECT ek.id,
+            ek.api_key_enc AS binance_api_key_enc,
+            ek.api_secret_enc AS binance_api_secret_enc
        FROM users u
        LEFT JOIN exchange_keys ek ON ek.user_id = u.id AND ek.provider = 'binance'
       WHERE u.id = $1`,
     [id],
   );
-  const row = rows[0] as
-    | {
-        id: string | null;
-        binanceApiKeyEnc: string | null;
-        binanceApiSecretEnc: string | null;
-      }
-    | undefined;
+  const row = rows[0];
   if (!row) return undefined;
+  const entity = convertKeysToCamelCase(row) as {
+    id: string | null;
+    binanceApiKeyEnc: string | null;
+    binanceApiSecretEnc: string | null;
+  };
   return {
-    id: row.id ?? null,
-    binanceApiKeyEnc: row.binanceApiKeyEnc ?? null,
-    binanceApiSecretEnc: row.binanceApiSecretEnc ?? null,
+    id: entity.id ?? null,
+    binanceApiKeyEnc: entity.binanceApiKeyEnc ?? null,
+    binanceApiSecretEnc: entity.binanceApiSecretEnc ?? null,
   };
 }
 

--- a/backend/src/repos/limit-orders.types.ts
+++ b/backend/src/repos/limit-orders.types.ts
@@ -1,0 +1,29 @@
+export type LimitOrderStatus = 'open' | 'filled' | 'canceled';
+
+export interface LimitOrderInsert {
+  userId: string;
+  planned: Record<string, unknown>;
+  status: LimitOrderStatus;
+  reviewResultId: string;
+  orderId: string;
+  cancellationReason?: string;
+}
+
+export interface LimitOrderByReviewResult {
+  plannedJson: string;
+  status: LimitOrderStatus;
+  createdAt: Date;
+  orderId: string;
+  cancellationReason: string | null;
+}
+
+export interface LimitOrderOpenWorkflow {
+  userId: string;
+  orderId: string;
+  plannedJson: string;
+}
+
+export interface LimitOrderOpen extends LimitOrderOpenWorkflow {
+  portfolioWorkflowId: string;
+  workflowStatus: string;
+}

--- a/backend/src/repos/news.types.ts
+++ b/backend/src/repos/news.types.ts
@@ -1,0 +1,12 @@
+export interface NewsInsert {
+  title: string;
+  link: string;
+  pubDate?: string;
+  tokens: string[];
+}
+
+export interface NewsEntry {
+  title: string;
+  link: string;
+  pubDate: string | null;
+}

--- a/backend/src/routes/helpers/api-key-helpers.ts
+++ b/backend/src/routes/helpers/api-key-helpers.ts
@@ -1,6 +1,9 @@
 import type { FastifyBaseLogger } from 'fastify';
 import { z } from 'zod';
-import { getOpenLimitOrdersForWorkflow, updateLimitOrderStatus } from '../../repos/limit-orders.js';
+import {
+  getOpenLimitOrdersForWorkflow,
+  updateLimitOrderStatus,
+} from '../../repos/limit-orders.js';
 import { cancelLimitOrder } from '../../services/limit-order.js';
 
 export const userIdParams = z.object({ id: z.string().regex(/^\d+$/) });
@@ -13,28 +16,28 @@ export async function cancelOrdersForWorkflow(
   for (const order of openOrders) {
     let symbol: string | undefined;
     try {
-      const planned = JSON.parse(order.planned_json);
+      const planned = JSON.parse(order.plannedJson);
       if (typeof planned.symbol === 'string') symbol = planned.symbol;
     } catch (err) {
-      log.error({ err, orderId: order.order_id }, 'failed to parse planned order');
+      log.error({ err, orderId: order.orderId }, 'failed to parse planned order');
     }
     if (!symbol) {
       await updateLimitOrderStatus(
-        order.user_id,
-        order.order_id,
+        order.userId,
+        order.orderId,
         'canceled',
         'API key removed',
       );
       continue;
     }
     try {
-      await cancelLimitOrder(order.user_id, {
+      await cancelLimitOrder(order.userId, {
         symbol,
-        orderId: order.order_id,
+        orderId: order.orderId,
         reason: 'API key removed',
       });
     } catch (err) {
-      log.error({ err, orderId: order.order_id }, 'failed to cancel order');
+      log.error({ err, orderId: order.orderId }, 'failed to cancel order');
     }
   }
 }

--- a/backend/src/services/rebalance.ts
+++ b/backend/src/services/rebalance.ts
@@ -1,5 +1,6 @@
 import type { FastifyBaseLogger } from 'fastify';
-import { insertLimitOrder, type LimitOrderStatus } from '../repos/limit-orders.js';
+import { insertLimitOrder } from '../repos/limit-orders.js';
+import type { LimitOrderStatus } from '../repos/limit-orders.types.js';
 import type { MainTraderOrder } from '../agents/main-trader.js';
 import {
   fetchPairData,

--- a/backend/src/util/objectCase.ts
+++ b/backend/src/util/objectCase.ts
@@ -1,6 +1,6 @@
-import camelCase from 'lodash/camelCase.js';
-import isPlainObject from 'lodash/isPlainObject.js';
-import snakeCase from 'lodash/snakeCase.js';
+import lodash from 'lodash';
+
+const { camelCase, isPlainObject, snakeCase } = lodash;
 
 type KeyConverter = (value: string) => string;
 

--- a/backend/src/workflows/portfolio-review.ts
+++ b/backend/src/workflows/portfolio-review.ts
@@ -93,15 +93,15 @@ async function cleanupOpenOrders(
   await Promise.all(
     orders.map((o) =>
       limit(async () => {
-        const planned = JSON.parse(o.planned_json);
+        const planned = JSON.parse(o.plannedJson);
         try {
-          const res = await cancelLimitOrder(o.user_id, {
+          const res = await cancelLimitOrder(o.userId, {
             symbol: planned.symbol,
-            orderId: o.order_id,
+            orderId: o.orderId,
             reason: 'Could not fill within interval',
           });
           log.info(
-            { orderId: o.order_id },
+            { orderId: o.orderId },
             res === 'canceled' ? 'canceled stale order' : 'order already filled',
           );
         } catch (err) {

--- a/backend/test/collectPromptData.test.ts
+++ b/backend/test/collectPromptData.test.ts
@@ -69,11 +69,11 @@ vi.mock('../src/repos/limit-orders.js', () => ({
     const i = Number(reviewId.slice(1));
     return [
       {
-        planned_json: JSON.stringify({ symbol: 'BTCUSDT', side: 'BUY', quantity: i }),
+        plannedJson: JSON.stringify({ symbol: 'BTCUSDT', side: 'BUY', quantity: i }),
         status: 'filled',
-        created_at: new Date(`2025-01-0${i}T00:00:00.000Z`),
-        order_id: String(i),
-        cancellation_reason: 'price limit',
+        createdAt: new Date(`2025-01-0${i}T00:00:00.000Z`),
+        orderId: String(i),
+        cancellationReason: 'price limit',
       },
     ];
   }),

--- a/backend/test/openOrdersCleanup.test.ts
+++ b/backend/test/openOrdersCleanup.test.ts
@@ -213,7 +213,7 @@ describe('cleanup open orders', () => {
     await reviewAgentPortfolio(log, agent.id);
     const orders = await getLimitOrdersByReviewResult(agent.id, rrId);
     expect(orders[0].status).toBe('filled');
-    expect(orders[0].cancellation_reason).toBeNull();
+    expect(orders[0].cancellationReason).toBeNull();
   });
 
   it('marks order canceled when Binance reports unknown order with canceled status', async () => {
@@ -255,7 +255,7 @@ describe('cleanup open orders', () => {
     await reviewAgentPortfolio(log, agent.id);
     const orders = await getLimitOrdersByReviewResult(agent.id, rrId);
     expect(orders[0].status).toBe('canceled');
-    expect(orders[0].cancellation_reason).toBe('Could not fill within interval');
+    expect(orders[0].cancellationReason).toBe('Could not fill within interval');
   });
 
   it('marks order filled when cancel returns FILLED', async () => {
@@ -295,6 +295,6 @@ describe('cleanup open orders', () => {
     await reviewAgentPortfolio(log, agent.id);
     const orders = await getLimitOrdersByReviewResult(agent.id, rrId);
     expect(orders[0].status).toBe('filled');
-    expect(orders[0].cancellation_reason).toBeNull();
+    expect(orders[0].cancellationReason).toBeNull();
   });
 });

--- a/backend/test/openOrdersCleanup.test.ts
+++ b/backend/test/openOrdersCleanup.test.ts
@@ -168,9 +168,9 @@ describe('cleanup open orders', () => {
     resolves.forEach((r) => r());
     await runPromise;
     const orders = await getLimitOrdersByReviewResult(agent.id, rrId);
-    expect(orders.map((o) => ({ order_id: o.order_id, status: o.status }))).toEqual([
-      { order_id: '123', status: 'canceled' },
-      { order_id: '456', status: 'canceled' },
+    expect(orders.map((o) => ({ orderId: o.orderId, status: o.status }))).toEqual([
+      { orderId: '123', status: 'canceled' },
+      { orderId: '456', status: 'canceled' },
     ]);
   });
 


### PR DESCRIPTION
## Summary
- return camelCased records from the limit order repository with new typed contracts and adjust callers to parse `plannedJson`
- use the shared camelCase conversion helper for news, AI API key, and exchange key repositories instead of camelCase SQL aliases
- update jobs, routes, services, and tests that consumed snake_case limit order fields to the new camelCase properties

## Testing
- DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test
- npm --prefix backend run build

------
https://chatgpt.com/codex/tasks/task_e_68cae795d7ec832c98d9ca67dc20e7f6