### PR TITLE
Rename project to FinCobra

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ Environment variables: `DATABASE_URL`, `KEY_PASSWORD`, `GOOGLE_CLIENT_ID`.
   - IMPORTANT: AGENT MUST RUN LOCAL PG SERVER TO BE ABLE TO RUN TEST!
   - Check `psql` or `pg_isready` to confirm PostgreSQL is installed; install it if missing.
   - Run tests with
-    `DATABASE_URL=postgres://postgres:postgres@localhost:5432/promptswap_test npm --prefix backend test`.
+    `DATABASE_URL=postgres://postgres:postgres@localhost:5432/fincobra_test npm --prefix backend test`.
   - `npm run build`
 
 ### Guidelines

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# prompt-swap
+# FinCobra
 
-Prompt Swap is a playground for experimenting with AI‑assisted crypto trading
+FinCobra is a playground for experimenting with AI‑assisted crypto trading
 agents. Users write natural‑language prompts that describe a strategy, and an
 OpenAI model plans token swaps accordingly. Trades execute on Binance using the
 user's encrypted API keys. A Fastify backend schedules agents and records

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "promptswap-server",
+  "name": "fincobra-server",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "promptswap-server",
+      "name": "fincobra-server",
       "version": "0.1.0",
       "dependencies": {
         "@fastify/cookie": "9.4.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "promptswap-server",
+  "name": "fincobra-server",
   "version": "0.1.0",
-  "description": "PromptSwap Server",
+  "description": "FinCobra Server",
   "type": "module",
   "scripts": {
     "build": "rm -rf dist && tsc && mkdir -p dist/src/db && cp src/db/schema.sql dist/src/db/schema.sql && cp -r src/db/migrations dist/src/db/migrations",

--- a/backend/src/routes/twofa.ts
+++ b/backend/src/routes/twofa.ts
@@ -29,7 +29,7 @@ export default async function twofaRoutes(app: FastifyInstance) {
       const userId = requireUserId(req, reply);
       if (!userId) return;
       const secret = authenticator.generateSecret();
-      const otpauthUrl = authenticator.keyuri(String(userId), 'PromptSwap', secret);
+      const otpauthUrl = authenticator.keyuri(String(userId), 'FinCobra', secret);
       const qr = await QRCode.toDataURL(otpauthUrl);
       return { secret, otpauthUrl, qr };
     }

--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -1,7 +1,7 @@
 import { beforeAll, beforeEach, afterAll } from 'vitest';
 
 process.env.DATABASE_URL ??=
-  'postgres://postgres:postgres@localhost:5432/promptswap_test';
+  'postgres://postgres:postgres@localhost:5432/fincobra_test';
 
 import { db, migrate } from '../src/db/index.js';
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,7 +9,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="theme-color" content="#ffffff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>PromptSwap</title>
+    <title>FinCobra</title>
     <script
       src="https://accounts.google.com/gsi/client"
       async

--- a/frontend/public/manifest.webmanifest
+++ b/frontend/public/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "PromptSwap",
-  "short_name": "PromptSwap",
+  "name": "FinCobra",
+  "short_name": "FinCobra",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#ffffff",

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -32,7 +32,7 @@ export default function AppShell() {
     <div className="h-screen flex flex-col">
       <header className="fixed top-0 left-0 right-0 bg-gray-800 text-white p-4 flex justify-between z-10">
         <Link to="/" className="font-bold">
-          PromptSwap
+          FinCobra
         </Link>
         <div className="flex items-center gap-4">
           <span className="hidden md:inline">

--- a/frontend/src/lib/i18n.tsx
+++ b/frontend/src/lib/i18n.tsx
@@ -15,7 +15,7 @@ const translations: Record<Lang, Record<string, string>> = {
     privacy: 'Privacy',
     terms_title: 'Terms of Use',
     terms_p1:
-      'PromptSwap is open source software provided "as is" without warranties or guarantees of any kind. Use it at your own risk.',
+      'FinCobra is open source software provided "as is" without warranties or guarantees of any kind. Use it at your own risk.',
     terms_p2:
       'You are free to review the source code and run your own instance on your infrastructure. The code is available at ',
     terms_link: 'this GitHub repository',
@@ -183,7 +183,7 @@ const translations: Record<Lang, Record<string, string>> = {
     privacy: 'Конфиденциальность',
     terms_title: 'Условия использования',
     terms_p1:
-      'PromptSwap — программное обеспечение с открытым исходным кодом, предоставляется «как есть» без каких-либо гарантий. Используйте на свой страх и риск.',
+      'FinCobra — программное обеспечение с открытым исходным кодом, предоставляется «как есть» без каких-либо гарантий. Используйте на свой страх и риск.',
     terms_p2:
       'Вы можете изучать исходный код и запускать собственный экземпляр на своей инфраструктуре. Код доступен в ',
     terms_link: 'этом репозитории GitHub',

--- a/frontend/src/routes/Terms.tsx
+++ b/frontend/src/routes/Terms.tsx
@@ -9,7 +9,7 @@ export default function Terms() {
       <p>
         {t('terms_p2')}
         <a
-          href="https://github.com/dexstandard/prompt-swap"
+          href="https://github.com/dexstandard/fincobra"
           target="_blank"
           rel="noopener noreferrer"
           className="text-blue-600 underline"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "prompt-swap",
+  "name": "fincobra",
   "private": true,
   "scripts": {
     "dev": "./scripts/dev.sh",


### PR DESCRIPTION
## Summary
- update project documentation, packages, and testing instructions to use the FinCobra name
- refresh backend OTP configuration and frontend branding, strings, and terms link for FinCobra

## Testing
- npm --prefix frontend run lint
- npm --prefix backend run lint
- DATABASE_URL=postgres://postgres:postgres@localhost:5432/fincobra_test npm --prefix backend test *(fails: PostgreSQL is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce21355d4c832ca32769667a47ff6b