### PR TITLE
Refine AI API key workflow guard helpers

### DIFF
--- a/backend/src/routes/_shared/guards.ts
+++ b/backend/src/routes/_shared/guards.ts
@@ -1,0 +1,41 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import { parseParams } from '../../util/validation.js';
+import { requireUserIdMatch, requireAdmin } from '../../util/auth.js';
+import { errorResponse, ERROR_MESSAGES } from '../../util/errorMessages.js';
+import { userIdParams } from './validation.js';
+
+export type RequestWithUserId = FastifyRequest & { validatedUserId: string };
+
+export function getValidatedUserId(req: FastifyRequest): string {
+  return (req as RequestWithUserId).validatedUserId;
+}
+
+export async function parseUserIdParam(
+  req: FastifyRequest,
+  reply: FastifyReply,
+) {
+  const params = parseParams(userIdParams, req.params, reply);
+  if (!params) return reply;
+  (req as RequestWithUserId).validatedUserId = params.id;
+}
+
+export async function requireUserOwner(
+  req: FastifyRequest,
+  reply: FastifyReply,
+) {
+  const { validatedUserId } = req as RequestWithUserId;
+  if (!requireUserIdMatch(req, reply, validatedUserId)) return reply;
+}
+
+export async function requireOwnerAdmin(
+  req: FastifyRequest,
+  reply: FastifyReply,
+) {
+  const adminId = await requireAdmin(req, reply);
+  if (!adminId) return reply;
+  const { validatedUserId } = req as RequestWithUserId;
+  if (adminId !== validatedUserId) {
+    reply.code(403).send(errorResponse(ERROR_MESSAGES.forbidden));
+    return reply;
+  }
+}

--- a/backend/src/routes/_shared/validation.ts
+++ b/backend/src/routes/_shared/validation.ts
@@ -1,0 +1,3 @@
+import { z } from 'zod';
+
+export const userIdParams = z.object({ id: z.string().regex(/^\d+$/) });

--- a/backend/src/routes/exchange-api-keys.ts
+++ b/backend/src/routes/exchange-api-keys.ts
@@ -25,8 +25,8 @@ import { parseParams } from '../util/validation.js';
 import {
   CANCEL_ORDER_REASONS,
   cancelOrdersForWorkflow,
-  userIdParams,
 } from '../services/order-orchestrator.js';
+import { userIdParams } from './_shared/validation.js';
 
 export default async function exchangeApiKeyRoutes(app: FastifyInstance) {
   app.post(

--- a/backend/src/services/order-orchestrator.ts
+++ b/backend/src/services/order-orchestrator.ts
@@ -1,5 +1,4 @@
 import type { FastifyBaseLogger } from 'fastify';
-import { z } from 'zod';
 import {
   getAllOpenLimitOrders,
   getOpenLimitOrdersForWorkflow,
@@ -13,8 +12,6 @@ import {
   type OpenOrder,
 } from './binance.js';
 import { cancelLimitOrder } from './limit-order.js';
-
-export const userIdParams = z.object({ id: z.string().regex(/^\d+$/) });
 
 export const CANCEL_ORDER_REASONS = {
   API_KEY_REMOVED: 'API key removed',

--- a/backend/src/util/api-keys.ts
+++ b/backend/src/util/api-keys.ts
@@ -77,8 +77,14 @@ export interface ValidationErr {
   body: ErrorResponse;
 }
 
-export function ensureUser(row: unknown): ValidationErr | null {
-  if (!row) return { code: 404, body: errorResponse('user not found') };
+export function ensureUser(rowOrExists: unknown): ValidationErr | null {
+  if (typeof rowOrExists === 'boolean') {
+    return rowOrExists
+      ? null
+      : { code: 404, body: errorResponse('user not found') };
+  }
+  if (!rowOrExists)
+    return { code: 404, body: errorResponse('user not found') };
   return null;
 }
 


### PR DESCRIPTION
## Summary
- centralize reusable user parameter validation and guards under routes/_shared
- update AI API key routes to use the shared guards, tighten the user check, and log workflow disablement
- fold unscheduling into disableUserWorkflows and adjust callers accordingly

## Testing
- npm --prefix backend run build
- npm --prefix backend test *(fails: PostgreSQL connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68cc01116304832ca442d83ab9b0aa4f