### PR TITLE
Refine AI key guards and workflow disabling

### DIFF
--- a/backend/src/routes/_shared/guards.ts
+++ b/backend/src/routes/_shared/guards.ts
@@ -1,0 +1,44 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import { requireAdmin, requireUserIdMatch } from '../../util/auth.js';
+import { parseParams } from '../../util/validation.js';
+import { errorResponse, ERROR_MESSAGES } from '../../util/errorMessages.js';
+import { userIdParams } from './validation.js';
+
+export type RequestWithUserId = FastifyRequest & { validatedUserId: string };
+
+export async function parseUserIdParam(
+  req: FastifyRequest,
+  reply: FastifyReply,
+): Promise<void | FastifyReply> {
+  const params = parseParams(userIdParams, req.params, reply);
+  if (!params) return reply;
+  (req as RequestWithUserId).validatedUserId = params.id;
+}
+
+export async function requireUserOwner(
+  req: FastifyRequest,
+  reply: FastifyReply,
+): Promise<void | FastifyReply> {
+  const { validatedUserId } = req as RequestWithUserId;
+  if (!requireUserIdMatch(req, reply, validatedUserId)) return reply;
+}
+
+export async function requireOwnerAdmin(
+  req: FastifyRequest,
+  reply: FastifyReply,
+): Promise<void | FastifyReply> {
+  const adminId = await requireAdmin(req, reply);
+  if (!adminId) return reply;
+  const { validatedUserId } = req as RequestWithUserId;
+  if (adminId !== validatedUserId) {
+    reply.code(403).send(errorResponse(ERROR_MESSAGES.forbidden));
+    return reply;
+  }
+}
+
+export function getValidatedUserId(req: FastifyRequest): string {
+  return (req as RequestWithUserId).validatedUserId;
+}
+
+export const userPreHandlers = [parseUserIdParam, requireUserOwner];
+export const adminPreHandlers = [parseUserIdParam, requireOwnerAdmin];

--- a/backend/src/routes/_shared/validation.ts
+++ b/backend/src/routes/_shared/validation.ts
@@ -1,0 +1,3 @@
+import { z } from 'zod';
+
+export const userIdParams = z.object({ id: z.string().regex(/^\d+$/) });

--- a/backend/src/routes/ai-api-keys.ts
+++ b/backend/src/routes/ai-api-keys.ts
@@ -11,7 +11,6 @@ import {
   hasAiKeyShare,
   getAiKeyShareTargets,
 } from '../repos/ai-api-key.js';
-import { requireUserIdMatch, requireAdmin } from '../util/auth.js';
 import {
   ApiKeyType,
   verifyApiKey,
@@ -22,12 +21,12 @@ import {
 } from '../util/api-keys.js';
 import { errorResponse, ERROR_MESSAGES } from '../util/errorMessages.js';
 import { findUserByEmail } from '../repos/users.js';
-import { parseParams } from '../util/validation.js';
-import { userIdParams } from '../services/order-orchestrator.js';
+import { disableUserWorkflows } from '../workflows/portfolio-review.js';
 import {
-  disableUserWorkflows,
-  removeWorkflowFromSchedule,
-} from '../workflows/portfolio-review.js';
+  adminPreHandlers,
+  getValidatedUserId,
+  userPreHandlers,
+} from './_shared/guards.js';
 
 interface AiKeyBody {
   key: string;
@@ -59,46 +58,21 @@ const revokeShareBodySchema: z.ZodType<RevokeShareBody> = z
   })
   .strict();
 
-type RequestWithUserId = FastifyRequest & { validatedUserId: string };
-type RequestWithOwnerAdmin = RequestWithUserId & { adminUserId: string };
+type DisableWorkflowsSummary = Awaited<ReturnType<typeof disableUserWorkflows>>;
 
-const parseUserIdParam = async (
+function logDisabledWorkflows(
   req: FastifyRequest,
-  reply: FastifyReply,
-) => {
-  const params = parseParams(userIdParams, req.params, reply);
-  if (!params) return reply;
-  (req as RequestWithUserId).validatedUserId = params.id;
-};
-
-const requireUserOwner = async (
-  req: FastifyRequest,
-  reply: FastifyReply,
-) => {
-  const { validatedUserId } = req as RequestWithUserId;
-  if (!requireUserIdMatch(req, reply, validatedUserId)) return reply;
-};
-
-const requireOwnerAdmin = async (
-  req: FastifyRequest,
-  reply: FastifyReply,
-) => {
-  const adminId = await requireAdmin(req, reply);
-  if (!adminId) return reply;
-  const { validatedUserId } = req as RequestWithUserId;
-  if (adminId !== validatedUserId) {
-    reply.code(403).send(errorResponse(ERROR_MESSAGES.forbidden));
-    return reply;
-  }
-  (req as RequestWithOwnerAdmin).adminUserId = adminId;
-};
-
-function getUserId(req: FastifyRequest): string {
-  return (req as RequestWithUserId).validatedUserId;
+  userId: string,
+  summary: DisableWorkflowsSummary,
+  context: string,
+) {
+  const { disabledWorkflowIds, unscheduledWorkflowIds } = summary;
+  if (!disabledWorkflowIds.length && !unscheduledWorkflowIds.length) return;
+  req.log.info(
+    { userId, disabledWorkflowIds, unscheduledWorkflowIds, context },
+    'disabled workflows after AI key update',
+  );
 }
-
-const userPreHandlers = [parseUserIdParam, requireUserOwner];
-const adminPreHandlers = [parseUserIdParam, requireOwnerAdmin];
 
 function parseBody<S extends z.ZodTypeAny>(
   schema: S,
@@ -121,12 +95,12 @@ export default async function aiApiKeyRoutes(app: FastifyInstance) {
       preHandler: userPreHandlers,
     },
     async (req, reply) => {
-      const id = getUserId(req);
+      const id = getValidatedUserId(req);
       const body = parseBody(aiKeyBodySchema, req, reply);
       if (!body) return;
       const { key } = body;
       const aiKey = await getAiKey(id);
-      const userErr = ensureUser(aiKey === undefined ? undefined : {});
+      const userErr = ensureUser(aiKey !== undefined);
       if (userErr) return reply.code(userErr.code).send(userErr.body);
       const keyErr = ensureKeyAbsent(aiKey, ['aiApiKeyEnc']);
       if (keyErr) return reply.code(keyErr.code).send(keyErr.body);
@@ -145,7 +119,7 @@ export default async function aiApiKeyRoutes(app: FastifyInstance) {
       preHandler: userPreHandlers,
     },
     async (req, reply) => {
-      const id = getUserId(req);
+      const id = getValidatedUserId(req);
       const aiKey = await getAiKey(id);
       if (!aiKey?.aiApiKeyEnc)
         return reply
@@ -162,7 +136,7 @@ export default async function aiApiKeyRoutes(app: FastifyInstance) {
       preHandler: userPreHandlers,
     },
     async (req, reply) => {
-      const id = getUserId(req);
+      const id = getValidatedUserId(req);
       const sharedKey = await getSharedAiKey(id);
       if (!sharedKey?.aiApiKeyEnc)
         return reply
@@ -179,7 +153,7 @@ export default async function aiApiKeyRoutes(app: FastifyInstance) {
       preHandler: userPreHandlers,
     },
     async (req, reply) => {
-      const id = getUserId(req);
+      const id = getValidatedUserId(req);
       const body = parseBody(aiKeyBodySchema, req, reply);
       if (!body) return;
       const { key } = body;
@@ -203,19 +177,19 @@ export default async function aiApiKeyRoutes(app: FastifyInstance) {
       preHandler: userPreHandlers,
     },
     async (req, reply) => {
-      const id = getUserId(req);
+      const id = getValidatedUserId(req);
       const aiKey = await getAiKey(id);
       if (!aiKey?.aiApiKeyEnc)
         return reply
           .code(404)
           .send(errorResponse(ERROR_MESSAGES.notFound));
 
-      const disabledIds = await disableUserWorkflows({
+      const disableSummary = await disableUserWorkflows({
         log: req.log,
         userId: id,
         aiKeyId: aiKey.id,
       });
-      for (const workflowId of disabledIds) removeWorkflowFromSchedule(workflowId);
+      logDisabledWorkflows(req, id, disableSummary, 'owner-ai-key-removed');
 
       const targets = await getAiKeyShareTargets(id);
       for (const targetId of targets) {
@@ -224,13 +198,17 @@ export default async function aiApiKeyRoutes(app: FastifyInstance) {
           getSharedAiKey(targetId),
         ]);
         if (!targetOwnKey && targetSharedKey) {
-          const affectedIds = await disableUserWorkflows({
+          const targetSummary = await disableUserWorkflows({
             log: req.log,
             userId: targetId,
             aiKeyId: targetSharedKey.id,
           });
-          for (const workflowId of affectedIds)
-            removeWorkflowFromSchedule(workflowId);
+          logDisabledWorkflows(
+            req,
+            targetId,
+            targetSummary,
+            'shared-ai-key-removed',
+          );
         }
         await revokeAiKeyShare({ ownerUserId: id, targetUserId: targetId });
       }
@@ -246,7 +224,7 @@ export default async function aiApiKeyRoutes(app: FastifyInstance) {
       preHandler: adminPreHandlers,
     },
     async (req, reply) => {
-      const id = getUserId(req);
+      const id = getValidatedUserId(req);
       const body = parseBody(shareAiKeyBodySchema, req, reply);
       if (!body) return;
       const { email, model } = body;
@@ -267,7 +245,7 @@ export default async function aiApiKeyRoutes(app: FastifyInstance) {
       preHandler: adminPreHandlers,
     },
     async (req, reply) => {
-      const id = getUserId(req);
+      const id = getValidatedUserId(req);
       const body = parseBody(revokeShareBodySchema, req, reply);
       if (!body) return;
       const { email } = body;
@@ -280,13 +258,17 @@ export default async function aiApiKeyRoutes(app: FastifyInstance) {
         getSharedAiKey(target.id),
       ]);
       if (!targetOwnKey && targetSharedKey) {
-        const affectedIds = await disableUserWorkflows({
+        const disableSummary = await disableUserWorkflows({
           log: req.log,
           userId: target.id,
           aiKeyId: targetSharedKey.id,
         });
-        for (const workflowId of affectedIds)
-          removeWorkflowFromSchedule(workflowId);
+        logDisabledWorkflows(
+          req,
+          target.id,
+          disableSummary,
+          'shared-ai-key-revoked',
+        );
       }
       await revokeAiKeyShare({ ownerUserId: id, targetUserId: target.id });
       return { ok: true };

--- a/backend/src/routes/exchange-api-keys.ts
+++ b/backend/src/routes/exchange-api-keys.ts
@@ -25,8 +25,8 @@ import { parseParams } from '../util/validation.js';
 import {
   CANCEL_ORDER_REASONS,
   cancelOrdersForWorkflow,
-  userIdParams,
 } from '../services/order-orchestrator.js';
+import { userIdParams } from './_shared/validation.js';
 
 export default async function exchangeApiKeyRoutes(app: FastifyInstance) {
   app.post(

--- a/backend/src/services/order-orchestrator.ts
+++ b/backend/src/services/order-orchestrator.ts
@@ -1,5 +1,4 @@
 import type { FastifyBaseLogger } from 'fastify';
-import { z } from 'zod';
 import {
   getAllOpenLimitOrders,
   getOpenLimitOrdersForWorkflow,
@@ -13,8 +12,6 @@ import {
   type OpenOrder,
 } from './binance.js';
 import { cancelLimitOrder } from './limit-order.js';
-
-export const userIdParams = z.object({ id: z.string().regex(/^\d+$/) });
 
 export const CANCEL_ORDER_REASONS = {
   API_KEY_REMOVED: 'API key removed',


### PR DESCRIPTION
## Summary
- move the shared user-id Zod schema into `routes/_shared/validation` and add reusable guard helpers in `routes/_shared/guards`
- refactor the AI API key routes to use the new guard helpers, simplify the user existence check, and log workflow-disable summaries
- fold unscheduling into `disableUserWorkflows` so it returns a summary object, and update imports that referenced the moved validation

## Testing
- DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test *(fails: repository depends on local PostgreSQL and optional packages such as lodash modules that are unavailable in the environment)*
- npm --prefix backend run build *(fails: missing optional dependency `node-cache` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc104e5e5c832cb7b846fcaba4f3c8