### PR TITLE
Use camelCase repo types for users and identities

### DIFF
--- a/backend/src/repos/user-identities.types.ts
+++ b/backend/src/repos/user-identities.types.ts
@@ -1,0 +1,7 @@
+export interface UserIdentityDetails {
+  id: string;
+  role: string;
+  isEnabled: boolean;
+  totpSecret?: string;
+  isTotpEnabled?: boolean;
+}

--- a/backend/src/repos/users.types.ts
+++ b/backend/src/repos/users.types.ts
@@ -1,0 +1,26 @@
+export interface UserDetails {
+  totpSecret?: string;
+  isTotpEnabled?: boolean;
+  role: string;
+  isEnabled: boolean;
+}
+
+export interface UserDetailsWithId extends UserDetails {
+  id: string;
+}
+
+export interface UserAuthInfo {
+  email?: string;
+  role: string;
+  isEnabled: boolean;
+}
+
+export interface UserListEntry {
+  id: string;
+  role: string;
+  isEnabled: boolean;
+  emailEnc?: string;
+  createdAt: string;
+  hasAiKey: boolean;
+  hasBinanceKey: boolean;
+}

--- a/backend/src/routes/login.ts
+++ b/backend/src/routes/login.ts
@@ -85,7 +85,7 @@ export default async function loginRoutes(app: FastifyInstance) {
       }
       id = row.id;
       if (emailEnc) await setUserEmail(id, emailEnc);
-      if (!row.is_enabled) {
+      if (!row.isEnabled) {
         return reply.code(403).send(errorResponse('user disabled'));
       }
       const err = validateOtp(row, body.otp);
@@ -104,7 +104,7 @@ export default async function loginRoutes(app: FastifyInstance) {
       const info = await getUserAuthInfo(id);
       if (!info)
         return reply.code(404).send(errorResponse('user not found'));
-      if (!info.is_enabled)
+      if (!info.isEnabled)
         return reply.code(403).send(errorResponse('user disabled'));
       return { id, email: info.email, role: info.role };
     },
@@ -112,12 +112,12 @@ export default async function loginRoutes(app: FastifyInstance) {
 }
 
 function validateOtp(
-  row: { totp_secret?: string; is_totp_enabled?: boolean },
+  row: { totpSecret?: string; isTotpEnabled?: boolean },
   otp: string | undefined,
 ): ValidationErr | null {
-  if (row.is_totp_enabled && row.totp_secret) {
+  if (row.isTotpEnabled && row.totpSecret) {
     if (!otp) return { code: 401, body: errorResponse('otp required') };
-    const valid = authenticator.verify({ token: otp, secret: row.totp_secret });
+    const valid = authenticator.verify({ token: otp, secret: row.totpSecret });
     if (!valid) return { code: 401, body: errorResponse('invalid otp') };
   }
   return null;

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -21,11 +21,11 @@ export default async function usersRoutes(app: FastifyInstance) {
       return rows.map((u) => ({
         id: u.id,
         role: u.role,
-        isEnabled: !!u.is_enabled,
-        email: u.email_enc ? decrypt(u.email_enc, env.KEY_PASSWORD) : null,
-        createdAt: u.created_at,
-        hasAiKey: u.has_ai_key,
-        hasBinanceKey: u.has_binance_key,
+        isEnabled: u.isEnabled,
+        email: u.emailEnc ? decrypt(u.emailEnc, env.KEY_PASSWORD) : null,
+        createdAt: u.createdAt,
+        hasAiKey: u.hasAiKey,
+        hasBinanceKey: u.hasBinanceKey,
       }));
     },
   );

--- a/backend/src/util/auth.ts
+++ b/backend/src/util/auth.ts
@@ -40,7 +40,7 @@ export async function requireAdmin(
   const userId = requireUserId(req, reply);
   if (!userId) return null;
   const row = await getUser(userId);
-  if (!row || row.role !== 'admin' || !row.is_enabled) {
+  if (!row || row.role !== 'admin' || !row.isEnabled) {
     reply.code(403).send(errorResponse(ERROR_MESSAGES.forbidden));
     return null;
   }

--- a/backend/test/adminUsers.test.ts
+++ b/backend/test/adminUsers.test.ts
@@ -67,7 +67,7 @@ describe('admin user routes', () => {
     });
     expect(resDisable.statusCode).toBe(200);
     let row = await getUser(userId);
-    expect(row?.is_enabled).toBe(false);
+    expect(row?.isEnabled).toBe(false);
 
     const resEnable = await app.inject({
       method: 'POST',
@@ -76,7 +76,7 @@ describe('admin user routes', () => {
     });
     expect(resEnable.statusCode).toBe(200);
     row = await getUser(userId);
-    expect(row?.is_enabled).toBe(true);
+    expect(row?.isEnabled).toBe(true);
 
     await app.close();
   });


### PR DESCRIPTION
## Summary
- convert user and identity repository payload types to camelCase and map database rows with `convertKeysToCamelCase`
- update login and user routes, auth helper, and admin tests to consume the camelCase fields

## Testing
- KEY_PASSWORD=test DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test
- npm --prefix backend run build

------
https://chatgpt.com/codex/tasks/task_e_68cae7ed04a8832c84db6071cfb3ff7d