### PR TITLE
Refactor portfolio workflow types

### DIFF
--- a/backend/src/agents/main-trader.ts
+++ b/backend/src/agents/main-trader.ts
@@ -87,11 +87,11 @@ export async function collectPromptData(
   row: ActivePortfolioWorkflowRow,
   log: FastifyBaseLogger,
 ): Promise<RebalancePrompt | undefined> {
-  const cash = row.cash_token;
+  const cash = row.cashToken;
   const tokens = row.tokens.map((t) => t.token);
   const allTokens = [cash, ...tokens];
 
-  const account = await fetchAccount(row.user_id).catch((err) => {
+  const account = await fetchAccount(row.userId).catch((err) => {
     log.error({ err }, 'failed to fetch balance');
     return null;
   });
@@ -119,7 +119,7 @@ export async function collectPromptData(
       price_usdt: currentPrice,
       value_usdt: currentPrice * qty,
     });
-    floor[t.token] = t.min_allocation;
+    floor[t.token] = t.minAllocation;
   }
 
   for (let i = 0; i < allTokens.length; i++) {
@@ -150,10 +150,10 @@ export async function collectPromptData(
   };
 
   const totalValue = positions.reduce((sum, p) => sum + p.value_usdt, 0);
-  if (row.start_balance !== null) {
-    portfolio.start_balance_usd = row.start_balance;
-    portfolio.start_balance_ts = row.created_at;
-    portfolio.pnl_usd = totalValue - row.start_balance;
+  if (row.startBalance !== null) {
+    portfolio.start_balance_usd = row.startBalance;
+    portfolio.start_balance_ts = row.createdAt;
+    portfolio.pnl_usd = totalValue - row.startBalance;
   }
 
   const prevRows = await getRecentReviewResults(row.id, 5);
@@ -183,8 +183,8 @@ export async function collectPromptData(
   }
 
   const prompt: RebalancePrompt = {
-    instructions: row.agent_instructions,
-    reviewInterval: row.review_interval,
+    instructions: row.agentInstructions,
+    reviewInterval: row.reviewInterval,
     policy: { floor },
     cash,
     portfolio,

--- a/backend/src/repos/portfolio-workflow.types.ts
+++ b/backend/src/repos/portfolio-workflow.types.ts
@@ -1,0 +1,89 @@
+export interface PortfolioWorkflowToken {
+  token: string;
+  minAllocation: number;
+}
+
+export interface PortfolioWorkflowRow {
+  id: string;
+  userId: string;
+  model: string | null;
+  status: string;
+  createdAt: string;
+  startBalance: number | null;
+  name: string;
+  cashToken: string;
+  tokens: PortfolioWorkflowToken[];
+  risk: string;
+  reviewInterval: string;
+  agentInstructions: string;
+  manualRebalance: boolean;
+  useEarn: boolean;
+  aiApiKeyId: string | null;
+  exchangeApiKeyId: string | null;
+}
+
+export interface PortfolioWorkflowInsert {
+  userId: string;
+  model: string | null;
+  status: string;
+  startBalance: number | null;
+  name: string;
+  cashToken: string;
+  tokens: PortfolioWorkflowToken[];
+  risk: string;
+  reviewInterval: string;
+  agentInstructions: string;
+  manualRebalance: boolean;
+  useEarn: boolean;
+}
+
+export interface PortfolioWorkflowUpdate {
+  id: string;
+  model: string | null;
+  status: string;
+  name: string;
+  cashToken: string;
+  tokens: PortfolioWorkflowToken[];
+  risk: string;
+  reviewInterval: string;
+  agentInstructions: string;
+  startBalance: number | null;
+  manualRebalance: boolean;
+  useEarn: boolean;
+}
+
+export interface PortfolioWorkflowDraftSearch {
+  userId: string;
+  model: string | null;
+  name: string;
+  cashToken: string;
+  tokens: PortfolioWorkflowToken[];
+  risk: string;
+  reviewInterval: string;
+  agentInstructions: string;
+  manualRebalance: boolean;
+  useEarn: boolean;
+}
+
+export interface PortfolioWorkflowUserApiKeys {
+  aiApiKeyEnc?: string | null;
+  binanceApiKeyEnc?: string | null;
+  binanceApiSecretEnc?: string | null;
+}
+
+export interface ActivePortfolioWorkflowRow {
+  id: string;
+  userId: string;
+  model: string | null;
+  cashToken: string;
+  tokens: PortfolioWorkflowToken[];
+  risk: string;
+  reviewInterval: string;
+  agentInstructions: string;
+  aiApiKeyEnc: string | null;
+  manualRebalance: boolean;
+  useEarn: boolean;
+  startBalance: number | null;
+  createdAt: string;
+  portfolioId: string;
+}

--- a/backend/src/routes/portfolio-workflows.ts
+++ b/backend/src/routes/portfolio-workflows.ts
@@ -67,7 +67,7 @@ async function getWorkflowForRequest(
     reply.code(404).send(errorResponse(ERROR_MESSAGES.notFound));
     return;
   }
-  if (workflow.user_id !== userId) {
+  if (workflow.userId !== userId) {
     log.error('forbidden');
     reply.code(403).send(errorResponse(ERROR_MESSAGES.forbidden));
     return;
@@ -304,7 +304,7 @@ export default async function portfolioWorkflowRoutes(app: FastifyInstance) {
       const ctx = await getWorkflowForRequest(req, reply);
       if (!ctx) return;
       const { id, userId, log, workflow } = ctx;
-      if (!workflow.manual_rebalance) {
+      if (!workflow.manualRebalance) {
         log.error('workflow not in manual mode');
         return reply
           .code(400)
@@ -427,7 +427,7 @@ export default async function portfolioWorkflowRoutes(app: FastifyInstance) {
       const ctx = await getWorkflowForRequest(req, reply);
       if (!ctx) return;
       const { id, userId, log, workflow } = ctx;
-      if (!workflow.manual_rebalance) {
+      if (!workflow.manualRebalance) {
         log.error('workflow not in manual mode');
         return reply
           .code(400)

--- a/backend/src/util/agents.ts
+++ b/backend/src/util/agents.ts
@@ -138,9 +138,9 @@ export async function ensureApiKeys(
 ): Promise<ValidationErr | null> {
   const userRow = await getUserApiKeys(userId);
   if (
-    !userRow?.ai_api_key_enc ||
-    !userRow.binance_api_key_enc ||
-    !userRow.binance_api_secret_enc
+    !userRow?.aiApiKeyEnc ||
+    !userRow.binanceApiKeyEnc ||
+    !userRow.binanceApiSecretEnc
   ) {
     log.error('missing api keys');
     return { code: 400, body: errorResponse('missing api keys') };

--- a/backend/test/agents.test.ts
+++ b/backend/test/agents.test.ts
@@ -405,7 +405,7 @@ describe('agent routes', () => {
     });
     expect(resUpdate.statusCode).toBe(200);
     const row = await getAgent(id);
-    expect(row?.start_balance).toBeGreaterThanOrEqual(0);
+    expect(row?.startBalance).toBeGreaterThanOrEqual(0);
     expect(fetchMock).toHaveBeenCalledTimes(4);
 
     await app.close();

--- a/backend/test/apiKeys.test.ts
+++ b/backend/test/apiKeys.test.ts
@@ -151,7 +151,7 @@ describe('AI API key routes', () => {
     expect(res.json()).toMatchObject({ key: '<REDACTED>', shared: true });
 
     let keyRow = await getUserApiKeys(userId);
-    expect(keyRow?.ai_api_key_enc).toBeDefined();
+    expect(keyRow?.aiApiKeyEnc).toBeDefined();
 
     res = await app.inject({
       method: 'POST',
@@ -199,7 +199,7 @@ describe('AI API key routes', () => {
     expect(res.statusCode).toBe(200);
 
     keyRow = await getUserApiKeys(userId);
-    expect(keyRow?.ai_api_key_enc).toBeNull();
+    expect(keyRow?.aiApiKeyEnc).toBeNull();
 
     res = await app.inject({
       method: 'GET',
@@ -599,7 +599,7 @@ describe('key deletion effects on agents', () => {
       orderId: 4,
     });
     const keyRow = await getUserApiKeys(userId);
-    expect(keyRow?.ai_api_key_enc).toBeNull();
+    expect(keyRow?.aiApiKeyEnc).toBeNull();
     const shareExists = await hasAiKeyShare({
       ownerUserId: adminId,
       targetUserId: userId,
@@ -663,7 +663,7 @@ describe('key deletion effects on agents', () => {
     expect(removeWorkflowFromSchedule).not.toHaveBeenCalled();
     expect(cancelOrder).not.toHaveBeenCalled();
     const keyRow = await getUserApiKeys(userId);
-    expect(keyRow?.ai_api_key_enc).toBeDefined();
+    expect(keyRow?.aiApiKeyEnc).toBeDefined();
     await app.close();
   });
 

--- a/backend/test/collectPromptData.test.ts
+++ b/backend/test/collectPromptData.test.ts
@@ -83,18 +83,19 @@ describe('collectPromptData', () => {
   it('includes start balance and PnL in prompt', async () => {
     const row: ActivePortfolioWorkflowRow = {
       id: '1',
-      user_id: 'u1',
+      userId: 'u1',
       model: 'm',
-      cash_token: 'USDT',
-      tokens: [{ token: 'BTC', min_allocation: 50 }],
+      cashToken: 'USDT',
+      tokens: [{ token: 'BTC', minAllocation: 50 }],
       risk: 'low',
-      review_interval: '1h',
-      agent_instructions: 'inst',
-      ai_api_key_enc: '',
-      manual_rebalance: false,
-      start_balance: 20000,
-      created_at: '2025-01-01T00:00:00.000Z',
-      portfolio_id: '1',
+      reviewInterval: '1h',
+      agentInstructions: 'inst',
+      aiApiKeyEnc: '',
+      manualRebalance: false,
+      useEarn: false,
+      startBalance: 20000,
+      createdAt: '2025-01-01T00:00:00.000Z',
+      portfolioId: '1',
     };
 
     const prompt = await collectPromptData(row, mockLogger());
@@ -107,18 +108,19 @@ describe('collectPromptData', () => {
   it('includes recent limit orders in prompt', async () => {
     const row: ActivePortfolioWorkflowRow = {
       id: '1',
-      user_id: 'u1',
+      userId: 'u1',
       model: 'm',
-      cash_token: 'USDT',
-      tokens: [{ token: 'BTC', min_allocation: 50 }],
+      cashToken: 'USDT',
+      tokens: [{ token: 'BTC', minAllocation: 50 }],
       risk: 'low',
-      review_interval: '1h',
-      agent_instructions: 'inst',
-      ai_api_key_enc: '',
-      manual_rebalance: false,
-      start_balance: null,
-      created_at: '2025-01-01T00:00:00.000Z',
-      portfolio_id: '1',
+      reviewInterval: '1h',
+      agentInstructions: 'inst',
+      aiApiKeyEnc: '',
+      manualRebalance: false,
+      useEarn: false,
+      startBalance: null,
+      createdAt: '2025-01-01T00:00:00.000Z',
+      portfolioId: '1',
     };
 
     const prompt = await collectPromptData(row, mockLogger());
@@ -142,21 +144,22 @@ describe('collectPromptData', () => {
   it('handles three-token portfolio', async () => {
     const row: ActivePortfolioWorkflowRow = {
       id: '1',
-      user_id: 'u1',
+      userId: 'u1',
       model: 'm',
-      cash_token: 'USDT',
+      cashToken: 'USDT',
       tokens: [
-        { token: 'BTC', min_allocation: 40 },
-        { token: 'ETH', min_allocation: 30 },
+        { token: 'BTC', minAllocation: 40 },
+        { token: 'ETH', minAllocation: 30 },
       ],
       risk: 'low',
-      review_interval: '1h',
-      agent_instructions: 'inst',
-      ai_api_key_enc: '',
-      manual_rebalance: false,
-      start_balance: null,
-      created_at: '2025-01-01T00:00:00.000Z',
-      portfolio_id: '1',
+      reviewInterval: '1h',
+      agentInstructions: 'inst',
+      aiApiKeyEnc: '',
+      manualRebalance: false,
+      useEarn: false,
+      startBalance: null,
+      createdAt: '2025-01-01T00:00:00.000Z',
+      portfolioId: '1',
     };
 
     const prompt = await collectPromptData(row, mockLogger());
@@ -183,18 +186,19 @@ describe('collectPromptData', () => {
 
     const row: ActivePortfolioWorkflowRow = {
       id: '1',
-      user_id: 'u1',
+      userId: 'u1',
       model: 'm',
-      cash_token: 'USDT',
-      tokens: [{ token: 'BTC', min_allocation: 50 }],
+      cashToken: 'USDT',
+      tokens: [{ token: 'BTC', minAllocation: 50 }],
       risk: 'low',
-      review_interval: '1h',
-      agent_instructions: 'inst',
-      ai_api_key_enc: '',
-      manual_rebalance: false,
-      start_balance: null,
-      created_at: '2025-01-01T00:00:00.000Z',
-      portfolio_id: '1',
+      reviewInterval: '1h',
+      agentInstructions: 'inst',
+      aiApiKeyEnc: '',
+      manualRebalance: false,
+      useEarn: false,
+      startBalance: null,
+      createdAt: '2025-01-01T00:00:00.000Z',
+      portfolioId: '1',
     };
 
     const prompt = await collectPromptData(row, mockLogger());


### PR DESCRIPTION
## Summary
- add a dedicated `portfolio-workflow.types.ts` module with camel-case public interfaces
- update the portfolio workflow repository, agent utilities, and routes to return camel-case data via `convertKeysToCamelCase`
- align agent logic and tests with the new field names and guard workflow execution when the AI key or model is missing

## Testing
- npm --prefix backend run build
- KEY_PASSWORD=test GOOGLE_CLIENT_ID=test DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test

------
https://chatgpt.com/codex/tasks/task_e_68cb90c4ce7c832cb774ef32dbefdf68